### PR TITLE
Add justfile for common development tasks

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,0 +1,84 @@
+# Magpie justfile - Common development tasks
+
+# Default recipe lists all available commands
+default:
+    @just --list
+
+# Run all tests
+test:
+    uv run pytest
+
+# Run tests with coverage report
+test-cov:
+    uv run pytest --cov=magpie --cov-report=term-missing --cov-report=html
+
+# Run only unit tests
+test-unit:
+    uv run pytest tests/unit
+
+# Run only integration tests
+test-integration:
+    uv run pytest tests/integration
+
+# Run e2e tests (requires docker compose up)
+e2e:
+    uv run pytest -m e2e
+
+# Run linting checks
+lint:
+    uv run ruff check .
+
+# Run code formatting
+fmt:
+    uv run ruff format .
+
+# Run security scanning with bandit
+security:
+    uv run bandit -r src/magpie
+
+# Run all checks (lint + format check + tests)
+check:
+    uv run ruff check .
+    uv run ruff format --check .
+    uv run pytest
+
+# Start development server with auto-reload
+serve:
+    uv run uvicorn magpie.server.app:app --reload
+
+# Start development server on specific host/port
+serve-custom host="0.0.0.0" port="8000":
+    uv run uvicorn magpie.server.app:app --host {{host}} --port {{port}} --reload
+
+# Build docker image
+build tag="magpie:latest":
+    docker build -t {{tag}} .
+
+# Start full stack with docker compose
+up:
+    docker compose up --build
+
+# Stop docker compose stack
+down:
+    docker compose down
+
+# Clean temporary files and caches
+clean:
+    find . -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true
+    find . -type d -name ".pytest_cache" -exec rm -rf {} + 2>/dev/null || true
+    find . -type d -name ".ruff_cache" -exec rm -rf {} + 2>/dev/null || true
+    find . -type d -name "htmlcov" -exec rm -rf {} + 2>/dev/null || true
+    find . -type f -name "*.pyc" -delete 2>/dev/null || true
+    find . -type f -name ".coverage" -delete 2>/dev/null || true
+
+# Install/update dependencies
+sync:
+    uv sync
+
+# Run pre-commit hooks on all files
+pre-commit:
+    uv run pre-commit run --all-files
+
+# Show project version
+version:
+    @uv run python -c "from magpie import __version__; print(__version__)"


### PR DESCRIPTION
## Summary

Adds a comprehensive justfile with standardized recipes for development workflow.

## Recipes

### Testing
- `just test` - Run all tests
- `just test-cov` - Run tests with coverage
- `just test-unit` - Run unit tests only
- `just test-integration` - Run integration tests only
- `just e2e` - Run e2e tests (requires docker compose)

### Code Quality
- `just lint` - Run ruff linting
- `just fmt` - Format code with ruff
- `just security` - Run bandit security scan
- `just check` - Run all checks (lint + format + tests)

### Development
- `just serve` - Start dev server with auto-reload
- `just build` - Build docker image
- `just up` / `just down` - Docker compose commands

### Maintenance
- `just clean` - Remove temp files and caches
- `just sync` - Install/update dependencies

Fixes #4
Closes #23

---
Generated with [Claude Code](https://claude.ai/code)