### PR TITLE
Enforce token scope permissions on protected endpoints

### DIFF
--- a/src/magpie/server/deps.py
+++ b/src/magpie/server/deps.py
@@ -32,20 +32,21 @@ def get_token_service() -> TokenService:
     return TokenService(settings)
 
 
-def require_write_scope(
-    x_magpie_scope: Annotated[str | None, Header(alias="X-Magpie-Scope")] = None,
-) -> None:
-    """Dependency that requires write or admin scope from Caddy forward_auth.
+def _validate_scope_header(x_magpie_scope: str | None) -> str:
+    """Validate and return the scope header value.
 
-    Checks the X-Magpie-Scope header set by Caddy's forward_auth middleware
-    and ensures the token has write or admin scope. Read-only tokens are rejected.
+    Shared helper function for scope validation that checks if the
+    X-Magpie-Scope header is present and contains a valid scope value.
 
     Args:
         x_magpie_scope: Scope header value from Caddy forward_auth.
 
+    Returns:
+        The validated scope value.
+
     Raises:
         HTTPException 401: If X-Magpie-Scope header is missing (unauthenticated).
-        HTTPException 403: If token has invalid or read scope (insufficient permissions).
+        HTTPException 403: If scope value is not a valid TokenScope enum value.
     """
     if x_magpie_scope is None:
         raise HTTPException(
@@ -61,7 +62,27 @@ def require_write_scope(
             detail=f"Invalid scope: {x_magpie_scope}",
         )
 
-    if x_magpie_scope == TokenScope.READ.value:
+    return x_magpie_scope
+
+
+def require_write_scope(
+    x_magpie_scope: Annotated[str | None, Header(alias="X-Magpie-Scope")] = None,
+) -> None:
+    """Dependency that requires write or admin scope from Caddy forward_auth.
+
+    Checks the X-Magpie-Scope header set by Caddy's forward_auth middleware
+    and ensures the token has write or admin scope. Read-only tokens are rejected.
+
+    Args:
+        x_magpie_scope: Scope header value from Caddy forward_auth.
+
+    Raises:
+        HTTPException 401: If X-Magpie-Scope header is missing (unauthenticated).
+        HTTPException 403: If token has invalid or read scope (insufficient permissions).
+    """
+    validated_scope = _validate_scope_header(x_magpie_scope)
+
+    if validated_scope == TokenScope.READ.value:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Write or admin scope required",
@@ -83,21 +104,9 @@ def require_admin_scope_header(
         HTTPException 401: If X-Magpie-Scope header is missing (unauthenticated).
         HTTPException 403: If token has invalid or non-admin scope (insufficient permissions).
     """
-    if x_magpie_scope is None:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Authentication required",
-        )
+    validated_scope = _validate_scope_header(x_magpie_scope)
 
-    # Validate scope value is one of the allowed scopes
-    valid_scopes = {scope.value for scope in TokenScope}
-    if x_magpie_scope not in valid_scopes:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail=f"Invalid scope: {x_magpie_scope}",
-        )
-
-    if x_magpie_scope != TokenScope.ADMIN.value:
+    if validated_scope != TokenScope.ADMIN.value:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Admin scope required",

--- a/src/magpie/server/deps.py
+++ b/src/magpie/server/deps.py
@@ -32,6 +32,62 @@ def get_token_service() -> TokenService:
     return TokenService(settings)
 
 
+def require_write_scope(
+    x_magpie_scope: Annotated[str | None, Header(alias="X-Magpie-Scope")] = None,
+) -> None:
+    """Dependency that requires write or admin scope from Caddy forward_auth.
+
+    Checks the X-Magpie-Scope header set by Caddy's forward_auth middleware
+    and ensures the token has write or admin scope. Read-only tokens are rejected.
+
+    Args:
+        x_magpie_scope: Scope header value from Caddy forward_auth.
+
+    Raises:
+        HTTPException 401: If X-Magpie-Scope header is missing (unauthenticated).
+        HTTPException 403: If token has read scope (insufficient permissions).
+    """
+    if x_magpie_scope is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Authentication required",
+        )
+
+    if x_magpie_scope == TokenScope.READ.value:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Write or admin scope required",
+        )
+
+
+def require_admin_scope_header(
+    x_magpie_scope: Annotated[str | None, Header(alias="X-Magpie-Scope")] = None,
+) -> None:
+    """Dependency that requires admin scope from Caddy forward_auth.
+
+    Checks the X-Magpie-Scope header set by Caddy's forward_auth middleware
+    and ensures the token has admin scope.
+
+    Args:
+        x_magpie_scope: Scope header value from Caddy forward_auth.
+
+    Raises:
+        HTTPException 401: If X-Magpie-Scope header is missing (unauthenticated).
+        HTTPException 403: If token doesn't have admin scope.
+    """
+    if x_magpie_scope is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Authentication required",
+        )
+
+    if x_magpie_scope != TokenScope.ADMIN.value:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Admin scope required",
+        )
+
+
 def require_admin_scope(
     authorization: Annotated[str | None, Header()] = None,
     token_service: Annotated[TokenService, Depends(get_token_service)] = None,

--- a/src/magpie/server/deps.py
+++ b/src/magpie/server/deps.py
@@ -45,12 +45,20 @@ def require_write_scope(
 
     Raises:
         HTTPException 401: If X-Magpie-Scope header is missing (unauthenticated).
-        HTTPException 403: If token has read scope (insufficient permissions).
+        HTTPException 403: If token has invalid or read scope (insufficient permissions).
     """
     if x_magpie_scope is None:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Authentication required",
+        )
+
+    # Validate scope value is one of the allowed scopes
+    valid_scopes = {scope.value for scope in TokenScope}
+    if x_magpie_scope not in valid_scopes:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"Invalid scope: {x_magpie_scope}",
         )
 
     if x_magpie_scope == TokenScope.READ.value:
@@ -73,12 +81,20 @@ def require_admin_scope_header(
 
     Raises:
         HTTPException 401: If X-Magpie-Scope header is missing (unauthenticated).
-        HTTPException 403: If token doesn't have admin scope.
+        HTTPException 403: If token has invalid or non-admin scope (insufficient permissions).
     """
     if x_magpie_scope is None:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Authentication required",
+        )
+
+    # Validate scope value is one of the allowed scopes
+    valid_scopes = {scope.value for scope in TokenScope}
+    if x_magpie_scope not in valid_scopes:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"Invalid scope: {x_magpie_scope}",
         )
 
     if x_magpie_scope != TokenScope.ADMIN.value:

--- a/src/magpie/server/routes/artifacts.py
+++ b/src/magpie/server/routes/artifacts.py
@@ -8,7 +8,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, Response, status
 from pydantic import BaseModel
 
-from magpie.server.deps import get_storage_service
+from magpie.server.deps import get_storage_service, require_write_scope
 from magpie.storage.exceptions import ArtifactNotFoundError
 from magpie.storage.service import StorageService
 
@@ -109,8 +109,11 @@ async def create_tag(
     ref: str,
     request: CreateTagRequest,
     storage_service: Annotated[StorageService, Depends(get_storage_service)],
+    _write_scope_check: Annotated[None, Depends(require_write_scope)] = None,
 ) -> TagResponse:
     """Create or update a tag pointing to a specific artifact version.
+
+    Requires write or admin scope. Read-only tokens will be rejected with 403.
 
     Creates a named tag that points to the blob identified by ref. If the tag
     already exists, it will be updated to point to the new blob.
@@ -124,6 +127,8 @@ async def create_tag(
         TagResponse with the created tag info and updated tags list.
 
     Raises:
+        HTTPException 401: If X-Magpie-Scope header is missing (unauthenticated).
+        HTTPException 403: If token has read scope (insufficient permissions).
         ArtifactNotFoundError: If path doesn't exist or ref doesn't resolve.
             Automatically converted to HTTP 404 by error handlers.
     """
@@ -150,8 +155,11 @@ async def remove_tag(
     path: str,
     tag_name: str,
     storage_service: Annotated[StorageService, Depends(get_storage_service)],
+    _write_scope_check: Annotated[None, Depends(require_write_scope)] = None,
 ) -> Response:
     """Remove a tag from an artifact.
+
+    Requires write or admin scope. Read-only tokens will be rejected with 403.
 
     Deletes the named tag from the artifact. The underlying blob is not affected.
 
@@ -163,6 +171,8 @@ async def remove_tag(
         204 No Content on success.
 
     Raises:
+        HTTPException 401: If X-Magpie-Scope header is missing (unauthenticated).
+        HTTPException 403: If token has read scope (insufficient permissions).
         ArtifactNotFoundError: If path doesn't exist or tag doesn't exist.
             Automatically converted to HTTP 404 by error handlers.
     """
@@ -184,8 +194,11 @@ async def amend_metadata(
     ref: str,
     request: AmendMetadataRequest,
     storage_service: Annotated[StorageService, Depends(get_storage_service)],
+    _write_scope_check: Annotated[None, Depends(require_write_scope)] = None,
 ) -> ArtifactInfoResponse:
     """Amend metadata for a specific artifact version.
+
+    Requires write or admin scope. Read-only tokens will be rejected with 403.
 
     Updates mutable metadata fields on an existing blob. Immutable fields
     (hash, uploaded_by, uploaded_at) are preserved.
@@ -199,6 +212,8 @@ async def amend_metadata(
         ArtifactInfoResponse with the updated metadata.
 
     Raises:
+        HTTPException 401: If X-Magpie-Scope header is missing (unauthenticated).
+        HTTPException 403: If token has read scope (insufficient permissions).
         ArtifactNotFoundError: If path doesn't exist or ref doesn't resolve.
             Automatically converted to HTTP 404 by error handlers.
     """

--- a/src/magpie/server/routes/tags.py
+++ b/src/magpie/server/routes/tags.py
@@ -7,7 +7,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel
 
-from magpie.server.deps import get_storage_service
+from magpie.server.deps import get_storage_service, require_admin_scope_header
 from magpie.storage.service import StorageService
 
 router = APIRouter()
@@ -36,11 +36,13 @@ async def flush_tag(
         Query(description="If true, return preview without actually removing tags"),
     ] = False,
     storage_service: Annotated[StorageService, Depends(get_storage_service)] = None,
+    _admin_scope_check: Annotated[None, Depends(require_admin_scope_header)] = None,
 ) -> FlushTagResponse:
     """Remove a tag from all artifacts globally.
 
-    This is a potentially destructive operation that walks the entire storage
-    tree and removes the specified tag from every artifact that has it.
+    Requires admin scope. This is a potentially destructive operation that walks
+    the entire storage tree and removes the specified tag from every artifact that
+    has it.
 
     The confirm_walk_filesystem parameter must be explicitly set to true to
     acknowledge that this operation will scan the entire storage filesystem.
@@ -54,6 +56,8 @@ async def flush_tag(
         FlushTagResponse with list of affected artifacts and count.
 
     Raises:
+        HTTPException 401: If X-Magpie-Scope header is missing (unauthenticated).
+        HTTPException 403: If token doesn't have admin scope.
         HTTPException 400: If confirm_walk_filesystem is not true.
     """
     if confirm_walk_filesystem is not True:

--- a/src/magpie/server/routes/upload.py
+++ b/src/magpie/server/routes/upload.py
@@ -8,7 +8,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, Header, UploadFile
 from pydantic import BaseModel
 
-from magpie.server.deps import get_storage_service
+from magpie.server.deps import get_storage_service, require_write_scope
 from magpie.storage.service import StorageService
 
 logger = logging.getLogger(__name__)
@@ -31,11 +31,14 @@ async def upload_artifact(
     path: str,
     file: UploadFile,
     storage_service: Annotated[StorageService, Depends(get_storage_service)],
+    _write_scope_check: Annotated[None, Depends(require_write_scope)] = None,
     source_uri: str | None = None,
     uploaded_by: str = "anonymous",
     x_magpie_user: Annotated[str | None, Header(alias="X-Magpie-User")] = None,
 ) -> UploadResponse:
     """Upload an artifact to the storage system.
+
+    Requires write or admin scope. Read-only tokens will be rejected with 403.
 
     Stores the uploaded file at the specified artifact path. If an artifact
     with identical content already exists at this path, returns the existing
@@ -57,6 +60,8 @@ async def upload_artifact(
         and duplicate detection status.
 
     Raises:
+        HTTPException 401: If X-Magpie-Scope header is missing (unauthenticated).
+        HTTPException 403: If token has read scope (insufficient permissions).
         StorageError: If storage operation fails.
     """
     # Use X-Magpie-User header if present (authenticated via Caddy)

--- a/tests/unit/test_scope_deps.py
+++ b/tests/unit/test_scope_deps.py
@@ -1,0 +1,150 @@
+"""Unit tests for scope validation dependency functions."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+
+from magpie.server.deps import (
+    _validate_scope_header,
+    require_admin_scope_header,
+    require_write_scope,
+)
+
+
+class TestValidateScopeHeader:
+    """Tests for the _validate_scope_header helper function."""
+
+    def test_returns_valid_read_scope(self) -> None:
+        """Returns 'read' for valid read scope."""
+        result = _validate_scope_header("read")
+        assert result == "read"
+
+    def test_returns_valid_write_scope(self) -> None:
+        """Returns 'write' for valid write scope."""
+        result = _validate_scope_header("write")
+        assert result == "write"
+
+    def test_returns_valid_admin_scope(self) -> None:
+        """Returns 'admin' for valid admin scope."""
+        result = _validate_scope_header("admin")
+        assert result == "admin"
+
+    def test_raises_401_for_none_header(self) -> None:
+        """Raises 401 when scope header is None (unauthenticated)."""
+        with pytest.raises(HTTPException) as exc_info:
+            _validate_scope_header(None)
+
+        assert exc_info.value.status_code == 401
+        assert "Authentication required" in exc_info.value.detail
+
+    def test_raises_403_for_invalid_scope(self) -> None:
+        """Raises 403 for scope values not in TokenScope enum."""
+        with pytest.raises(HTTPException) as exc_info:
+            _validate_scope_header("superadmin")
+
+        assert exc_info.value.status_code == 403
+        assert "Invalid scope" in exc_info.value.detail
+
+    def test_raises_403_for_empty_string(self) -> None:
+        """Raises 403 for empty string scope."""
+        with pytest.raises(HTTPException) as exc_info:
+            _validate_scope_header("")
+
+        assert exc_info.value.status_code == 403
+        assert "Invalid scope" in exc_info.value.detail
+
+    def test_raises_403_for_uppercase_scope(self) -> None:
+        """Raises 403 for uppercase scope (case-sensitive)."""
+        with pytest.raises(HTTPException) as exc_info:
+            _validate_scope_header("ADMIN")
+
+        assert exc_info.value.status_code == 403
+        assert "Invalid scope" in exc_info.value.detail
+
+    def test_raises_403_for_arbitrary_string(self) -> None:
+        """Raises 403 for arbitrary invalid scope string."""
+        with pytest.raises(HTTPException) as exc_info:
+            _validate_scope_header("invalid")
+
+        assert exc_info.value.status_code == 403
+        assert "Invalid scope" in exc_info.value.detail
+
+
+class TestRequireWriteScope:
+    """Tests for the require_write_scope dependency function."""
+
+    def test_allows_write_scope(self) -> None:
+        """Write scope passes without raising."""
+        # Should not raise
+        require_write_scope("write")
+
+    def test_allows_admin_scope(self) -> None:
+        """Admin scope passes without raising (admin >= write)."""
+        # Should not raise
+        require_write_scope("admin")
+
+    def test_rejects_read_scope_with_403(self) -> None:
+        """Read scope raises 403 (insufficient permissions)."""
+        with pytest.raises(HTTPException) as exc_info:
+            require_write_scope("read")
+
+        assert exc_info.value.status_code == 403
+        assert "Write or admin scope required" in exc_info.value.detail
+
+    def test_raises_401_for_none_header(self) -> None:
+        """Missing header raises 401 (unauthenticated)."""
+        with pytest.raises(HTTPException) as exc_info:
+            require_write_scope(None)
+
+        assert exc_info.value.status_code == 401
+        assert "Authentication required" in exc_info.value.detail
+
+    def test_raises_403_for_invalid_scope(self) -> None:
+        """Invalid scope raises 403."""
+        with pytest.raises(HTTPException) as exc_info:
+            require_write_scope("superadmin")
+
+        assert exc_info.value.status_code == 403
+        assert "Invalid scope" in exc_info.value.detail
+
+
+class TestRequireAdminScopeHeader:
+    """Tests for the require_admin_scope_header dependency function."""
+
+    def test_allows_admin_scope(self) -> None:
+        """Admin scope passes without raising."""
+        # Should not raise
+        require_admin_scope_header("admin")
+
+    def test_rejects_write_scope_with_403(self) -> None:
+        """Write scope raises 403 (admin required)."""
+        with pytest.raises(HTTPException) as exc_info:
+            require_admin_scope_header("write")
+
+        assert exc_info.value.status_code == 403
+        assert "Admin scope required" in exc_info.value.detail
+
+    def test_rejects_read_scope_with_403(self) -> None:
+        """Read scope raises 403 (admin required)."""
+        with pytest.raises(HTTPException) as exc_info:
+            require_admin_scope_header("read")
+
+        assert exc_info.value.status_code == 403
+        assert "Admin scope required" in exc_info.value.detail
+
+    def test_raises_401_for_none_header(self) -> None:
+        """Missing header raises 401 (unauthenticated)."""
+        with pytest.raises(HTTPException) as exc_info:
+            require_admin_scope_header(None)
+
+        assert exc_info.value.status_code == 401
+        assert "Authentication required" in exc_info.value.detail
+
+    def test_raises_403_for_invalid_scope(self) -> None:
+        """Invalid scope raises 403."""
+        with pytest.raises(HTTPException) as exc_info:
+            require_admin_scope_header("superadmin")
+
+        assert exc_info.value.status_code == 403
+        assert "Invalid scope" in exc_info.value.detail


### PR DESCRIPTION
## Summary

- Add `require_write_scope` dependency for upload, tag, untag, and amend endpoints
- Add `require_admin_scope_header` dependency for flush-tag endpoint
- These dependencies check `X-Magpie-Scope` header from Caddy forward_auth

## Permission Matrix

| Scope | Upload | Tag/Untag | Amend | Flush-tag |
|-------|--------|-----------|-------|-----------|
| read  | 403    | 403       | 403   | 403       |
| write | 200    | 200       | 200   | 403       |
| admin | 200    | 200       | 200   | 200       |

Fixes #25

---
Generated with [Claude Code](https://claude.ai/code)