### PR TITLE
Add --force flag for protected tags in flush-tag

### DIFF
--- a/.claude/agents/magpie-issue-solver.md
+++ b/.claude/agents/magpie-issue-solver.md
@@ -1,0 +1,118 @@
+---
+name: magpie-issue-solver
+description: "Use this agent when you need to work on a specific GitHub issue or bug fix in the magpie codebase. This agent creates an isolated git worktree for the issue, works independently, and commits changes incrementally. It's designed for parallel work where multiple instances can tackle different issues simultaneously.\\n\\nExamples:\\n\\n<example>\\nContext: User wants to fix a specific GitHub issue in magpie.\\nuser: \"Can you work on issue #42 in the magpie repo? It's about the authentication timeout being too short.\"\\nassistant: \"I'll use the magpie-issue-solver agent to work on this authentication timeout issue.\"\\n<Task tool call to launch magpie-issue-solver with the issue details>\\n</example>\\n\\n<example>\\nContext: User has a bug description they want addressed.\\nuser: \"There's a bug where the API returns 500 errors when the cache is cold. Can you investigate and fix it?\"\\nassistant: \"I'll launch the magpie-issue-solver agent to investigate and fix this cache-related API error.\"\\n<Task tool call to launch magpie-issue-solver with the bug description>\\n</example>\\n\\n<example>\\nContext: User provides a GitHub issue URL.\\nuser: \"Please fix https://github.com/org/magpie/issues/127\"\\nassistant: \"I'll use the magpie-issue-solver agent to work on that GitHub issue.\"\\n<Task tool call to launch magpie-issue-solver with the issue URL>\\n</example>\\n\\n<example>\\nContext: User wants multiple issues worked on in parallel.\\nuser: \"I need issues #15, #23, and #31 worked on. Can you handle them?\"\\nassistant: \"I'll launch separate magpie-issue-solver agents for each issue so they can work in parallel without conflicts.\"\\n<Task tool calls to launch three separate magpie-issue-solver instances>\\n</example>"
+model: sonnet
+color: green
+---
+
+You are an expert software engineer specializing in focused, methodical issue resolution for the magpie codebase. You have deep expertise in understanding complex codebases, debugging, implementing fixes, and maintaining code quality.
+
+## Your Mission
+
+You receive a GitHub issue (URL or description) and work independently to understand, implement, and commit a solution. You operate in isolation using git worktrees, enabling multiple agents to work on different issues simultaneously without conflicts.
+
+## Initial Setup Protocol
+
+When starting work on an issue:
+
+1. **Parse the Issue**: Extract the issue number, title, and full description. If given a URL, fetch the issue details. If given a description, identify or create an appropriate issue identifier.
+
+2. **Understand the Magpie Codebase**: Before making changes, orient yourself:
+   - Read any `.github/copilot-instructions.md` or `CLAUDE.md` files for project conventions
+   - Examine the repository structure (`README.md`, directory layout, `package.json`/`pyproject.toml`/etc.)
+   - Identify the tech stack, testing framework, and build system
+   - Understand the component architecture relevant to the issue
+
+3. **Create Isolated Worktree**:
+   ```bash
+   # Generate a unique worktree name using issue number and timestamp
+   WORKTREE_NAME="issue-${ISSUE_NUMBER}-$(date +%s)"
+   WORKTREE_PATH="../magpie-worktrees/${WORKTREE_NAME}"
+   
+   # Create the worktree directory if needed
+   mkdir -p ../magpie-worktrees
+   
+   # Create worktree from main/master branch
+   git worktree add "${WORKTREE_PATH}" -b "fix/issue-${ISSUE_NUMBER}" origin/main
+   ```
+   - Always work within your dedicated worktree, never the main checkout
+   - Use descriptive branch names: `fix/issue-{number}` or `feat/issue-{number}`
+
+4. **Port Allocation for Docker Services**:
+   If you need to run Docker containers or services:
+   - Calculate session-specific ports: `BASE_PORT = 10000 + (ISSUE_NUMBER * 100)`
+   - Document port mappings in a `.env.local` or similar file in your worktree
+   - Example: Issue #42 uses ports 14200-14299
+   - Always check port availability before binding: `lsof -i :PORT` or `ss -tuln | grep PORT`
+
+## Working Protocol
+
+### Investigation Phase
+1. Reproduce the issue if possible (create a failing test)
+2. Trace the code path involved
+3. Identify root cause vs. symptoms
+4. Document your findings in commit messages
+
+### Implementation Phase
+1. Make incremental, focused changes
+2. **Commit frequently** - at every logical stopping point:
+   - After initial investigation findings
+   - After each component of the fix
+   - After adding/updating tests
+   - After documentation updates
+3. Write clear commit messages referencing the issue:
+   ```
+   fix(component): brief description
+   
+   Detailed explanation of what changed and why.
+   
+   Addresses #ISSUE_NUMBER
+   ```
+
+### Quality Standards
+1. **Tests**: Add or update tests for any code changes
+2. **Documentation**: Update relevant docs when behavior changes:
+   - API documentation
+   - README files
+   - Inline code comments for complex logic
+   - CHANGELOG if the project maintains one
+3. **Linting**: Run project linters before committing
+4. **Type Safety**: Maintain or improve type coverage
+
+## Commit Strategy
+
+Commit at these checkpoints (even if work is incomplete):
+- "WIP: Initial investigation of issue #X" - after understanding the problem
+- "WIP: Identified root cause in [component]" - after finding the source
+- "Add failing test for issue #X" - after reproducing
+- "Fix [specific thing] for issue #X" - after implementing fix
+- "Update tests for issue #X" - after test updates
+- "Update documentation for issue #X changes" - after docs
+
+Never leave uncommitted work. If interrupted or reaching a stopping point, commit with a WIP prefix.
+
+## Handling Blockers
+
+If you encounter:
+- **Missing context**: State what you need and make reasonable assumptions, documenting them
+- **Ambiguous requirements**: Implement the most likely interpretation and note alternatives
+- **External dependencies**: Document what external changes would be needed
+- **Scope creep**: Focus on the core issue; note related issues for separate work
+
+## Cleanup Protocol
+
+When finished:
+1. Ensure all changes are committed
+2. Run the full test suite
+3. Summarize changes made and any follow-up items
+4. Note the branch name and worktree path for the user
+5. Do NOT delete the worktree - leave that decision to the user
+
+## Communication Style
+
+- Be methodical and transparent about your process
+- Explain your reasoning when making architectural decisions
+- Flag any assumptions or uncertainties
+- Provide clear status updates at major milestones
+
+You are autonomous but not opaque. Document your journey through the codebase so your work can be reviewed and understood.

--- a/src/magpie/cli/commands/flush_tag.py
+++ b/src/magpie/cli/commands/flush_tag.py
@@ -56,7 +56,7 @@ def flush_tag(
         raise click.ClickException("No server configured. Use --server or set MAGPIE_SERVER.")
 
     # Refuse to flush protected tags without --force
-    if tag_name in PROTECTED_TAGS and not force:
+    if tag_name.lower() in PROTECTED_TAGS and not force:
         raise click.ClickException(
             f"Tag '{tag_name}' is protected. Use --force to confirm you want to remove "
             f"this tag from ALL artifacts. Protected tags: {', '.join(sorted(PROTECTED_TAGS))}"

--- a/src/magpie/cli/commands/flush_tag.py
+++ b/src/magpie/cli/commands/flush_tag.py
@@ -6,6 +6,9 @@ import click
 
 from magpie.cli import CLIContext
 
+# Tags that require --force to flush due to their common importance
+PROTECTED_TAGS = frozenset({"latest", "stable", "production", "prod", "release"})
+
 
 @click.command(name="flush-tag")
 @click.argument("tag_name")
@@ -22,8 +25,17 @@ from magpie.cli import CLIContext
     default=False,
     help="Skip confirmation prompt.",
 )
+@click.option(
+    "--force",
+    "-f",
+    is_flag=True,
+    default=False,
+    help="Required to flush protected tags (latest, stable, production, etc).",
+)
 @click.pass_obj
-def flush_tag(ctx: CLIContext, tag_name: str, dry_run: bool, yes: bool) -> None:
+def flush_tag(
+    ctx: CLIContext, tag_name: str, dry_run: bool, yes: bool, force: bool
+) -> None:
     """Remove a tag from all artifacts globally.
 
     TAG_NAME is the tag to remove from all artifacts.
@@ -37,9 +49,18 @@ def flush_tag(ctx: CLIContext, tag_name: str, dry_run: bool, yes: bool) -> None:
         magpie flush-tag old-release --dry-run
 
         magpie flush-tag deprecated --yes
+
+        magpie flush-tag latest --force --yes
     """
     if not ctx.server:
         raise click.ClickException("No server configured. Use --server or set MAGPIE_SERVER.")
+
+    # Refuse to flush protected tags without --force
+    if tag_name in PROTECTED_TAGS and not force:
+        raise click.ClickException(
+            f"Tag '{tag_name}' is protected. Use --force to confirm you want to remove "
+            f"this tag from ALL artifacts. Protected tags: {', '.join(sorted(PROTECTED_TAGS))}"
+        )
 
     # Confirm before proceeding (unless --yes or --dry-run)
     if not dry_run and not yes:

--- a/src/magpie/server/deps.py
+++ b/src/magpie/server/deps.py
@@ -32,6 +32,78 @@ def get_token_service() -> TokenService:
     return TokenService(settings)
 
 
+def require_write_scope(
+    x_magpie_scope: Annotated[str | None, Header(alias="X-Magpie-Scope")] = None,
+) -> None:
+    """Dependency that requires write or admin scope from Caddy forward_auth.
+
+    Checks the X-Magpie-Scope header set by Caddy's forward_auth middleware
+    and ensures the token has write or admin scope. Read-only tokens are rejected.
+
+    Args:
+        x_magpie_scope: Scope header value from Caddy forward_auth.
+
+    Raises:
+        HTTPException 401: If X-Magpie-Scope header is missing (unauthenticated).
+        HTTPException 403: If token has invalid or read scope (insufficient permissions).
+    """
+    if x_magpie_scope is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Authentication required",
+        )
+
+    # Validate scope value is one of the allowed scopes
+    valid_scopes = {scope.value for scope in TokenScope}
+    if x_magpie_scope not in valid_scopes:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"Invalid scope: {x_magpie_scope}",
+        )
+
+    if x_magpie_scope == TokenScope.READ.value:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Write or admin scope required",
+        )
+
+
+def require_admin_scope_header(
+    x_magpie_scope: Annotated[str | None, Header(alias="X-Magpie-Scope")] = None,
+) -> None:
+    """Dependency that requires admin scope from Caddy forward_auth.
+
+    Checks the X-Magpie-Scope header set by Caddy's forward_auth middleware
+    and ensures the token has admin scope.
+
+    Args:
+        x_magpie_scope: Scope header value from Caddy forward_auth.
+
+    Raises:
+        HTTPException 401: If X-Magpie-Scope header is missing (unauthenticated).
+        HTTPException 403: If token has invalid or non-admin scope (insufficient permissions).
+    """
+    if x_magpie_scope is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Authentication required",
+        )
+
+    # Validate scope value is one of the allowed scopes
+    valid_scopes = {scope.value for scope in TokenScope}
+    if x_magpie_scope not in valid_scopes:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"Invalid scope: {x_magpie_scope}",
+        )
+
+    if x_magpie_scope != TokenScope.ADMIN.value:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Admin scope required",
+        )
+
+
 def require_admin_scope(
     authorization: Annotated[str | None, Header()] = None,
     token_service: Annotated[TokenService, Depends(get_token_service)] = None,

--- a/tests/integration/test_cli_tags.py
+++ b/tests/integration/test_cli_tags.py
@@ -317,7 +317,7 @@ class TestFlushTagCommand:
         self, cli_runner: CliRunner
     ) -> None:
         """Flush-tag on protected tags requires --force flag."""
-        # Test several protected tags
+        # Test several protected tags (lowercase)
         protected_tags = ["latest", "stable", "production", "prod", "release"]
 
         for tag in protected_tags:
@@ -327,6 +327,23 @@ class TestFlushTagCommand:
             )
 
             assert result.exit_code != 0, f"Tag '{tag}' should require --force"
+            assert "protected" in result.output.lower()
+            assert "--force" in result.output
+
+    def test_flush_tag_protected_tag_case_insensitive(
+        self, cli_runner: CliRunner
+    ) -> None:
+        """Flush-tag protection is case-insensitive."""
+        # Test mixed-case variants of protected tags
+        mixed_case_tags = ["LATEST", "Stable", "PRODUCTION", "Prod", "Release"]
+
+        for tag in mixed_case_tags:
+            result = cli_runner.invoke(
+                cli,
+                ["--server", "http://test", "flush-tag", tag, "--yes"],
+            )
+
+            assert result.exit_code != 0, f"Tag '{tag}' should require --force (case-insensitive)"
             assert "protected" in result.output.lower()
             assert "--force" in result.output
 

--- a/tests/integration/test_cli_tags.py
+++ b/tests/integration/test_cli_tags.py
@@ -312,3 +312,60 @@ class TestFlushTagCommand:
 
         assert result.exit_code != 0
         assert "No server configured" in result.output
+
+    def test_flush_tag_protected_tag_requires_force(
+        self, cli_runner: CliRunner
+    ) -> None:
+        """Flush-tag on protected tags requires --force flag."""
+        # Test several protected tags
+        protected_tags = ["latest", "stable", "production", "prod", "release"]
+
+        for tag in protected_tags:
+            result = cli_runner.invoke(
+                cli,
+                ["--server", "http://test", "flush-tag", tag, "--yes"],
+            )
+
+            assert result.exit_code != 0, f"Tag '{tag}' should require --force"
+            assert "protected" in result.output.lower()
+            assert "--force" in result.output
+
+    def test_flush_tag_protected_tag_with_force_succeeds(
+        self, cli_runner: CliRunner, api_client: TestClient
+    ) -> None:
+        """Flush-tag on protected tags succeeds with --force flag."""
+        # Upload artifact (auto-tagged as 'latest')
+        upload_test_artifact(api_client, "test/force-flush", b"content")
+
+        with patch(PATCH_GET_CLIENT) as mock_get_client:
+            mock_get_client.return_value = api_client
+
+            result = cli_runner.invoke(
+                cli,
+                ["--server", "http://test", "flush-tag", "latest", "--force", "--yes"],
+            )
+
+        assert result.exit_code == 0, f"Output: {result.output}"
+        assert "Removed tag 'latest'" in result.output
+
+    def test_flush_tag_non_protected_tag_no_force_needed(
+        self, cli_runner: CliRunner, api_client: TestClient
+    ) -> None:
+        """Flush-tag on non-protected tags works without --force."""
+        upload_test_artifact(api_client, "test/normal-tag", b"content")
+
+        api_client.post(
+            "/api/v1/artifacts/test/normal-tag/latest/tags",
+            json={"tag_name": "custom-tag"},
+        )
+
+        with patch(PATCH_GET_CLIENT) as mock_get_client:
+            mock_get_client.return_value = api_client
+
+            result = cli_runner.invoke(
+                cli,
+                ["--server", "http://test", "flush-tag", "custom-tag", "--yes"],
+            )
+
+        assert result.exit_code == 0, f"Output: {result.output}"
+        assert "Removed tag 'custom-tag'" in result.output

--- a/uv.lock
+++ b/uv.lock
@@ -146,6 +146,67 @@ wheels = [
 ]
 
 [[package]]
+name = "coverage"
+version = "7.13.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/23/f9/e92df5e07f3fc8d4c7f9a0f146ef75446bf870351cd37b788cf5897f8079/coverage-7.13.1.tar.gz", hash = "sha256:b7593fe7eb5feaa3fbb461ac79aac9f9fc0387a5ca8080b0c6fe2ca27b091afd", size = 825862, upload-time = "2025-12-28T15:42:56.969Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/a4/e98e689347a1ff1a7f67932ab535cef82eb5e78f32a9e4132e114bbb3a0a/coverage-7.13.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:cb237bfd0ef4d5eb6a19e29f9e528ac67ac3be932ea6b44fb6cc09b9f3ecff78", size = 218951, upload-time = "2025-12-28T15:41:16.653Z" },
+    { url = "https://files.pythonhosted.org/packages/32/33/7cbfe2bdc6e2f03d6b240d23dc45fdaf3fd270aaf2d640be77b7f16989ab/coverage-7.13.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1dcb645d7e34dcbcc96cd7c132b1fc55c39263ca62eb961c064eb3928997363b", size = 219325, upload-time = "2025-12-28T15:41:18.609Z" },
+    { url = "https://files.pythonhosted.org/packages/59/f6/efdabdb4929487baeb7cb2a9f7dac457d9356f6ad1b255be283d58b16316/coverage-7.13.1-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:3d42df8201e00384736f0df9be2ced39324c3907607d17d50d50116c989d84cd", size = 250309, upload-time = "2025-12-28T15:41:20.629Z" },
+    { url = "https://files.pythonhosted.org/packages/12/da/91a52516e9d5aea87d32d1523f9cdcf7a35a3b298e6be05d6509ba3cfab2/coverage-7.13.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fa3edde1aa8807de1d05934982416cb3ec46d1d4d91e280bcce7cca01c507992", size = 252907, upload-time = "2025-12-28T15:41:22.257Z" },
+    { url = "https://files.pythonhosted.org/packages/75/38/f1ea837e3dc1231e086db1638947e00d264e7e8c41aa8ecacf6e1e0c05f4/coverage-7.13.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9edd0e01a343766add6817bc448408858ba6b489039eaaa2018474e4001651a4", size = 254148, upload-time = "2025-12-28T15:41:23.87Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/43/f4f16b881aaa34954ba446318dea6b9ed5405dd725dd8daac2358eda869a/coverage-7.13.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:985b7836931d033570b94c94713c6dba5f9d3ff26045f72c3e5dbc5fe3361e5a", size = 250515, upload-time = "2025-12-28T15:41:25.437Z" },
+    { url = "https://files.pythonhosted.org/packages/84/34/8cba7f00078bd468ea914134e0144263194ce849ec3baad187ffb6203d1c/coverage-7.13.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ffed1e4980889765c84a5d1a566159e363b71d6b6fbaf0bebc9d3c30bc016766", size = 252292, upload-time = "2025-12-28T15:41:28.459Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/a4/cffac66c7652d84ee4ac52d3ccb94c015687d3b513f9db04bfcac2ac800d/coverage-7.13.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:8842af7f175078456b8b17f1b73a0d16a65dcbdc653ecefeb00a56b3c8c298c4", size = 250242, upload-time = "2025-12-28T15:41:30.02Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/78/9a64d462263dde416f3c0067efade7b52b52796f489b1037a95b0dc389c9/coverage-7.13.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:ccd7a6fca48ca9c131d9b0a2972a581e28b13416fc313fb98b6d24a03ce9a398", size = 250068, upload-time = "2025-12-28T15:41:32.007Z" },
+    { url = "https://files.pythonhosted.org/packages/69/c8/a8994f5fece06db7c4a97c8fc1973684e178599b42e66280dded0524ef00/coverage-7.13.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0403f647055de2609be776965108447deb8e384fe4a553c119e3ff6bfbab4784", size = 251846, upload-time = "2025-12-28T15:41:33.946Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/f7/91fa73c4b80305c86598a2d4e54ba22df6bf7d0d97500944af7ef155d9f7/coverage-7.13.1-cp313-cp313-win32.whl", hash = "sha256:549d195116a1ba1e1ae2f5ca143f9777800f6636eab917d4f02b5310d6d73461", size = 221512, upload-time = "2025-12-28T15:41:35.519Z" },
+    { url = "https://files.pythonhosted.org/packages/45/0b/0768b4231d5a044da8f75e097a8714ae1041246bb765d6b5563bab456735/coverage-7.13.1-cp313-cp313-win_amd64.whl", hash = "sha256:5899d28b5276f536fcf840b18b61a9fce23cc3aec1d114c44c07fe94ebeaa500", size = 222321, upload-time = "2025-12-28T15:41:37.371Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/b8/bdcb7253b7e85157282450262008f1366aa04663f3e3e4c30436f596c3e2/coverage-7.13.1-cp313-cp313-win_arm64.whl", hash = "sha256:868a2fae76dfb06e87291bcbd4dcbcc778a8500510b618d50496e520bd94d9b9", size = 220949, upload-time = "2025-12-28T15:41:39.553Z" },
+    { url = "https://files.pythonhosted.org/packages/70/52/f2be52cc445ff75ea8397948c96c1b4ee14f7f9086ea62fc929c5ae7b717/coverage-7.13.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:67170979de0dacac3f3097d02b0ad188d8edcea44ccc44aaa0550af49150c7dc", size = 219643, upload-time = "2025-12-28T15:41:41.567Z" },
+    { url = "https://files.pythonhosted.org/packages/47/79/c85e378eaa239e2edec0c5523f71542c7793fe3340954eafb0bc3904d32d/coverage-7.13.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:f80e2bb21bfab56ed7405c2d79d34b5dc0bc96c2c1d2a067b643a09fb756c43a", size = 219997, upload-time = "2025-12-28T15:41:43.418Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/9b/b1ade8bfb653c0bbce2d6d6e90cc6c254cbb99b7248531cc76253cb4da6d/coverage-7.13.1-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:f83351e0f7dcdb14d7326c3d8d8c4e915fa685cbfdc6281f9470d97a04e9dfe4", size = 261296, upload-time = "2025-12-28T15:41:45.207Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/af/ebf91e3e1a2473d523e87e87fd8581e0aa08741b96265730e2d79ce78d8d/coverage-7.13.1-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:bb3f6562e89bad0110afbe64e485aac2462efdce6232cdec7862a095dc3412f6", size = 263363, upload-time = "2025-12-28T15:41:47.163Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/8b/fb2423526d446596624ac7fde12ea4262e66f86f5120114c3cfd0bb2befa/coverage-7.13.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:77545b5dcda13b70f872c3b5974ac64c21d05e65b1590b441c8560115dc3a0d1", size = 265783, upload-time = "2025-12-28T15:41:49.03Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/26/ef2adb1e22674913b89f0fe7490ecadcef4a71fa96f5ced90c60ec358789/coverage-7.13.1-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a4d240d260a1aed814790bbe1f10a5ff31ce6c21bc78f0da4a1e8268d6c80dbd", size = 260508, upload-time = "2025-12-28T15:41:51.035Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/7d/f0f59b3404caf662e7b5346247883887687c074ce67ba453ea08c612b1d5/coverage-7.13.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:d2287ac9360dec3837bfdad969963a5d073a09a85d898bd86bea82aa8876ef3c", size = 263357, upload-time = "2025-12-28T15:41:52.631Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/b1/29896492b0b1a047604d35d6fa804f12818fa30cdad660763a5f3159e158/coverage-7.13.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:0d2c11f3ea4db66b5cbded23b20185c35066892c67d80ec4be4bab257b9ad1e0", size = 260978, upload-time = "2025-12-28T15:41:54.589Z" },
+    { url = "https://files.pythonhosted.org/packages/48/f2/971de1238a62e6f0a4128d37adadc8bb882ee96afbe03ff1570291754629/coverage-7.13.1-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:3fc6a169517ca0d7ca6846c3c5392ef2b9e38896f61d615cb75b9e7134d4ee1e", size = 259877, upload-time = "2025-12-28T15:41:56.263Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/fc/0474efcbb590ff8628830e9aaec5f1831594874360e3251f1fdec31d07a3/coverage-7.13.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:d10a2ed46386e850bb3de503a54f9fe8192e5917fcbb143bfef653a9355e9a53", size = 262069, upload-time = "2025-12-28T15:41:58.093Z" },
+    { url = "https://files.pythonhosted.org/packages/88/4f/3c159b7953db37a7b44c0eab8a95c37d1aa4257c47b4602c04022d5cb975/coverage-7.13.1-cp313-cp313t-win32.whl", hash = "sha256:75a6f4aa904301dab8022397a22c0039edc1f51e90b83dbd4464b8a38dc87842", size = 222184, upload-time = "2025-12-28T15:41:59.763Z" },
+    { url = "https://files.pythonhosted.org/packages/58/a5/6b57d28f81417f9335774f20679d9d13b9a8fb90cd6160957aa3b54a2379/coverage-7.13.1-cp313-cp313t-win_amd64.whl", hash = "sha256:309ef5706e95e62578cda256b97f5e097916a2c26247c287bbe74794e7150df2", size = 223250, upload-time = "2025-12-28T15:42:01.52Z" },
+    { url = "https://files.pythonhosted.org/packages/81/7c/160796f3b035acfbb58be80e02e484548595aa67e16a6345e7910ace0a38/coverage-7.13.1-cp313-cp313t-win_arm64.whl", hash = "sha256:92f980729e79b5d16d221038dbf2e8f9a9136afa072f9d5d6ed4cb984b126a09", size = 221521, upload-time = "2025-12-28T15:42:03.275Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/8e/ba0e597560c6563fc0adb902fda6526df5d4aa73bb10adf0574d03bd2206/coverage-7.13.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:97ab3647280d458a1f9adb85244e81587505a43c0c7cff851f5116cd2814b894", size = 218996, upload-time = "2025-12-28T15:42:04.978Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/8e/764c6e116f4221dc7aa26c4061181ff92edb9c799adae6433d18eeba7a14/coverage-7.13.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:8f572d989142e0908e6acf57ad1b9b86989ff057c006d13b76c146ec6a20216a", size = 219326, upload-time = "2025-12-28T15:42:06.691Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/a6/6130dc6d8da28cdcbb0f2bf8865aeca9b157622f7c0031e48c6cf9a0e591/coverage-7.13.1-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:d72140ccf8a147e94274024ff6fd8fb7811354cf7ef88b1f0a988ebaa5bc774f", size = 250374, upload-time = "2025-12-28T15:42:08.786Z" },
+    { url = "https://files.pythonhosted.org/packages/82/2b/783ded568f7cd6b677762f780ad338bf4b4750205860c17c25f7c708995e/coverage-7.13.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:d3c9f051b028810f5a87c88e5d6e9af3c0ff32ef62763bf15d29f740453ca909", size = 252882, upload-time = "2025-12-28T15:42:10.515Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/b2/9808766d082e6a4d59eb0cc881a57fc1600eb2c5882813eefff8254f71b5/coverage-7.13.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f398ba4df52d30b1763f62eed9de5620dcde96e6f491f4c62686736b155aa6e4", size = 254218, upload-time = "2025-12-28T15:42:12.208Z" },
+    { url = "https://files.pythonhosted.org/packages/44/ea/52a985bb447c871cb4d2e376e401116520991b597c85afdde1ea9ef54f2c/coverage-7.13.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:132718176cc723026d201e347f800cd1a9e4b62ccd3f82476950834dad501c75", size = 250391, upload-time = "2025-12-28T15:42:14.21Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/1d/125b36cc12310718873cfc8209ecfbc1008f14f4f5fa0662aa608e579353/coverage-7.13.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9e549d642426e3579b3f4b92d0431543b012dcb6e825c91619d4e93b7363c3f9", size = 252239, upload-time = "2025-12-28T15:42:16.292Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/16/10c1c164950cade470107f9f14bbac8485f8fb8515f515fca53d337e4a7f/coverage-7.13.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:90480b2134999301eea795b3a9dbf606c6fbab1b489150c501da84a959442465", size = 250196, upload-time = "2025-12-28T15:42:18.54Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/c6/cd860fac08780c6fd659732f6ced1b40b79c35977c1356344e44d72ba6c4/coverage-7.13.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e825dbb7f84dfa24663dd75835e7257f8882629fc11f03ecf77d84a75134b864", size = 250008, upload-time = "2025-12-28T15:42:20.365Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/a8c58d3d38f82a5711e1e0a67268362af48e1a03df27c03072ac30feefcf/coverage-7.13.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:623dcc6d7a7ba450bbdbeedbaa0c42b329bdae16491af2282f12a7e809be7eb9", size = 251671, upload-time = "2025-12-28T15:42:22.114Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/bc/fd4c1da651d037a1e3d53e8cb3f8182f4b53271ffa9a95a2e211bacc0349/coverage-7.13.1-cp314-cp314-win32.whl", hash = "sha256:6e73ebb44dca5f708dc871fe0b90cf4cff1a13f9956f747cc87b535a840386f5", size = 221777, upload-time = "2025-12-28T15:42:23.919Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/50/71acabdc8948464c17e90b5ffd92358579bd0910732c2a1c9537d7536aa6/coverage-7.13.1-cp314-cp314-win_amd64.whl", hash = "sha256:be753b225d159feb397bd0bf91ae86f689bad0da09d3b301478cd39b878ab31a", size = 222592, upload-time = "2025-12-28T15:42:25.619Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/c8/a6fb943081bb0cc926499c7907731a6dc9efc2cbdc76d738c0ab752f1a32/coverage-7.13.1-cp314-cp314-win_arm64.whl", hash = "sha256:228b90f613b25ba0019361e4ab81520b343b622fc657daf7e501c4ed6a2366c0", size = 221169, upload-time = "2025-12-28T15:42:27.629Z" },
+    { url = "https://files.pythonhosted.org/packages/16/61/d5b7a0a0e0e40d62e59bc8c7aa1afbd86280d82728ba97f0673b746b78e2/coverage-7.13.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:60cfb538fe9ef86e5b2ab0ca8fc8d62524777f6c611dcaf76dc16fbe9b8e698a", size = 219730, upload-time = "2025-12-28T15:42:29.306Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/2c/8881326445fd071bb49514d1ce97d18a46a980712b51fee84f9ab42845b4/coverage-7.13.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:57dfc8048c72ba48a8c45e188d811e5efd7e49b387effc8fb17e97936dde5bf6", size = 220001, upload-time = "2025-12-28T15:42:31.319Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/d7/50de63af51dfa3a7f91cc37ad8fcc1e244b734232fbc8b9ab0f3c834a5cd/coverage-7.13.1-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:3f2f725aa3e909b3c5fdb8192490bdd8e1495e85906af74fe6e34a2a77ba0673", size = 261370, upload-time = "2025-12-28T15:42:32.992Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/2c/d31722f0ec918fd7453b2758312729f645978d212b410cd0f7c2aed88a94/coverage-7.13.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9ee68b21909686eeb21dfcba2c3b81fee70dcf38b140dcd5aa70680995fa3aa5", size = 263485, upload-time = "2025-12-28T15:42:34.759Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/7a/2c114fa5c5fc08ba0777e4aec4c97e0b4a1afcb69c75f1f54cff78b073ab/coverage-7.13.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:724b1b270cb13ea2e6503476e34541a0b1f62280bc997eab443f87790202033d", size = 265890, upload-time = "2025-12-28T15:42:36.517Z" },
+    { url = "https://files.pythonhosted.org/packages/65/d9/f0794aa1c74ceabc780fe17f6c338456bbc4e96bd950f2e969f48ac6fb20/coverage-7.13.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:916abf1ac5cf7eb16bc540a5bf75c71c43a676f5c52fcb9fe75a2bd75fb944e8", size = 260445, upload-time = "2025-12-28T15:42:38.646Z" },
+    { url = "https://files.pythonhosted.org/packages/49/23/184b22a00d9bb97488863ced9454068c79e413cb23f472da6cbddc6cfc52/coverage-7.13.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:776483fd35b58d8afe3acbd9988d5de592ab6da2d2a865edfdbc9fdb43e7c486", size = 263357, upload-time = "2025-12-28T15:42:40.788Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/bd/58af54c0c9199ea4190284f389005779d7daf7bf3ce40dcd2d2b2f96da69/coverage-7.13.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:b6f3b96617e9852703f5b633ea01315ca45c77e879584f283c44127f0f1ec564", size = 260959, upload-time = "2025-12-28T15:42:42.808Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/2a/6839294e8f78a4891bf1df79d69c536880ba2f970d0ff09e7513d6e352e9/coverage-7.13.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:bd63e7b74661fed317212fab774e2a648bc4bb09b35f25474f8e3325d2945cd7", size = 259792, upload-time = "2025-12-28T15:42:44.818Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/c3/528674d4623283310ad676c5af7414b9850ab6d55c2300e8aa4b945ec554/coverage-7.13.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:933082f161bbb3e9f90d00990dc956120f608cdbcaeea15c4d897f56ef4fe416", size = 262123, upload-time = "2025-12-28T15:42:47.108Z" },
+    { url = "https://files.pythonhosted.org/packages/06/c5/8c0515692fb4c73ac379d8dc09b18eaf0214ecb76ea6e62467ba7a1556ff/coverage-7.13.1-cp314-cp314t-win32.whl", hash = "sha256:18be793c4c87de2965e1c0f060f03d9e5aff66cfeae8e1dbe6e5b88056ec153f", size = 222562, upload-time = "2025-12-28T15:42:49.144Z" },
+    { url = "https://files.pythonhosted.org/packages/05/0e/c0a0c4678cb30dac735811db529b321d7e1c9120b79bd728d4f4d6b010e9/coverage-7.13.1-cp314-cp314t-win_amd64.whl", hash = "sha256:0e42e0ec0cd3e0d851cb3c91f770c9301f48647cb2877cb78f74bdaa07639a79", size = 223670, upload-time = "2025-12-28T15:42:51.218Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/5f/b177aa0011f354abf03a8f30a85032686d290fdeed4222b27d36b4372a50/coverage-7.13.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eaecf47ef10c72ece9a2a92118257da87e460e113b83cc0d2905cbbe931792b4", size = 221707, upload-time = "2025-12-28T15:42:53.034Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/48/d9f421cb8da5afaa1a64570d9989e00fb7955e6acddc5a12979f7666ef60/coverage-7.13.1-py3-none-any.whl", hash = "sha256:2016745cb3ba554469d02819d78958b571792bb68e31302610e898f80dd3a573", size = 210722, upload-time = "2025-12-28T15:42:54.901Z" },
+]
+
+[[package]]
 name = "distlib"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -342,6 +403,7 @@ dev = [
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
     { name = "ruff" },
 ]
 
@@ -365,6 +427,7 @@ dev = [
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
     { name = "ruff" },
 ]
 
@@ -742,6 +805,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "7.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage" },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/f7/c933acc76f5208b3b00089573cf6a2bc26dc80a8aece8f52bb7d6b1855ca/pytest_cov-7.0.0.tar.gz", hash = "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1", size = 54328, upload-time = "2025-09-09T10:57:02.113Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ee/49/1377b49de7d0c1ce41292161ea0f721913fa8722c19fb9c1e3aa0367eecb/pytest_cov-7.0.0-py3-none-any.whl", hash = "sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861", size = 22424, upload-time = "2025-09-09T10:57:00.695Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Require explicit `--force` flag to flush protected tags that could cause significant disruption if accidentally removed from all artifacts.

## Protected Tags

- `latest`
- `stable`
- `production`
- `prod`
- `release`

## Example

```bash
# This will fail with an error
magpie flush-tag latest --yes

# This will work
magpie flush-tag latest --force --yes
```

## Tests

Added 3 new tests:
- `test_flush_tag_protected_tag_requires_force`
- `test_flush_tag_protected_tag_with_force_succeeds`
- `test_flush_tag_non_protected_tag_no_force_needed`

Fixes #31

---
Generated with [Claude Code](https://claude.ai/code)