### PR TITLE
Fix critical bugs found during acceptance testing

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -65,7 +65,7 @@
 	# Note: POST/DELETE to /artifacts/*/tags* are handled by protected routes below
 	@artifacts_read {
 		method GET
-		path /api/v1/artifacts/*
+		path_regexp read ^/api/v1/artifacts/.+
 	}
 	handle @artifacts_read {
 		reverse_proxy magpie:8000
@@ -95,7 +95,7 @@
 	# Matches: PATCH /api/v1/artifacts/{path}/{ref}
 	@artifacts_amend {
 		method PATCH
-		path /api/v1/artifacts/*
+		path_regexp amend ^/api/v1/artifacts/.+
 	}
 	handle @artifacts_amend {
 		forward_auth magpie:8000 {
@@ -109,7 +109,7 @@
 	# Matches: POST /api/v1/artifacts/{path}/{ref}/tags
 	#          DELETE /api/v1/artifacts/{path}/tags/{tag_name}
 	@artifacts_tags {
-		path /api/v1/artifacts/*/tags*
+		path_regexp tags ^/api/v1/artifacts/.+/tags
 	}
 	handle @artifacts_tags {
 		forward_auth magpie:8000 {

--- a/Caddyfile
+++ b/Caddyfile
@@ -91,6 +91,20 @@
 		reverse_proxy magpie:8000
 	}
 
+	# Artifact metadata amendment - requires write or admin scope
+	# Matches: PATCH /api/v1/artifacts/{path}/{ref}
+	@artifacts_amend {
+		method PATCH
+		path /api/v1/artifacts/*
+	}
+	handle @artifacts_amend {
+		forward_auth magpie:8000 {
+			uri /api/v1/auth/validate
+			copy_headers X-Magpie-User X-Magpie-Scope
+		}
+		reverse_proxy magpie:8000
+	}
+
 	# Tag mutation endpoints - requires write or admin scope
 	# Matches: POST /api/v1/artifacts/{path}/{ref}/tags
 	#          DELETE /api/v1/artifacts/{path}/tags/{tag_name}

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ COPY --from=deps /app/.venv /app/.venv
 ENV PATH="/app/.venv/bin:$PATH"
 
 COPY src/ ./src/
-COPY pyproject.toml ./
+COPY pyproject.toml uv.lock ./
 
 # Install the project itself
 RUN uv sync --frozen --no-dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ COPY --from=deps /app/.venv /app/.venv
 ENV PATH="/app/.venv/bin:$PATH"
 
 COPY src/ ./src/
-COPY pyproject.toml uv.lock ./
+COPY pyproject.toml uv.lock README.md ./
 
 # Install the project itself
 RUN uv sync --frozen --no-dev

--- a/src/magpie/cli/client.py
+++ b/src/magpie/cli/client.py
@@ -18,4 +18,6 @@ def get_client(server: str, token: str | None = None) -> httpx.Client:
     headers: dict[str, str] = {}
     if token:
         headers["Authorization"] = f"Bearer {token}"
-    return httpx.Client(base_url=server, headers=headers)
+    # Long timeout for large file uploads (30 min)
+    timeout = httpx.Timeout(30.0, read=1800.0, write=1800.0)
+    return httpx.Client(base_url=server, headers=headers, timeout=timeout)

--- a/src/magpie/cli/commands/get.py
+++ b/src/magpie/cli/commands/get.py
@@ -83,7 +83,11 @@ def get(
             click.echo(f"Hash ref: {hash_ref}", err=True)
 
         # Download the artifact
-        download_url = f"/artifacts/{path}/{hash_ref}"
+        # Hash refs use blobs/ subdirectory, tags are symlinks at root
+        if hash_ref.startswith("@"):
+            download_url = f"/artifacts/{path}/blobs/{hash_ref.lstrip('@')}"
+        else:
+            download_url = f"/artifacts/{path}/{hash_ref}"
 
         if ctx.debug:
             click.echo(f"Downloading from {download_url}...", err=True)

--- a/src/magpie/ctl/commands/gc.py
+++ b/src/magpie/ctl/commands/gc.py
@@ -75,8 +75,9 @@ def gc(ctx: CTLContext, dry_run: bool, reconcile_only: bool) -> None:
             click.echo(f"Processing artifact: {artifact_path}", err=True)
 
         # Read manifest to get tagged hashes
+        # Manifest stores full hashes, but blobs are stored with short hashes (8 chars)
         manifest = read_manifest(artifact_dir)
-        tagged_hashes = set(manifest.tags.values())
+        tagged_hashes = {h[:8] for h in manifest.tags.values()}
 
         # Reconcile symlinks for this artifact
         reconcile_symlinks(artifact_dir, manifest)

--- a/src/magpie/storage/blob.py
+++ b/src/magpie/storage/blob.py
@@ -32,12 +32,16 @@ def get_temp_path(config: MagpieSettings) -> Path:
 
 def store_blob(
     artifact_dir: Path, file_stream: BinaryIO, config: MagpieSettings
-) -> tuple[str, bool]:
+) -> tuple[str, str, bool]:
     """Store blob content with streaming upload and duplicate detection.
 
     Streams content to a temp file while computing SHA-256 hash, then
     atomically moves to final location. Detects duplicates by checking
     if blob already exists.
+
+    Blobs are stored using the first 8 characters of the hash as the filename
+    to save space and improve readability, while the full hash is preserved
+    in metadata for verification.
 
     Args:
         artifact_dir: Path to artifact directory.
@@ -45,7 +49,8 @@ def store_blob(
         config: MagpieSettings instance for temp path configuration.
 
     Returns:
-        Tuple of (hash_ref, is_duplicate):
+        Tuple of (full_hash, hash_ref, is_duplicate):
+        - full_hash: Full SHA-256 hex digest (64 chars)
         - hash_ref: Short hash reference like '@abc12345'
         - is_duplicate: True if blob already existed, False if newly stored
     """
@@ -60,18 +65,18 @@ def store_blob(
         full_hash = _stream_to_temp(fd, file_stream)
         hash_ref = short_hash(full_hash)
 
-        # Check if blob already exists
-        dest_path = blob_path(artifact_dir, full_hash)
+        # Check if blob already exists (use short hash for storage path)
+        dest_path = blob_path(artifact_dir, hash_ref)
 
         if dest_path.exists():
             # Duplicate detected - clean up temp file
             temp_file.unlink(missing_ok=True)
-            return (hash_ref, True)
+            return (full_hash, hash_ref, True)
 
         # New blob - atomic move to destination
         dest_path.parent.mkdir(parents=True, exist_ok=True)
         shutil.move(str(temp_file), dest_path)
-        return (hash_ref, False)
+        return (full_hash, hash_ref, False)
 
     except Exception:
         # Clean up temp file on any error

--- a/src/magpie/storage/paths.py
+++ b/src/magpie/storage/paths.py
@@ -21,6 +21,10 @@ def artifact_dir_path(base: Path, artifact_path: str) -> Path:
 def blob_path(artifact_dir: Path, hash_ref: str) -> Path:
     """Get path to blob file for a given hash reference.
 
+    Blobs are stored using only the first 8 characters of the hash.
+    This function accepts either a short hash (@abc12345 or abc12345)
+    or a full 64-character hash and normalizes to the 8-char filename.
+
     Args:
         artifact_dir: Artifact directory path.
         hash_ref: Hash reference string (e.g., '@abc12345' or full hash).
@@ -28,13 +32,17 @@ def blob_path(artifact_dir: Path, hash_ref: str) -> Path:
     Returns:
         Path to the blob file.
     """
-    # Strip @ prefix if present for filename
-    hash_name = hash_ref.lstrip("@")
+    # Strip @ prefix if present, then use first 8 chars
+    hash_name = hash_ref.lstrip("@")[:8]
     return artifact_dir / "blobs" / hash_name
 
 
 def metadata_path(artifact_dir: Path, hash_ref: str) -> Path:
     """Get path to metadata JSON sidecar for a given hash reference.
+
+    Metadata files are stored using only the first 8 characters of the hash,
+    matching the blob storage scheme. This function accepts either a short
+    hash (@abc12345 or abc12345) or a full 64-character hash.
 
     Args:
         artifact_dir: Artifact directory path.
@@ -43,8 +51,8 @@ def metadata_path(artifact_dir: Path, hash_ref: str) -> Path:
     Returns:
         Path to the metadata JSON file.
     """
-    # Strip @ prefix if present for filename
-    hash_name = hash_ref.lstrip("@")
+    # Strip @ prefix if present, then use first 8 chars
+    hash_name = hash_ref.lstrip("@")[:8]
     return artifact_dir / "metadata" / f"{hash_name}.json"
 
 

--- a/src/magpie/storage/service.py
+++ b/src/magpie/storage/service.py
@@ -86,22 +86,23 @@ class StorageService:
         artifact_dir = artifact_dir_path(self.config.storage_path, artifact_path)
 
         # Store blob (handles streaming and hashing)
-        hash_ref_short, is_duplicate = store_blob(artifact_dir, file_stream, self.config)
-
-        # Get full hash from stored blob
-        full_hash = self._resolve_hash_ref_to_full(artifact_dir, hash_ref_short)
-        hash_ref = short_hash(full_hash)
+        # Returns full hash for metadata, short hash ref for display
+        full_hash, hash_ref, is_duplicate = store_blob(
+            artifact_dir, file_stream, self.config
+        )
 
         # Write metadata sidecar (only for new blobs, write_metadata is write-once)
+        # Use hash_ref (short hash) for filename, but store full_hash inside
         metadata = BlobMetadata(
             hash=full_hash,
             uploaded_by=uploaded_by,
             uploaded_at=datetime.now(timezone.utc),
             source_uri=source_uri,
         )
-        write_metadata(artifact_dir, full_hash, metadata)
+        write_metadata(artifact_dir, hash_ref, metadata)
 
-        # Update manifest with "latest" tag - use full hash for symlink resolution
+        # Update manifest with "latest" tag - store full hash for verification,
+        # symlinks will extract first 8 chars for the actual blob path
         manifest = update_tag(artifact_dir, "latest", full_hash)
 
         # Reconcile symlinks to match manifest
@@ -111,7 +112,7 @@ class StorageService:
         tags = self._get_tags_for_hash(artifact_dir, full_hash)
 
         # Re-read metadata to get actual stored values (in case it was duplicate)
-        stored_metadata = read_metadata(artifact_dir, full_hash)
+        stored_metadata = read_metadata(artifact_dir, hash_ref)
 
         info = ArtifactInfo(
             hash=full_hash,
@@ -155,10 +156,12 @@ class StorageService:
         results: list[ArtifactInfo] = []
         for full_hash, tags in hash_to_tags.items():
             try:
-                metadata = read_metadata(artifact_dir, full_hash)
+                # Metadata is indexed by short hash (first 8 chars)
+                hash_ref = short_hash(full_hash)
+                metadata = read_metadata(artifact_dir, hash_ref)
                 info = ArtifactInfo(
                     hash=full_hash,
-                    hash_ref=short_hash(full_hash),
+                    hash_ref=hash_ref,
                     tags=sorted(tags),
                     uploaded_by=metadata.uploaded_by,
                     uploaded_at=metadata.uploaded_at,
@@ -195,18 +198,21 @@ class StorageService:
 
         # Resolve ref to full hash
         if ref.startswith("@"):
-            # Direct hash reference - resolve to full hash
-            full_hash = self._resolve_hash_ref_to_full(artifact_dir, ref)
+            # Direct hash reference - use as short hash for lookup
+            hash_ref = ref
+            # Resolve to full hash from metadata (for verification)
+            metadata = read_metadata(artifact_dir, hash_ref)
+            full_hash = metadata.hash
         else:
-            # Tag name - look up in manifest
+            # Tag name - look up in manifest (stores full hash)
             if ref not in manifest.tags:
                 raise ArtifactNotFoundError(
                     f"Tag '{ref}' not found in artifact {artifact_path}"
                 )
             full_hash = manifest.tags[ref]
-
-        # Get metadata
-        metadata = read_metadata(artifact_dir, full_hash)
+            # Convert to short hash for metadata lookup
+            hash_ref = short_hash(full_hash)
+            metadata = read_metadata(artifact_dir, hash_ref)
 
         # Get all tags pointing to this hash
         tags = self._get_tags_for_hash(artifact_dir, full_hash)
@@ -238,13 +244,14 @@ class StorageService:
         """
         artifact_dir = artifact_dir_path(self.config.storage_path, artifact_path)
 
-        # Resolve hash_ref to full hash (raises ArtifactNotFoundError if not found)
-        full_hash = self._resolve_hash_ref_to_full(artifact_dir, hash_ref)
+        # Validate blob exists and get short hash for metadata lookup
+        short_hash_name = self._validate_blob_exists(artifact_dir, hash_ref)
 
-        # Verify blob exists by checking metadata (also validates blob integrity)
-        metadata = read_metadata(artifact_dir, full_hash)
+        # Read metadata to get full hash and other info
+        metadata = read_metadata(artifact_dir, short_hash_name)
+        full_hash = metadata.hash
 
-        # Update manifest with tag (uses full hash)
+        # Update manifest with tag (uses full hash for verification)
         manifest = update_tag(artifact_dir, tag_name, full_hash)
 
         # Reconcile symlinks to match manifest
@@ -356,11 +363,12 @@ class StorageService:
         """
         artifact_dir = artifact_dir_path(self.config.storage_path, artifact_path)
 
-        # Resolve hash_ref to full hash (raises ArtifactNotFoundError if not found)
-        full_hash = self._resolve_hash_ref_to_full(artifact_dir, hash_ref)
+        # Validate blob exists and get short hash for metadata lookup
+        short_hash_name = self._validate_blob_exists(artifact_dir, hash_ref)
 
         # Update metadata (preserves immutable fields)
-        updated_metadata = update_metadata(artifact_dir, full_hash, source_uri=source_uri)
+        updated_metadata = update_metadata(artifact_dir, short_hash_name, source_uri=source_uri)
+        full_hash = updated_metadata.hash
 
         # Get all tags pointing to this hash
         tags = self._get_tags_for_hash(artifact_dir, full_hash)
@@ -374,20 +382,22 @@ class StorageService:
             source_uri=updated_metadata.source_uri,
         )
 
-    def _resolve_hash_ref_to_full(self, artifact_dir: Path, hash_ref: str) -> str:
-        """Resolve a short hash_ref to the full hash by finding the blob file.
+    def _validate_blob_exists(self, artifact_dir: Path, hash_ref: str) -> str:
+        """Validate that a blob exists for the given hash reference.
 
         Args:
             artifact_dir: Artifact directory path.
-            hash_ref: Short hash reference (with or without @ prefix).
+            hash_ref: Hash reference (with or without @ prefix). Can be short (8 chars)
+                     or full hash (64 chars) - only first 8 chars are used for lookup.
 
         Returns:
-            Full SHA-256 hash string.
+            Short hash (8 chars, no @ prefix) of the matching blob.
 
         Raises:
             ArtifactNotFoundError: If no matching blob found.
         """
-        prefix = hash_ref.lstrip("@")
+        # Use first 8 chars for lookup (blobs are stored with short hash)
+        prefix = hash_ref.lstrip("@")[:8]
         blobs_dir = artifact_dir / "blobs"
 
         if not blobs_dir.exists():
@@ -395,7 +405,7 @@ class StorageService:
 
         # Find blob file matching prefix
         for blob_file in blobs_dir.iterdir():
-            if blob_file.name.startswith(prefix) or blob_file.name == prefix:
+            if blob_file.name == prefix:
                 return blob_file.name
 
         raise ArtifactNotFoundError(f"Blob not found for hash ref {hash_ref}")

--- a/src/magpie/storage/symlinks.py
+++ b/src/magpie/storage/symlinks.py
@@ -20,9 +20,10 @@ def create_symlink(artifact_dir: Path, tag_name: str, hash_ref: str) -> None:
     """
     symlink_path = artifact_dir / tag_name
 
-    # Strip @ prefix if present for the target path
-    target_name = hash_ref.lstrip("@")
-    # Use relative path: blobs/{hash}
+    # Strip @ prefix if present and use first 8 chars for the target path
+    # (blobs are stored with 8-char short hash, but manifest may have full hash)
+    target_name = hash_ref.lstrip("@")[:8]
+    # Use relative path: blobs/{short_hash}
     target = Path("blobs") / target_name
 
     # Remove existing symlink if present (atomic update)
@@ -86,7 +87,7 @@ def reconcile_symlinks(artifact_dir: Path, manifest: Manifest) -> None:
     # Update existing symlinks that point to wrong target
     for tag_name in expected_tags & existing_symlinks:
         symlink_path = artifact_dir / tag_name
-        expected_target = Path("blobs") / manifest.tags[tag_name].lstrip("@")
+        expected_target = Path("blobs") / manifest.tags[tag_name].lstrip("@")[:8]
 
         # Check if current target matches expected
         try:

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -154,8 +154,9 @@ def admin_token(docker_services: dict[str, str]) -> str:
     env["COMPOSE_PROJECT_NAME"] = docker_services["project_name"]
 
     # Run magpie-ctl init inside the container
+    # Use --reset-admin-token to ensure we get a fresh token even if data persists
     result = subprocess.run(
-        [*compose_cmd, "exec", "-T", "magpie", "magpie-ctl", "init"],
+        [*compose_cmd, "exec", "-T", "magpie", "magpie-ctl", "init", "--reset-admin-token"],
         cwd=PROJECT_ROOT,
         env=env,
         capture_output=True,
@@ -238,6 +239,30 @@ def read_token(http_client: httpx.Client, admin_token: str) -> str:
 def write_token(http_client: httpx.Client, admin_token: str) -> str:
     """Create a write token for testing."""
     return create_token_via_api(http_client, admin_token, "test-writer", "write")
+
+
+def upload_artifact(
+    client: httpx.Client,
+    path: str,
+    content: bytes,
+    headers: dict[str, str] | None = None,
+) -> httpx.Response:
+    """Upload artifact content using multipart form data.
+
+    Args:
+        client: HTTP client instance.
+        path: Artifact path (e.g., "e2e-tests/my-artifact").
+        content: Binary content to upload.
+        headers: Optional additional headers (e.g., Authorization).
+
+    Returns:
+        HTTP response from the upload endpoint.
+    """
+    return client.post(
+        f"/api/v1/upload/{path}",
+        files={"file": ("artifact", content, "application/octet-stream")},
+        headers=headers,
+    )
 
 
 @pytest.fixture

--- a/tests/e2e/test_auth_workflow.py
+++ b/tests/e2e/test_auth_workflow.py
@@ -28,8 +28,8 @@ class TestUnauthenticatedAccess:
         """Verify unauthenticated upload returns 401."""
         response = http_client.post(
             "/api/v1/upload/e2e-tests/unauth-test",
-            content=test_artifact_content,
-            headers={"Content-Type": "application/octet-stream"},
+            files={"file": ("artifact", test_artifact_content, "application/octet-stream")},
+            
         )
 
         assert response.status_code == 401
@@ -68,8 +68,8 @@ class TestUnauthenticatedAccess:
         # First upload something with authenticated client
         authenticated_client.post(
             "/api/v1/upload/e2e-tests/public-list-test",
-            content=test_artifact_content,
-            headers={"Content-Type": "application/octet-stream"},
+            files={"file": ("artifact", test_artifact_content, "application/octet-stream")},
+            
         )
 
         # Unauthenticated GET should work
@@ -98,8 +98,8 @@ class TestReadTokenPermissions:
         # Upload something first (with admin)
         authenticated_client.post(
             "/api/v1/upload/e2e-tests/read-list-test",
-            content=test_artifact_content,
-            headers={"Content-Type": "application/octet-stream"},
+            files={"file": ("artifact", test_artifact_content, "application/octet-stream")},
+            
         )
 
         # List with read token (should work - GET is public anyway)
@@ -124,11 +124,8 @@ class TestReadTokenPermissions:
         # Try to upload with read token
         response = http_client.post(
             "/api/v1/upload/e2e-tests/read-upload-test",
-            content=test_artifact_content,
-            headers={
-                "Content-Type": "application/octet-stream",
-                "Authorization": f"Bearer {read_token}",
-            },
+            files={"file": ("artifact", test_artifact_content, "application/octet-stream")},
+            headers={"Authorization": f"Bearer {read_token}"},
         )
 
         assert response.status_code == 403
@@ -149,8 +146,8 @@ class TestReadTokenPermissions:
         # Upload artifact with admin
         upload_response = authenticated_client.post(
             "/api/v1/upload/e2e-tests/read-tag-test",
-            content=test_artifact_content,
-            headers={"Content-Type": "application/octet-stream"},
+            files={"file": ("artifact", test_artifact_content, "application/octet-stream")},
+            
         )
         artifact_hash = upload_response.json()["hash"]
 
@@ -209,9 +206,8 @@ class TestWriteTokenPermissions:
 
         response = http_client.post(
             "/api/v1/upload/e2e-tests/write-upload-test",
-            content=test_artifact_content,
+            files={"file": ("artifact", test_artifact_content, "application/octet-stream")},
             headers={
-                "Content-Type": "application/octet-stream",
                 "Authorization": f"Bearer {write_token}",
             },
         )
@@ -233,9 +229,8 @@ class TestWriteTokenPermissions:
         # Upload artifact
         upload_response = http_client.post(
             "/api/v1/upload/e2e-tests/write-tag-test",
-            content=test_artifact_content,
+            files={"file": ("artifact", test_artifact_content, "application/octet-stream")},
             headers={
-                "Content-Type": "application/octet-stream",
                 "Authorization": f"Bearer {write_token}",
             },
         )
@@ -332,8 +327,8 @@ class TestAdminTokenPermissions:
         """Verify admin token can upload artifacts."""
         response = authenticated_client.post(
             "/api/v1/upload/e2e-tests/admin-upload-test",
-            content=test_artifact_content,
-            headers={"Content-Type": "application/octet-stream"},
+            files={"file": ("artifact", test_artifact_content, "application/octet-stream")},
+            
         )
 
         assert response.status_code == 200
@@ -352,9 +347,8 @@ class TestInvalidToken:
         """Verify invalid token is rejected with 401."""
         response = http_client.post(
             "/api/v1/upload/e2e-tests/invalid-token-test",
-            content=test_artifact_content,
+            files={"file": ("artifact", test_artifact_content, "application/octet-stream")},
             headers={
-                "Content-Type": "application/octet-stream",
                 "Authorization": "Bearer invalid_token_12345",
             },
         )
@@ -370,9 +364,8 @@ class TestInvalidToken:
         # Missing "Bearer" prefix
         response = http_client.post(
             "/api/v1/upload/e2e-tests/malformed-auth-test",
-            content=test_artifact_content,
+            files={"file": ("artifact", test_artifact_content, "application/octet-stream")},
             headers={
-                "Content-Type": "application/octet-stream",
                 "Authorization": "mgp_some_token",
             },
         )

--- a/tests/e2e/test_core_workflow.py
+++ b/tests/e2e/test_core_workflow.py
@@ -123,8 +123,8 @@ class TestArtifactUpload:
 
         response = authenticated_client.post(
             "/api/v1/upload/e2e-tests/api-upload-test",
-            content=test_artifact_content,
-            headers={"Content-Type": "application/octet-stream"},
+            files={"file": ("artifact", test_artifact_content, "application/octet-stream")},
+            
         )
 
         assert response.status_code == 200
@@ -150,8 +150,8 @@ class TestArtifactListing:
         # First upload an artifact
         authenticated_client.post(
             "/api/v1/upload/e2e-tests/ls-test",
-            content=test_artifact_content,
-            headers={"Content-Type": "application/octet-stream"},
+            files={"file": ("artifact", test_artifact_content, "application/octet-stream")},
+            
         )
 
         # Run magpie ls command
@@ -179,8 +179,8 @@ class TestArtifactListing:
         # Upload an artifact first
         authenticated_client.post(
             "/api/v1/upload/e2e-tests/api-ls-test",
-            content=test_artifact_content,
-            headers={"Content-Type": "application/octet-stream"},
+            files={"file": ("artifact", test_artifact_content, "application/octet-stream")},
+            
         )
 
         # List artifacts
@@ -209,8 +209,8 @@ class TestArtifactDownload:
         # Upload artifact first
         upload_response = authenticated_client.post(
             "/api/v1/upload/e2e-tests/get-test",
-            content=test_artifact_content,
-            headers={"Content-Type": "application/octet-stream"},
+            files={"file": ("artifact", test_artifact_content, "application/octet-stream")},
+            
         )
         artifact_hash = upload_response.json()["hash"]
 
@@ -264,8 +264,8 @@ class TestTagging:
         # Upload artifact first
         upload_response = authenticated_client.post(
             "/api/v1/upload/e2e-tests/tag-test",
-            content=test_artifact_content,
-            headers={"Content-Type": "application/octet-stream"},
+            files={"file": ("artifact", test_artifact_content, "application/octet-stream")},
+            
         )
         artifact_hash = upload_response.json()["hash"]
 
@@ -298,8 +298,8 @@ class TestTagging:
         # Upload artifact
         upload_response = authenticated_client.post(
             "/api/v1/upload/e2e-tests/api-tag-test",
-            content=test_artifact_content,
-            headers={"Content-Type": "application/octet-stream"},
+            files={"file": ("artifact", test_artifact_content, "application/octet-stream")},
+            
         )
         artifact_hash = upload_response.json()["hash"]
 
@@ -330,8 +330,8 @@ class TestArtifactInfo:
         # Upload artifact
         upload_response = authenticated_client.post(
             "/api/v1/upload/e2e-tests/info-test",
-            content=test_artifact_content,
-            headers={"Content-Type": "application/octet-stream"},
+            files={"file": ("artifact", test_artifact_content, "application/octet-stream")},
+            
         )
         artifact_hash = upload_response.json()["hash"]
 
@@ -364,8 +364,8 @@ class TestArtifactInfo:
         # Upload artifact
         upload_response = authenticated_client.post(
             "/api/v1/upload/e2e-tests/api-info-test",
-            content=test_artifact_content,
-            headers={"Content-Type": "application/octet-stream"},
+            files={"file": ("artifact", test_artifact_content, "application/octet-stream")},
+            
         )
         artifact_hash = upload_response.json()["hash"]
 

--- a/tests/e2e/test_edge_cases.py
+++ b/tests/e2e/test_edge_cases.py
@@ -35,8 +35,7 @@ class TestDuplicateUpload:
         # First upload
         response1 = authenticated_client.post(
             "/api/v1/upload/e2e-tests/duplicate-test-1",
-            content=test_artifact_content,
-            headers={"Content-Type": "application/octet-stream"},
+            files={"file": ("artifact", test_artifact_content, "application/octet-stream")},
         )
         assert response1.status_code == 200
         hash1 = response1.json()["hash"]
@@ -44,8 +43,7 @@ class TestDuplicateUpload:
         # Second upload of same content to different path
         response2 = authenticated_client.post(
             "/api/v1/upload/e2e-tests/duplicate-test-2",
-            content=test_artifact_content,
-            headers={"Content-Type": "application/octet-stream"},
+            files={"file": ("artifact", test_artifact_content, "application/octet-stream")},
         )
         assert response2.status_code == 200
         hash2 = response2.json()["hash"]
@@ -64,8 +62,7 @@ class TestDuplicateUpload:
         # First upload
         response1 = authenticated_client.post(
             "/api/v1/upload/e2e-tests/same-path-test",
-            content=test_artifact_content,
-            headers={"Content-Type": "application/octet-stream"},
+            files={"file": ("artifact", test_artifact_content, "application/octet-stream")},
         )
         assert response1.status_code == 200
         hash1 = response1.json()["hash"]
@@ -73,8 +70,7 @@ class TestDuplicateUpload:
         # Second upload to same path
         response2 = authenticated_client.post(
             "/api/v1/upload/e2e-tests/same-path-test",
-            content=test_artifact_content,
-            headers={"Content-Type": "application/octet-stream"},
+            files={"file": ("artifact", test_artifact_content, "application/octet-stream")},
         )
         assert response2.status_code == 200
         hash2 = response2.json()["hash"]
@@ -98,8 +94,7 @@ class TestTagUpdate:
         # Upload v1
         response1 = authenticated_client.post(
             "/api/v1/upload/e2e-tests/tag-update-test",
-            content=content_v1,
-            headers={"Content-Type": "application/octet-stream"},
+            files={"file": ("artifact", content_v1, "application/octet-stream")},
         )
         hash_v1 = response1.json()["hash"]
 
@@ -112,8 +107,7 @@ class TestTagUpdate:
         # Upload v2
         response2 = authenticated_client.post(
             "/api/v1/upload/e2e-tests/tag-update-test",
-            content=content_v2,
-            headers={"Content-Type": "application/octet-stream"},
+            files={"file": ("artifact", content_v2, "application/octet-stream")},
         )
         hash_v2 = response2.json()["hash"]
 
@@ -148,8 +142,7 @@ class TestTagRemoval:
         # Upload artifact
         upload_response = authenticated_client.post(
             "/api/v1/upload/e2e-tests/untag-test",
-            content=test_artifact_content,
-            headers={"Content-Type": "application/octet-stream"},
+            files={"file": ("artifact", test_artifact_content, "application/octet-stream")},
         )
         artifact_hash = upload_response.json()["hash"]
 
@@ -185,8 +178,7 @@ class TestTagRemoval:
         # Upload artifact
         upload_response = authenticated_client.post(
             "/api/v1/upload/e2e-tests/cli-untag-test",
-            content=test_artifact_content,
-            headers={"Content-Type": "application/octet-stream"},
+            files={"file": ("artifact", test_artifact_content, "application/octet-stream")},
         )
         artifact_hash = upload_response.json()["hash"]
 
@@ -238,8 +230,7 @@ class TestGarbageCollection:
         content = b"GC test content - should be cleaned"
         authenticated_client.post(
             "/api/v1/upload/e2e-tests/gc-test",
-            content=content,
-            headers={"Content-Type": "application/octet-stream"},
+            files={"file": ("artifact", content, "application/octet-stream")},
         )
 
         env = os.environ.copy()
@@ -271,8 +262,7 @@ class TestGarbageCollection:
         # Upload and tag artifact
         upload_response = authenticated_client.post(
             "/api/v1/upload/e2e-tests/gc-preserve-test",
-            content=test_artifact_content,
-            headers={"Content-Type": "application/octet-stream"},
+            files={"file": ("artifact", test_artifact_content, "application/octet-stream")},
         )
         artifact_hash = upload_response.json()["hash"]
 
@@ -320,16 +310,14 @@ class TestContentOverwrite:
         # Upload content A
         response_a = authenticated_client.post(
             "/api/v1/upload/e2e-tests/overwrite-test",
-            content=content_a,
-            headers={"Content-Type": "application/octet-stream"},
+            files={"file": ("artifact", content_a, "application/octet-stream")},
         )
         hash_a = response_a.json()["hash"]
 
         # Upload content B to same path
         response_b = authenticated_client.post(
             "/api/v1/upload/e2e-tests/overwrite-test",
-            content=content_b,
-            headers={"Content-Type": "application/octet-stream"},
+            files={"file": ("artifact", content_b, "application/octet-stream")},
         )
         hash_b = response_b.json()["hash"]
 
@@ -355,8 +343,7 @@ class TestLargeArtifact:
 
         response = authenticated_client.post(
             "/api/v1/upload/e2e-tests/large-artifact-test",
-            content=large_content,
-            headers={"Content-Type": "application/octet-stream"},
+            files={"file": ("artifact", large_content, "application/octet-stream")},
             timeout=60.0,
         )
 

--- a/tests/integration/test_gc_endpoint.py
+++ b/tests/integration/test_gc_endpoint.py
@@ -251,8 +251,9 @@ class TestGCDeletesUntaggedBlobs:
         )
 
         # Manually age the blob by modifying metadata
+        # Metadata files use short hash (first 8 chars) as filename
         artifact_dir = test_config.storage_path / "gc-delete-test" / "artifact"
-        metadata_file = artifact_dir / "metadata" / f"{hash_value}.json"
+        metadata_file = artifact_dir / "metadata" / f"{hash_value[:8]}.json"
 
         if metadata_file.exists():
             import json
@@ -290,8 +291,9 @@ class TestGCDeletesUntaggedBlobs:
         client.delete("/api/v1/artifacts/gc-dryrun-test/artifact/tags/latest")
 
         # Age the blob
+        # Metadata files use short hash (first 8 chars) as filename
         artifact_dir = test_config.storage_path / "gc-dryrun-test" / "artifact"
-        metadata_file = artifact_dir / "metadata" / f"{hash_value}.json"
+        metadata_file = artifact_dir / "metadata" / f"{hash_value[:8]}.json"
 
         if metadata_file.exists():
             import json
@@ -317,6 +319,6 @@ class TestGCDeletesUntaggedBlobs:
         assert data["dry_run"] is True
         assert data["blobs_deleted"] >= 1
 
-        # Verify blob still exists
-        blob_file = artifact_dir / "blobs" / hash_value
+        # Verify blob still exists (blob files use short hash as filename)
+        blob_file = artifact_dir / "blobs" / hash_value[:8]
         assert blob_file.exists(), "Blob should not be deleted in dry run mode"

--- a/tests/unit/test_blob.py
+++ b/tests/unit/test_blob.py
@@ -62,25 +62,26 @@ class TestStoreBlob:
         content = b"test blob content"
         stream = io.BytesIO(content)
 
-        hash_ref, is_duplicate = store_blob(artifact_dir, stream, test_config)
+        full_hash, hash_ref, is_duplicate = store_blob(artifact_dir, stream, test_config)
 
-        # Verify file was created
-        full_hash = compute_hash(content)
-        expected_path = artifact_dir / "blobs" / full_hash
+        # Verify file was created (blob uses first 8 chars of hash)
+        expected_path = artifact_dir / "blobs" / full_hash[:8]
         assert expected_path.exists()
         assert expected_path.read_bytes() == content
 
     def test_store_blob_returns_correct_hash(
         self, artifact_dir: Path, test_config: MagpieSettings
     ) -> None:
-        """store_blob should return correct short hash reference."""
+        """store_blob should return correct full hash and short hash reference."""
         content = b"test blob content"
         stream = io.BytesIO(content)
 
-        hash_ref, is_duplicate = store_blob(artifact_dir, stream, test_config)
+        full_hash, hash_ref, is_duplicate = store_blob(artifact_dir, stream, test_config)
 
-        expected_hash = short_hash(compute_hash(content))
-        assert hash_ref == expected_hash
+        expected_full = compute_hash(content)
+        expected_short = short_hash(expected_full)
+        assert full_hash == expected_full
+        assert hash_ref == expected_short
         assert hash_ref.startswith("@")
 
     def test_store_blob_new_returns_not_duplicate(
@@ -90,7 +91,7 @@ class TestStoreBlob:
         content = b"unique content"
         stream = io.BytesIO(content)
 
-        hash_ref, is_duplicate = store_blob(artifact_dir, stream, test_config)
+        full_hash, hash_ref, is_duplicate = store_blob(artifact_dir, stream, test_config)
 
         assert is_duplicate is False
 
@@ -102,14 +103,15 @@ class TestStoreBlob:
 
         # First store
         stream1 = io.BytesIO(content)
-        hash_ref1, is_duplicate1 = store_blob(artifact_dir, stream1, test_config)
+        full_hash1, hash_ref1, is_duplicate1 = store_blob(artifact_dir, stream1, test_config)
         assert is_duplicate1 is False
 
         # Second store of same content
         stream2 = io.BytesIO(content)
-        hash_ref2, is_duplicate2 = store_blob(artifact_dir, stream2, test_config)
+        full_hash2, hash_ref2, is_duplicate2 = store_blob(artifact_dir, stream2, test_config)
         assert is_duplicate2 is True
         assert hash_ref1 == hash_ref2
+        assert full_hash1 == full_hash2
 
     def test_store_blob_temp_file_cleanup_on_duplicate(
         self, artifact_dir: Path, test_config: MagpieSettings
@@ -163,11 +165,10 @@ class TestStoreBlob:
         content = b"x" * 50000
         stream = io.BytesIO(content)
 
-        hash_ref, is_duplicate = store_blob(artifact_dir, stream, test_config)
+        full_hash, hash_ref, is_duplicate = store_blob(artifact_dir, stream, test_config)
 
-        # Verify content integrity
-        full_hash = compute_hash(content)
-        blob_file = artifact_dir / "blobs" / full_hash
+        # Verify content integrity (blob uses first 8 chars of hash)
+        blob_file = artifact_dir / "blobs" / full_hash[:8]
         assert blob_file.read_bytes() == content
 
 
@@ -180,9 +181,9 @@ class TestReadBlob:
         """read_blob should return path for existing blob."""
         content = b"readable content"
         stream = io.BytesIO(content)
-        hash_ref, _ = store_blob(artifact_dir, stream, test_config)
+        full_hash, hash_ref, _ = store_blob(artifact_dir, stream, test_config)
 
-        full_hash = compute_hash(content)
+        # read_blob accepts full hash and converts to short internally
         result = read_blob(artifact_dir, full_hash)
 
         assert result.exists()
@@ -194,12 +195,10 @@ class TestReadBlob:
         """read_blob should work with short hash reference."""
         content = b"short hash content"
         stream = io.BytesIO(content)
-        hash_ref, _ = store_blob(artifact_dir, stream, test_config)
+        full_hash, hash_ref, _ = store_blob(artifact_dir, stream, test_config)
 
-        # Note: read_blob uses blob_path which strips @ prefix
-        # But the actual file is stored with full hash
-        full_hash = compute_hash(content)
-        result = read_blob(artifact_dir, full_hash)
+        # read_blob works with short hash (strips @ prefix, uses first 8 chars)
+        result = read_blob(artifact_dir, hash_ref)
 
         assert result.exists()
 
@@ -214,11 +213,10 @@ class TestReadBlob:
         """read_blob should handle hash refs with @ prefix."""
         content = b"at prefix content"
         stream = io.BytesIO(content)
-        store_blob(artifact_dir, stream, test_config)
+        full_hash, hash_ref, _ = store_blob(artifact_dir, stream, test_config)
 
-        full_hash = compute_hash(content)
-        # Use @ prefix - blob_path strips it
-        result = read_blob(artifact_dir, f"@{full_hash}")
+        # Use @ prefix - blob_path strips it and uses first 8 chars
+        result = read_blob(artifact_dir, hash_ref)
 
         assert result.exists()
 
@@ -232,9 +230,9 @@ class TestCheckBlobExists:
         """check_blob_exists should return True for existing blob."""
         content = b"existing content"
         stream = io.BytesIO(content)
-        store_blob(artifact_dir, stream, test_config)
+        full_hash, hash_ref, _ = store_blob(artifact_dir, stream, test_config)
 
-        full_hash = compute_hash(content)
+        # check_blob_exists works with full hash (converts to short internally)
         result = check_blob_exists(artifact_dir, full_hash)
 
         assert result is True
@@ -250,9 +248,9 @@ class TestCheckBlobExists:
         """check_blob_exists should handle @ prefix."""
         content = b"prefix check content"
         stream = io.BytesIO(content)
-        store_blob(artifact_dir, stream, test_config)
+        full_hash, hash_ref, _ = store_blob(artifact_dir, stream, test_config)
 
-        full_hash = compute_hash(content)
-        result = check_blob_exists(artifact_dir, f"@{full_hash}")
+        # Works with @ prefix (strips prefix and uses first 8 chars)
+        result = check_blob_exists(artifact_dir, hash_ref)
 
         assert result is True

--- a/tests/unit/test_ctl_init_gc.py
+++ b/tests/unit/test_ctl_init_gc.py
@@ -38,6 +38,11 @@ def create_artifact_with_blobs(
 ) -> None:
     """Helper to create an artifact directory with blobs and manifest.
 
+    Simulates the actual storage scheme where:
+    - Manifest stores full hashes
+    - Blob files use first 8 chars of hash
+    - Metadata files use first 8 chars of hash (but contain full hash inside)
+
     Args:
         storage_path: Base storage path.
         artifact_path: Relative artifact path.
@@ -51,7 +56,7 @@ def create_artifact_with_blobs(
     blobs_dir.mkdir(parents=True, exist_ok=True)
     metadata_dir.mkdir(parents=True, exist_ok=True)
 
-    # Create manifest
+    # Create manifest (stores full hashes)
     manifest = {
         "version": 1,
         "tags": tagged_hashes,
@@ -64,20 +69,23 @@ def create_artifact_with_blobs(
     blob_ages_days = blob_ages_days or {}
 
     for blob_hash in all_hashes:
-        # Create blob file
-        blob_file = blobs_dir / blob_hash
+        # Blob and metadata files use short hash (first 8 chars)
+        short_hash = blob_hash[:8]
+
+        # Create blob file with short hash name
+        blob_file = blobs_dir / short_hash
         blob_file.write_bytes(b"test content for " + blob_hash.encode())
 
-        # Create metadata with upload timestamp
+        # Create metadata with upload timestamp (short hash filename, full hash inside)
         age_days = blob_ages_days.get(blob_hash, 0)
         upload_time = datetime.now(timezone.utc) - timedelta(days=age_days)
         metadata = {
-            "hash": blob_hash,
+            "hash": blob_hash,  # Full hash stored inside metadata
             "uploaded_by": "test",
             "uploaded_at": upload_time.isoformat(),
             "source_uri": None,
         }
-        metadata_file = metadata_dir / f"{blob_hash}.json"
+        metadata_file = metadata_dir / f"{short_hash}.json"
         metadata_file.write_text(json.dumps(metadata), encoding="utf-8")
 
 
@@ -207,7 +215,8 @@ class TestGCCommand:
             blob_ages_days={"tagged_hash_abc": 0, "untagged_hash_xyz": 100},
         )
 
-        blob_file = test_settings.storage_path / "test/artifact/blobs/untagged_hash_xyz"
+        # Blob files use short hash (first 8 chars)
+        blob_file = test_settings.storage_path / "test/artifact/blobs/untagged"
         assert blob_file.exists()
 
         with patch("magpie.ctl.get_settings", return_value=test_settings):
@@ -231,7 +240,8 @@ class TestGCCommand:
             blob_ages_days={"tagged_hash_abc": 0, "old_untagged_xyz": 100},
         )
 
-        blob_file = test_settings.storage_path / "test/artifact/blobs/old_untagged_xyz"
+        # Blob files use short hash (first 8 chars)
+        blob_file = test_settings.storage_path / "test/artifact/blobs/old_unta"
         assert blob_file.exists()
 
         with patch("magpie.ctl.get_settings", return_value=test_settings):
@@ -258,7 +268,8 @@ class TestGCCommand:
             },
         )
 
-        blob_file = test_settings.storage_path / "test/artifact/blobs/young_untagged_xyz"
+        # Blob files use short hash (first 8 chars)
+        blob_file = test_settings.storage_path / "test/artifact/blobs/young_un"
         assert blob_file.exists()
 
         with patch("magpie.ctl.get_settings", return_value=test_settings):
@@ -283,7 +294,8 @@ class TestGCCommand:
         )
 
         artifact_dir = test_settings.storage_path / "test/artifact"
-        blob_file = artifact_dir / "blobs/old_untagged_xyz"
+        # Blob files use short hash (first 8 chars)
+        blob_file = artifact_dir / "blobs/old_unta"
         assert blob_file.exists()
 
         with patch("magpie.ctl.get_settings", return_value=test_settings):
@@ -321,7 +333,8 @@ class TestGCCommand:
             blob_ages_days={"old_tagged_hash": 365},  # Very old but tagged
         )
 
-        blob_file = test_settings.storage_path / "test/artifact/blobs/old_tagged_hash"
+        # Blob files use short hash (first 8 chars)
+        blob_file = test_settings.storage_path / "test/artifact/blobs/old_tagg"
         assert blob_file.exists()
 
         with patch("magpie.ctl.get_settings", return_value=test_settings):

--- a/tests/unit/test_storage_utils.py
+++ b/tests/unit/test_storage_utils.py
@@ -144,11 +144,12 @@ class TestBlobPath:
         assert result == Path("/data/artifacts/project/blobs/abc12345")
 
     def test_blob_path_full_hash(self) -> None:
-        """blob_path should work with full hash."""
+        """blob_path should truncate full hash to first 8 chars."""
         artifact_dir = Path("/data/artifacts/project")
         full_hash = "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
         result = blob_path(artifact_dir, full_hash)
-        assert result == Path(f"/data/artifacts/project/blobs/{full_hash}")
+        # Blobs are stored with short hash (first 8 chars)
+        assert result == Path(f"/data/artifacts/project/blobs/{full_hash[:8]}")
 
 
 class TestMetadataPath:


### PR DESCRIPTION
## Summary

Fixes multiple critical bugs discovered during manual acceptance testing of CLI workflows.

## Fixes included

- **Symlink/blob path mismatch**: Manifest stored full 64-char hashes but blobs used 8-char short hashes, causing download failures
- **CLI download path**: `magpie get` used wrong path for hash ref downloads (`/@hash` vs `/blobs/hash`)
- **CLI timeout**: Default 5s timeout was too short for large file uploads (now 30 min)
- **Caddy PATCH route**: `magpie amend` returned 404 because PATCH wasn't routed
- **Caddy path patterns**: Single `*` didn't match multi-segment paths like `org/project/artifact`
- **E2E tests**: Tests used wrong upload format (`content=` instead of `files=`)

## Testing

- Manual acceptance testing of full workflow: push → get → tag → amend → untag → gc
- 442 unit/integration tests pass
- E2E tests now run (22 pass, remaining failures are pre-existing auth issues tracked in #25)

## Related issues

- #25 - Token scope permissions not enforced (pre-existing, not fixed in this PR)
- #27 - Storage layout vs design docs mismatch (documented, workaround applied)
- #28 - Configurable timeout/size limits (future enhancement)
- #30 - Comprehensive CLI integration tests needed

---
🤖 Generated with [Claude Code](https://claude.ai/code) (Opus 4.5)