### PR TITLE
Fix integration tests for future auth and path changes

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,37 @@
+"""Shared fixtures for integration tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from magpie.server.app import app
+from magpie.server.deps import require_admin_scope_header, require_write_scope
+
+
+def _noop_require_write_scope() -> None:
+    """No-op override for require_write_scope in tests."""
+    pass
+
+
+def _noop_require_admin_scope() -> None:
+    """No-op override for require_admin_scope_header in tests."""
+    pass
+
+
+@pytest.fixture(autouse=True)
+def override_auth_dependencies():
+    """Override auth dependencies for integration tests.
+
+    Integration tests run against the FastAPI app directly without Caddy,
+    so there are no X-Magpie-Scope headers. This fixture disables auth
+    checking for all integration tests.
+
+    For tests that specifically test auth behavior, use the e2e tests
+    which run against the full stack including Caddy.
+    """
+    app.dependency_overrides[require_write_scope] = _noop_require_write_scope
+    app.dependency_overrides[require_admin_scope_header] = _noop_require_admin_scope
+    yield
+    # Clean up - remove our overrides but preserve any others
+    app.dependency_overrides.pop(require_write_scope, None)
+    app.dependency_overrides.pop(require_admin_scope_header, None)

--- a/tests/integration/test_cli_amend.py
+++ b/tests/integration/test_cli_amend.py
@@ -104,7 +104,7 @@ class TestAmendCommand:
     ) -> None:
         """Amend command displays updated metadata including tags."""
         upload_data = upload_test_artifact(
-            api_client, "test/metadata", b"metadata test"
+            api_client, "test/amend-meta", b"metadata test"
         )
 
         with patch(PATCH_GET_CLIENT) as mock_get_client:
@@ -114,7 +114,7 @@ class TestAmendCommand:
                 cli,
                 [
                     "--server", "http://test",
-                    "amend", "test/metadata:latest",
+                    "amend", "test/amend-meta:latest",
                     "--source-uri", "https://example.com/source",
                 ],
             )

--- a/tests/integration/test_cli_push_get.py
+++ b/tests/integration/test_cli_push_get.py
@@ -78,15 +78,25 @@ class MockClientWithDownload:
         return self.api_client.post(url, **kwargs)
 
     def _handle_download(self, url: str) -> MagicMock:
-        """Handle download from /artifacts/{path}/{hash_ref}."""
+        """Handle download from /artifacts/{path}/{hash_ref} or /artifacts/{path}/blobs/{hash}."""
         from magpie.storage.blob import read_blob
         from magpie.storage.paths import artifact_dir_path
 
-        # Parse: /artifacts/{path}/{hash_ref}
+        # Parse URL - handle both patterns:
+        # /artifacts/{path}/{tag}  (tag symlinks)
+        # /artifacts/{path}/blobs/{hash}  (direct blob access)
         parts = url.split("/")
-        # parts = ['', 'artifacts', path_parts..., hash_ref]
-        hash_ref = parts[-1]
-        path = "/".join(parts[2:-1])
+        # parts = ['', 'artifacts', path_parts..., ref_or_blobs, maybe_hash]
+
+        if "blobs" in parts:
+            # Pattern: /artifacts/{path}/blobs/{hash}
+            blobs_idx = parts.index("blobs")
+            path = "/".join(parts[2:blobs_idx])
+            hash_ref = "@" + parts[blobs_idx + 1]  # Add @ prefix for lookup
+        else:
+            # Pattern: /artifacts/{path}/{hash_ref}
+            hash_ref = parts[-1]
+            path = "/".join(parts[2:-1])
 
         try:
             # Get the full hash from storage service


### PR DESCRIPTION
## Summary

Prepares the integration test suite for upcoming changes:

- **Add `tests/integration/conftest.py`** - Provides fixtures to override auth dependencies for integration tests that run without Caddy
- **Update `MockClientWithDownload`** - Handle `/blobs/` URL pattern used by CLI for hash-ref downloads
- **Rename test path** - Change `test/metadata` to `test/amend-meta` to avoid conflicts with reserved segments

## Context

These fixes are needed because:
1. Integration tests run against FastAPI directly without Caddy, so there are no `X-Magpie-Scope` headers
2. The CLI constructs different download URLs for hash refs vs tag refs
3. The path `metadata` will become a reserved segment in storage

## Test plan

- [x] All 449 unit/integration tests pass
- [x] No changes to production code

---
Generated with [Claude Code](https://claude.ai/code)