### PR TITLE
Add progress bar and JSON output to GC command

### DIFF
--- a/src/magpie/cli/commands/gc.py
+++ b/src/magpie/cli/commands/gc.py
@@ -35,7 +35,9 @@ def gc(ctx: CLIContext, dry_run: bool) -> None:
         raise click.ClickException("No server configured. Use --server or set MAGPIE_SERVER.")
 
     if not ctx.token:
-        raise click.ClickException("No token configured. Use --token or set MAGPIE_TOKEN. Admin token required.")
+        raise click.ClickException(
+            "No token configured. Use --token or set MAGPIE_TOKEN. Admin token required."
+        )
 
     with ctx.get_client() as client:
         if ctx.debug:
@@ -68,7 +70,9 @@ def gc(ctx: CLIContext, dry_run: bool) -> None:
 
     action = "Would delete" if dry_run else "Deleted"
     click.echo(f"  {action}: {data['blobs_deleted']} blob(s)")
-    click.echo(f"  Space {'reclaimable' if dry_run else 'reclaimed'}: {_format_size(data['space_reclaimed_bytes'])}")
+    click.echo(
+        f"  Space {'reclaimable' if dry_run else 'reclaimed'}: {_format_size(data['space_reclaimed_bytes'])}"
+    )
 
 
 def _handle_error(response: "httpx.Response", message: str | None = None) -> None:

--- a/src/magpie/ctl/commands/gc.py
+++ b/src/magpie/ctl/commands/gc.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import click
 
 from magpie.ctl import CTLContext
-from magpie.storage.manifest import Manifest, read_manifest
+from magpie.storage.manifest import read_manifest
 from magpie.storage.metadata import read_metadata
 from magpie.storage.symlinks import reconcile_symlinks
 
@@ -38,7 +38,9 @@ from magpie.storage.symlinks import reconcile_symlinks
     help="Suppress progress output (no effect with --json).",
 )
 @click.pass_obj
-def gc(ctx: CTLContext, dry_run: bool, reconcile_only: bool, json_output: bool, quiet: bool) -> None:
+def gc(
+    ctx: CTLContext, dry_run: bool, reconcile_only: bool, json_output: bool, quiet: bool
+) -> None:
     """Garbage collect untagged blobs older than retention period.
 
     Walks all artifact directories and:
@@ -88,11 +90,7 @@ def gc(ctx: CTLContext, dry_run: bool, reconcile_only: bool, json_output: bool, 
     manifest_files = list(storage_path.rglob(".magpie"))
 
     # Determine if we should show progress
-    show_progress = (
-        not json_output
-        and not quiet
-        and sys.stdout.isatty()
-    )
+    show_progress = not json_output and not quiet and sys.stdout.isatty()
 
     # Process artifacts with optional progress bar
     artifacts_iter = manifest_files

--- a/src/magpie/ctl/commands/gc.py
+++ b/src/magpie/ctl/commands/gc.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -24,8 +26,19 @@ from magpie.storage.symlinks import reconcile_symlinks
     is_flag=True,
     help="Only reconcile symlinks, don't delete blobs.",
 )
+@click.option(
+    "--json",
+    "json_output",
+    is_flag=True,
+    help="Output machine-readable JSON statistics.",
+)
+@click.option(
+    "--quiet",
+    is_flag=True,
+    help="Suppress progress output (no effect with --json).",
+)
 @click.pass_obj
-def gc(ctx: CTLContext, dry_run: bool, reconcile_only: bool) -> None:
+def gc(ctx: CTLContext, dry_run: bool, reconcile_only: bool, json_output: bool, quiet: bool) -> None:
     """Garbage collect untagged blobs older than retention period.
 
     Walks all artifact directories and:
@@ -35,6 +48,8 @@ def gc(ctx: CTLContext, dry_run: bool, reconcile_only: bool) -> None:
 
     Use --dry-run to see what would be deleted without making changes.
     Use --reconcile-only to only fix symlinks without deleting blobs.
+    Use --json to output machine-readable statistics.
+    Use --quiet to suppress progress bars.
 
     Examples:
 
@@ -43,6 +58,8 @@ def gc(ctx: CTLContext, dry_run: bool, reconcile_only: bool) -> None:
         magpie-ctl gc
 
         magpie-ctl gc --reconcile-only
+
+        magpie-ctl gc --json
     """
     settings = ctx.settings
     storage_path = settings.storage_path
@@ -51,7 +68,7 @@ def gc(ctx: CTLContext, dry_run: bool, reconcile_only: bool) -> None:
     if not storage_path.exists():
         raise click.ClickException(f"Storage path does not exist: {storage_path}")
 
-    if ctx.debug:
+    if ctx.debug and not json_output:
         click.echo(f"Storage path: {storage_path}", err=True)
         click.echo(f"Retention days: {retention_days}", err=True)
 
@@ -62,16 +79,37 @@ def gc(ctx: CTLContext, dry_run: bool, reconcile_only: bool) -> None:
     deleted_blobs = 0
     deleted_bytes = 0
     reconciled_artifacts = 0
+    symlinks_checked = 0
+    symlinks_fixed = 0
 
     now = datetime.now(timezone.utc)
 
-    # Find all artifact directories (containing .magpie manifest)
-    for manifest_file in storage_path.rglob(".magpie"):
+    # Collect all manifest files first for progress tracking
+    manifest_files = list(storage_path.rglob(".magpie"))
+
+    # Determine if we should show progress
+    show_progress = (
+        not json_output
+        and not quiet
+        and sys.stdout.isatty()
+    )
+
+    # Process artifacts with optional progress bar
+    artifacts_iter = manifest_files
+    if show_progress:
+        artifacts_iter = click.progressbar(
+            manifest_files,
+            label="Scanning artifacts",
+            show_pos=True,
+            item_show_func=lambda x: str(x.parent.relative_to(storage_path)) if x else "",
+        )
+
+    for manifest_file in artifacts_iter:
         artifact_dir = manifest_file.parent
         artifact_path = str(artifact_dir.relative_to(storage_path))
         total_artifacts += 1
 
-        if ctx.debug:
+        if ctx.debug and not json_output:
             click.echo(f"Processing artifact: {artifact_path}", err=True)
 
         # Read manifest to get tagged hashes
@@ -80,7 +118,9 @@ def gc(ctx: CTLContext, dry_run: bool, reconcile_only: bool) -> None:
         tagged_hashes = {h[:8] for h in manifest.tags.values()}
 
         # Reconcile symlinks for this artifact
-        reconcile_symlinks(artifact_dir, manifest)
+        checked, fixed = reconcile_symlinks(artifact_dir, manifest)
+        symlinks_checked += checked
+        symlinks_fixed += fixed
         reconciled_artifacts += 1
 
         if reconcile_only:
@@ -109,13 +149,13 @@ def gc(ctx: CTLContext, dry_run: bool, reconcile_only: bool) -> None:
 
             if blob_age_days is None:
                 # Can't determine age, skip
-                if ctx.debug:
+                if ctx.debug and not json_output:
                     click.echo(f"  Skipping blob {blob_hash[:12]}... (unknown age)", err=True)
                 continue
 
             # Check if blob is older than retention period
             if blob_age_days < retention_days:
-                if ctx.debug:
+                if ctx.debug and not json_output:
                     click.echo(
                         f"  Keeping blob {blob_hash[:12]}... ({blob_age_days} days old < {retention_days})",
                         err=True,
@@ -126,12 +166,13 @@ def gc(ctx: CTLContext, dry_run: bool, reconcile_only: bool) -> None:
             blob_size = blob_file.stat().st_size
 
             if dry_run:
-                click.echo(
-                    f"Would delete: {artifact_path}/blobs/{blob_hash[:12]}... "
-                    f"({blob_age_days} days old, {_format_size(blob_size)})"
-                )
+                if not json_output:
+                    click.echo(
+                        f"Would delete: {artifact_path}/blobs/{blob_hash[:12]}... "
+                        f"({blob_age_days} days old, {_format_size(blob_size)})"
+                    )
             else:
-                if ctx.debug:
+                if ctx.debug and not json_output:
                     click.echo(
                         f"  Deleting blob {blob_hash[:12]}... ({blob_age_days} days old)",
                         err=True,
@@ -146,17 +187,32 @@ def gc(ctx: CTLContext, dry_run: bool, reconcile_only: bool) -> None:
             deleted_blobs += 1
             deleted_bytes += blob_size
 
-    # Print summary
-    click.echo("")
-    click.echo("GC Summary:")
-    click.echo(f"  Artifacts scanned: {total_artifacts}")
-    click.echo(f"  Blobs found: {total_blobs_found}")
-    click.echo(f"  Untagged blobs: {untagged_blobs}")
-    click.echo(f"  Symlinks reconciled: {reconciled_artifacts} artifact(s)")
+    # Output results
+    if json_output:
+        # JSON output mode
+        output = {
+            "artifacts_scanned": total_artifacts,
+            "blobs_deleted": deleted_blobs,
+            "bytes_reclaimed": deleted_bytes,
+            "symlinks_checked": symlinks_checked,
+            "symlinks_fixed": symlinks_fixed,
+            "dry_run": dry_run,
+        }
+        click.echo(json.dumps(output, indent=2))
+    else:
+        # Human-readable output mode
+        click.echo("")
+        click.echo("GC Summary:")
+        click.echo(f"  Artifacts scanned: {total_artifacts}")
+        click.echo(f"  Blobs found: {total_blobs_found}")
+        click.echo(f"  Untagged blobs: {untagged_blobs}")
+        click.echo(f"  Symlinks reconciled: {reconciled_artifacts} artifact(s)")
+        click.echo(f"  Symlinks checked: {symlinks_checked}")
+        click.echo(f"  Symlinks fixed: {symlinks_fixed}")
 
-    if not reconcile_only:
-        action = "Would delete" if dry_run else "Deleted"
-        click.echo(f"  {action}: {deleted_blobs} blob(s), {_format_size(deleted_bytes)}")
+        if not reconcile_only:
+            action = "Would delete" if dry_run else "Deleted"
+            click.echo(f"  {action}: {deleted_blobs} blob(s), {_format_size(deleted_bytes)}")
 
 
 def _get_blob_age_days(artifact_dir: Path, blob_hash: str, now: datetime) -> int | None:

--- a/src/magpie/server/routes/artifacts.py
+++ b/src/magpie/server/routes/artifacts.py
@@ -169,9 +169,7 @@ async def remove_tag(
     removed = storage_service.remove_tag(path, tag_name)
 
     if not removed:
-        raise ArtifactNotFoundError(
-            f"Tag '{tag_name}' not found in artifact {path}"
-        )
+        raise ArtifactNotFoundError(f"Tag '{tag_name}' not found in artifact {path}")
 
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 

--- a/src/magpie/server/routes/gc.py
+++ b/src/magpie/server/routes/gc.py
@@ -70,7 +70,7 @@ async def trigger_gc(
             manifest = read_manifest(artifact_dir)
             tagged_hashes = set(manifest.tags.values())
 
-            # Reconcile symlinks for this artifact
+            # Reconcile symlinks for this artifact (ignore stats in API endpoint)
             reconcile_symlinks(artifact_dir, manifest)
 
             # Find all blobs in blobs/ directory

--- a/src/magpie/server/routes/tags.py
+++ b/src/magpie/server/routes/tags.py
@@ -27,9 +27,7 @@ async def flush_tag(
     tag_name: str,
     confirm_walk_filesystem: Annotated[
         bool | None,
-        Query(
-            description="Must be true to confirm this operation walks the entire filesystem"
-        ),
+        Query(description="Must be true to confirm this operation walks the entire filesystem"),
     ] = None,
     dry_run: Annotated[
         bool,

--- a/src/magpie/storage/hash.py
+++ b/src/magpie/storage/hash.py
@@ -33,9 +33,7 @@ def compute_hash(file_or_path: BinaryIO | Path | bytes) -> str:
     elif hasattr(file_or_path, "read"):
         _hash_file_chunks(file_or_path, hasher)
     else:
-        raise TypeError(
-            f"Expected BinaryIO, Path, or bytes, got {type(file_or_path).__name__}"
-        )
+        raise TypeError(f"Expected BinaryIO, Path, or bytes, got {type(file_or_path).__name__}")
 
     return hasher.hexdigest()
 

--- a/src/magpie/storage/metadata.py
+++ b/src/magpie/storage/metadata.py
@@ -25,9 +25,7 @@ class BlobMetadata(BaseModel):
     source_uri: str | None = None  # Optional source URI
 
 
-def write_metadata(
-    artifact_dir: Path, hash_ref: str, metadata: BlobMetadata
-) -> None:
+def write_metadata(artifact_dir: Path, hash_ref: str, metadata: BlobMetadata) -> None:
     """Write metadata sidecar file for a blob.
 
     Metadata is write-once: if the file already exists, this function

--- a/src/magpie/storage/service.py
+++ b/src/magpie/storage/service.py
@@ -105,7 +105,7 @@ class StorageService:
         # symlinks will extract first 8 chars for the actual blob path
         manifest = update_tag(artifact_dir, "latest", full_hash)
 
-        # Reconcile symlinks to match manifest
+        # Reconcile symlinks to match manifest (ignore stats in normal flow)
         reconcile_symlinks(artifact_dir, manifest)
 
         # Build artifact info
@@ -254,7 +254,7 @@ class StorageService:
         # Update manifest with tag (uses full hash for verification)
         manifest = update_tag(artifact_dir, tag_name, full_hash)
 
-        # Reconcile symlinks to match manifest
+        # Reconcile symlinks to match manifest (ignore stats in normal flow)
         reconcile_symlinks(artifact_dir, manifest)
 
         # Get all tags pointing to this hash
@@ -295,7 +295,7 @@ class StorageService:
         # Remove tag from manifest
         manifest = remove_tag(artifact_dir, tag_name)
 
-        # Reconcile symlinks to remove the symlink
+        # Reconcile symlinks to remove the symlink (ignore stats in normal flow)
         reconcile_symlinks(artifact_dir, manifest)
 
         return True

--- a/src/magpie/storage/service.py
+++ b/src/magpie/storage/service.py
@@ -87,9 +87,7 @@ class StorageService:
 
         # Store blob (handles streaming and hashing)
         # Returns full hash for metadata, short hash ref for display
-        full_hash, hash_ref, is_duplicate = store_blob(
-            artifact_dir, file_stream, self.config
-        )
+        full_hash, hash_ref, is_duplicate = store_blob(artifact_dir, file_stream, self.config)
 
         # Write metadata sidecar (only for new blobs, write_metadata is write-once)
         # Use hash_ref (short hash) for filename, but store full_hash inside
@@ -190,9 +188,7 @@ class StorageService:
         artifact_dir = artifact_dir_path(self.config.storage_path, artifact_path)
 
         if not artifact_dir.exists():
-            raise ArtifactNotFoundError(
-                f"Artifact path not found: {artifact_path}"
-            )
+            raise ArtifactNotFoundError(f"Artifact path not found: {artifact_path}")
 
         manifest = read_manifest(artifact_dir)
 
@@ -206,9 +202,7 @@ class StorageService:
         else:
             # Tag name - look up in manifest (stores full hash)
             if ref not in manifest.tags:
-                raise ArtifactNotFoundError(
-                    f"Tag '{ref}' not found in artifact {artifact_path}"
-                )
+                raise ArtifactNotFoundError(f"Tag '{ref}' not found in artifact {artifact_path}")
             full_hash = manifest.tags[ref]
             # Convert to short hash for metadata lookup
             hash_ref = short_hash(full_hash)
@@ -226,9 +220,7 @@ class StorageService:
             source_uri=metadata.source_uri,
         )
 
-    def create_tag(
-        self, artifact_path: str, hash_ref: str, tag_name: str
-    ) -> ArtifactInfo:
+    def create_tag(self, artifact_path: str, hash_ref: str, tag_name: str) -> ArtifactInfo:
         """Create or update a tag pointing to a specific blob.
 
         Args:
@@ -421,9 +413,5 @@ class StorageService:
             Sorted list of tag names pointing to this hash.
         """
         manifest = read_manifest(artifact_dir)
-        tags = [
-            tag_name
-            for tag_name, ref in manifest.tags.items()
-            if ref == hash_ref
-        ]
+        tags = [tag_name for tag_name, ref in manifest.tags.items() if ref == hash_ref]
         return sorted(tags)

--- a/src/magpie/storage/symlinks.py
+++ b/src/magpie/storage/symlinks.py
@@ -53,7 +53,7 @@ def remove_symlink(artifact_dir: Path, tag_name: str) -> None:
         symlink_path.unlink()
 
 
-def reconcile_symlinks(artifact_dir: Path, manifest: Manifest) -> None:
+def reconcile_symlinks(artifact_dir: Path, manifest: Manifest) -> tuple[int, int]:
     """Reconcile symlinks to match manifest tags exactly.
 
     Creates missing symlinks for tags in manifest, removes orphan symlinks
@@ -62,7 +62,15 @@ def reconcile_symlinks(artifact_dir: Path, manifest: Manifest) -> None:
     Args:
         artifact_dir: Path to artifact directory.
         manifest: Manifest containing authoritative tag mappings.
+
+    Returns:
+        Tuple of (symlinks_checked, symlinks_fixed) where:
+            - symlinks_checked: Total number of symlinks examined
+            - symlinks_fixed: Number of symlinks created, removed, or updated
     """
+    symlinks_checked = 0
+    symlinks_fixed = 0
+
     # Get set of expected tag names from manifest
     expected_tags = set(manifest.tags.keys())
 
@@ -72,17 +80,20 @@ def reconcile_symlinks(artifact_dir: Path, manifest: Manifest) -> None:
         for item in artifact_dir.iterdir():
             if item.is_symlink():
                 existing_symlinks.add(item.name)
+                symlinks_checked += 1
 
     # Create missing symlinks
     missing_tags = expected_tags - existing_symlinks
     for tag_name in missing_tags:
         hash_ref = manifest.tags[tag_name]
         create_symlink(artifact_dir, tag_name, hash_ref)
+        symlinks_fixed += 1
 
     # Remove orphan symlinks (symlinks not in manifest)
     orphan_symlinks = existing_symlinks - expected_tags
     for tag_name in orphan_symlinks:
         remove_symlink(artifact_dir, tag_name)
+        symlinks_fixed += 1
 
     # Update existing symlinks that point to wrong target
     for tag_name in expected_tags & existing_symlinks:
@@ -94,6 +105,10 @@ def reconcile_symlinks(artifact_dir: Path, manifest: Manifest) -> None:
             current_target = symlink_path.readlink()
             if current_target != expected_target:
                 create_symlink(artifact_dir, tag_name, manifest.tags[tag_name])
+                symlinks_fixed += 1
         except OSError:
             # If we can't read the symlink, recreate it
             create_symlink(artifact_dir, tag_name, manifest.tags[tag_name])
+            symlinks_fixed += 1
+
+    return symlinks_checked, symlinks_fixed

--- a/tests/e2e/test_auth_workflow.py
+++ b/tests/e2e/test_auth_workflow.py
@@ -29,7 +29,6 @@ class TestUnauthenticatedAccess:
         response = http_client.post(
             "/api/v1/upload/e2e-tests/unauth-test",
             files={"file": ("artifact", test_artifact_content, "application/octet-stream")},
-            
         )
 
         assert response.status_code == 401
@@ -69,7 +68,6 @@ class TestUnauthenticatedAccess:
         authenticated_client.post(
             "/api/v1/upload/e2e-tests/public-list-test",
             files={"file": ("artifact", test_artifact_content, "application/octet-stream")},
-            
         )
 
         # Unauthenticated GET should work
@@ -91,15 +89,12 @@ class TestReadTokenPermissions:
     ) -> None:
         """Verify read token can list artifacts."""
         # Create read token
-        read_token = create_token_via_api(
-            http_client, admin_token, "auth-test-reader", "read"
-        )
+        read_token = create_token_via_api(http_client, admin_token, "auth-test-reader", "read")
 
         # Upload something first (with admin)
         authenticated_client.post(
             "/api/v1/upload/e2e-tests/read-list-test",
             files={"file": ("artifact", test_artifact_content, "application/octet-stream")},
-            
         )
 
         # List with read token (should work - GET is public anyway)
@@ -147,7 +142,6 @@ class TestReadTokenPermissions:
         upload_response = authenticated_client.post(
             "/api/v1/upload/e2e-tests/read-tag-test",
             files={"file": ("artifact", test_artifact_content, "application/octet-stream")},
-            
         )
         artifact_hash = upload_response.json()["hash"]
 
@@ -328,7 +322,6 @@ class TestAdminTokenPermissions:
         response = authenticated_client.post(
             "/api/v1/upload/e2e-tests/admin-upload-test",
             files={"file": ("artifact", test_artifact_content, "application/octet-stream")},
-            
         )
 
         assert response.status_code == 200

--- a/tests/e2e/test_core_workflow.py
+++ b/tests/e2e/test_core_workflow.py
@@ -50,9 +50,7 @@ class TestTokenManagement:
         admin_token: str,
     ) -> None:
         """Create a read-only token via API."""
-        token = create_token_via_api(
-            http_client, admin_token, "e2e-read-test", "read"
-        )
+        token = create_token_via_api(http_client, admin_token, "e2e-read-test", "read")
         assert token
         assert token.startswith("mgp_")
 
@@ -62,9 +60,7 @@ class TestTokenManagement:
         admin_token: str,
     ) -> None:
         """Create a write token via API."""
-        token = create_token_via_api(
-            http_client, admin_token, "e2e-write-test", "write"
-        )
+        token = create_token_via_api(http_client, admin_token, "e2e-write-test", "write")
         assert token
         assert token.startswith("mgp_")
 
@@ -96,9 +92,13 @@ class TestArtifactUpload:
 
             result = subprocess.run(
                 [
-                    "uv", "run", "magpie", "push",
+                    "uv",
+                    "run",
+                    "magpie",
+                    "push",
                     temp_file,
-                    "--path", "e2e-tests/push-test",
+                    "--path",
+                    "e2e-tests/push-test",
                 ],
                 cwd=PROJECT_ROOT,
                 env=env,
@@ -124,7 +124,6 @@ class TestArtifactUpload:
         response = authenticated_client.post(
             "/api/v1/upload/e2e-tests/api-upload-test",
             files={"file": ("artifact", test_artifact_content, "application/octet-stream")},
-            
         )
 
         assert response.status_code == 200
@@ -151,7 +150,6 @@ class TestArtifactListing:
         authenticated_client.post(
             "/api/v1/upload/e2e-tests/ls-test",
             files={"file": ("artifact", test_artifact_content, "application/octet-stream")},
-            
         )
 
         # Run magpie ls command
@@ -180,7 +178,6 @@ class TestArtifactListing:
         authenticated_client.post(
             "/api/v1/upload/e2e-tests/api-ls-test",
             files={"file": ("artifact", test_artifact_content, "application/octet-stream")},
-            
         )
 
         # List artifacts
@@ -210,7 +207,6 @@ class TestArtifactDownload:
         upload_response = authenticated_client.post(
             "/api/v1/upload/e2e-tests/get-test",
             files={"file": ("artifact", test_artifact_content, "application/octet-stream")},
-            
         )
         artifact_hash = upload_response.json()["hash"]
 
@@ -224,7 +220,10 @@ class TestArtifactDownload:
 
             result = subprocess.run(
                 [
-                    "uv", "run", "magpie", "get",
+                    "uv",
+                    "run",
+                    "magpie",
+                    "get",
                     "e2e-tests/get-test",
                     str(output_file),
                 ],
@@ -265,7 +264,6 @@ class TestTagging:
         upload_response = authenticated_client.post(
             "/api/v1/upload/e2e-tests/tag-test",
             files={"file": ("artifact", test_artifact_content, "application/octet-stream")},
-            
         )
         artifact_hash = upload_response.json()["hash"]
 
@@ -276,7 +274,10 @@ class TestTagging:
         # Create tag via CLI
         result = subprocess.run(
             [
-                "uv", "run", "magpie", "tag",
+                "uv",
+                "run",
+                "magpie",
+                "tag",
                 "e2e-tests/tag-test",
                 artifact_hash,
                 "latest",
@@ -299,7 +300,6 @@ class TestTagging:
         upload_response = authenticated_client.post(
             "/api/v1/upload/e2e-tests/api-tag-test",
             files={"file": ("artifact", test_artifact_content, "application/octet-stream")},
-            
         )
         artifact_hash = upload_response.json()["hash"]
 
@@ -331,7 +331,6 @@ class TestArtifactInfo:
         upload_response = authenticated_client.post(
             "/api/v1/upload/e2e-tests/info-test",
             files={"file": ("artifact", test_artifact_content, "application/octet-stream")},
-            
         )
         artifact_hash = upload_response.json()["hash"]
 
@@ -341,7 +340,10 @@ class TestArtifactInfo:
 
         result = subprocess.run(
             [
-                "uv", "run", "magpie", "info",
+                "uv",
+                "run",
+                "magpie",
+                "info",
                 "e2e-tests/info-test",
                 artifact_hash,
             ],
@@ -365,7 +367,6 @@ class TestArtifactInfo:
         upload_response = authenticated_client.post(
             "/api/v1/upload/e2e-tests/api-info-test",
             files={"file": ("artifact", test_artifact_content, "application/octet-stream")},
-            
         )
         artifact_hash = upload_response.json()["hash"]
 

--- a/tests/e2e/test_edge_cases.py
+++ b/tests/e2e/test_edge_cases.py
@@ -195,7 +195,10 @@ class TestTagRemoval:
         # Remove tag via CLI
         result = subprocess.run(
             [
-                "uv", "run", "magpie", "untag",
+                "uv",
+                "run",
+                "magpie",
+                "untag",
                 "e2e-tests/cli-untag-test",
                 "cli-remove",
             ],

--- a/tests/integration/test_cli_amend.py
+++ b/tests/integration/test_cli_amend.py
@@ -76,9 +76,7 @@ def upload_test_artifact(
 class TestAmendCommand:
     """Integration tests for amend command."""
 
-    def test_amend_updates_source_uri(
-        self, cli_runner: CliRunner, api_client: TestClient
-    ) -> None:
+    def test_amend_updates_source_uri(self, cli_runner: CliRunner, api_client: TestClient) -> None:
         """Amend command updates source_uri."""
         # Upload artifact without source_uri
         upload_test_artifact(api_client, "test/amend", b"amend test content")
@@ -89,9 +87,12 @@ class TestAmendCommand:
             result = cli_runner.invoke(
                 cli,
                 [
-                    "--server", "http://test",
-                    "amend", "test/amend:latest",
-                    "--source-uri", "https://github.com/example/repo",
+                    "--server",
+                    "http://test",
+                    "amend",
+                    "test/amend:latest",
+                    "--source-uri",
+                    "https://github.com/example/repo",
                 ],
             )
 
@@ -103,9 +104,7 @@ class TestAmendCommand:
         self, cli_runner: CliRunner, api_client: TestClient
     ) -> None:
         """Amend command displays updated metadata including tags."""
-        upload_data = upload_test_artifact(
-            api_client, "test/amend-meta", b"metadata test"
-        )
+        upload_data = upload_test_artifact(api_client, "test/amend-meta", b"metadata test")
 
         with patch(PATCH_GET_CLIENT) as mock_get_client:
             mock_get_client.return_value = api_client
@@ -113,9 +112,12 @@ class TestAmendCommand:
             result = cli_runner.invoke(
                 cli,
                 [
-                    "--server", "http://test",
-                    "amend", "test/amend-meta:latest",
-                    "--source-uri", "https://example.com/source",
+                    "--server",
+                    "http://test",
+                    "amend",
+                    "test/amend-meta:latest",
+                    "--source-uri",
+                    "https://example.com/source",
                 ],
             )
 
@@ -135,18 +137,19 @@ class TestAmendCommand:
             result = cli_runner.invoke(
                 cli,
                 [
-                    "--server", "http://test",
-                    "amend", "nonexistent/artifact:latest",
-                    "--source-uri", "https://example.com",
+                    "--server",
+                    "http://test",
+                    "amend",
+                    "nonexistent/artifact:latest",
+                    "--source-uri",
+                    "https://example.com",
                 ],
             )
 
         assert result.exit_code != 0
         assert "not found" in result.output.lower()
 
-    def test_amend_by_tag_name_works(
-        self, cli_runner: CliRunner, api_client: TestClient
-    ) -> None:
+    def test_amend_by_tag_name_works(self, cli_runner: CliRunner, api_client: TestClient) -> None:
         """Amend by tag name resolves correctly."""
         upload_test_artifact(api_client, "test/bytag", b"tag test content")
 
@@ -162,9 +165,12 @@ class TestAmendCommand:
             result = cli_runner.invoke(
                 cli,
                 [
-                    "--server", "http://test",
-                    "amend", "test/bytag:stable",
-                    "--source-uri", "https://stable.example.com",
+                    "--server",
+                    "http://test",
+                    "amend",
+                    "test/bytag:stable",
+                    "--source-uri",
+                    "https://stable.example.com",
                 ],
             )
 
@@ -172,13 +178,9 @@ class TestAmendCommand:
         assert "Updated:" in result.output
         assert "https://stable.example.com" in result.output
 
-    def test_amend_by_hash_ref_works(
-        self, cli_runner: CliRunner, api_client: TestClient
-    ) -> None:
+    def test_amend_by_hash_ref_works(self, cli_runner: CliRunner, api_client: TestClient) -> None:
         """Amend by hash ref resolves correctly."""
-        upload_data = upload_test_artifact(
-            api_client, "test/byhash", b"hash ref test"
-        )
+        upload_data = upload_test_artifact(api_client, "test/byhash", b"hash ref test")
         hash_ref = upload_data["hash_ref"]
 
         with patch(PATCH_GET_CLIENT) as mock_get_client:
@@ -187,9 +189,12 @@ class TestAmendCommand:
             result = cli_runner.invoke(
                 cli,
                 [
-                    "--server", "http://test",
-                    "amend", f"test/byhash:{hash_ref}",
-                    "--source-uri", "https://hash.example.com",
+                    "--server",
+                    "http://test",
+                    "amend",
+                    f"test/byhash:{hash_ref}",
+                    "--source-uri",
+                    "https://hash.example.com",
                 ],
             )
 
@@ -215,9 +220,12 @@ class TestAmendCommand:
             result = cli_runner.invoke(
                 cli,
                 [
-                    "--server", "http://test",
-                    "amend", "test/update-uri:latest",
-                    "--source-uri", "https://updated.example.com",
+                    "--server",
+                    "http://test",
+                    "amend",
+                    "test/update-uri:latest",
+                    "--source-uri",
+                    "https://updated.example.com",
                 ],
             )
 

--- a/tests/integration/test_cli_gc.py
+++ b/tests/integration/test_cli_gc.py
@@ -97,6 +97,7 @@ class TestGCCommand:
         self, cli_runner: CliRunner, api_client: TestClient, admin_token: str
     ) -> None:
         """GC command calls the GC endpoint."""
+
         # Create a mock client that wraps api_client and adds auth header
         class MockClientWithAuth:
             def __init__(self, client: TestClient, token: str) -> None:
@@ -166,8 +167,11 @@ class TestGCCommand:
         assert "Would delete:" in result.output
 
     def test_gc_displays_stats(
-        self, cli_runner: CliRunner, api_client: TestClient, admin_token: str,
-        storage_service: StorageService
+        self,
+        cli_runner: CliRunner,
+        api_client: TestClient,
+        admin_token: str,
+        storage_service: StorageService,
     ) -> None:
         """GC displays statistics from server response."""
         # Upload some artifacts first

--- a/tests/integration/test_cli_push_get.py
+++ b/tests/integration/test_cli_push_get.py
@@ -103,9 +103,7 @@ class MockClientWithDownload:
             info = self.storage_service.get_artifact_info(path, hash_ref)
 
             # Read the blob using the full hash
-            artifact_dir = artifact_dir_path(
-                self.storage_service.config.storage_path, path
-            )
+            artifact_dir = artifact_dir_path(self.storage_service.config.storage_path, path)
             blob_file = read_blob(artifact_dir, info.hash)
             content = blob_file.read_bytes()
 
@@ -181,8 +179,11 @@ class TestPushCommand:
         assert "Hash ref:" in result.output
 
     def test_push_with_source_uri(
-        self, cli_runner: CliRunner, api_client: TestClient, tmp_path: Path,
-        test_storage_service: StorageService
+        self,
+        cli_runner: CliRunner,
+        api_client: TestClient,
+        tmp_path: Path,
+        test_storage_service: StorageService,
     ) -> None:
         """Push with --source-uri includes it in metadata."""
         test_file = tmp_path / "source_uri_test.bin"
@@ -195,10 +196,14 @@ class TestPushCommand:
             result = cli_runner.invoke(
                 cli,
                 [
-                    "--server", "http://test",
-                    "push", str(test_file),
-                    "--to", "source/uri-test",
-                    "--source-uri", "git://repo@v1.0"
+                    "--server",
+                    "http://test",
+                    "push",
+                    str(test_file),
+                    "--to",
+                    "source/uri-test",
+                    "--source-uri",
+                    "git://repo@v1.0",
                 ],
             )
 
@@ -256,8 +261,11 @@ class TestGetCommand:
     """Integration tests for get command."""
 
     def test_get_downloads_and_verifies_hash(
-        self, cli_runner: CliRunner, api_client: TestClient, tmp_path: Path,
-        test_storage_service: StorageService
+        self,
+        cli_runner: CliRunner,
+        api_client: TestClient,
+        tmp_path: Path,
+        test_storage_service: StorageService,
     ) -> None:
         """Get command downloads artifact and verifies hash."""
         # First upload a file
@@ -276,9 +284,12 @@ class TestGetCommand:
             result = cli_runner.invoke(
                 cli,
                 [
-                    "--server", "http://test",
-                    "get", "get/test:latest",
-                    "-o", str(output_file),
+                    "--server",
+                    "http://test",
+                    "get",
+                    "get/test:latest",
+                    "-o",
+                    str(output_file),
                 ],
             )
 
@@ -288,8 +299,11 @@ class TestGetCommand:
         assert output_file.read_bytes() == test_content
 
     def test_get_with_no_verify_skips_verification(
-        self, cli_runner: CliRunner, api_client: TestClient, tmp_path: Path,
-        test_storage_service: StorageService
+        self,
+        cli_runner: CliRunner,
+        api_client: TestClient,
+        tmp_path: Path,
+        test_storage_service: StorageService,
     ) -> None:
         """Get with --no-verify skips hash verification."""
         # Upload a file
@@ -307,9 +321,12 @@ class TestGetCommand:
             result = cli_runner.invoke(
                 cli,
                 [
-                    "--server", "http://test",
-                    "get", "noverify/test",
-                    "-o", str(output_file),
+                    "--server",
+                    "http://test",
+                    "get",
+                    "noverify/test",
+                    "-o",
+                    str(output_file),
                     "--no-verify",
                 ],
             )
@@ -360,9 +377,12 @@ class TestGetCommand:
             result = cli_runner.invoke(
                 cli,
                 [
-                    "--server", "http://test",
-                    "get", "mismatch/test",
-                    "-o", str(output_file),
+                    "--server",
+                    "http://test",
+                    "get",
+                    "mismatch/test",
+                    "-o",
+                    str(output_file),
                 ],
             )
 
@@ -370,8 +390,11 @@ class TestGetCommand:
         assert "Hash mismatch" in result.output
 
     def test_get_defaults_to_latest_ref(
-        self, cli_runner: CliRunner, api_client: TestClient, tmp_path: Path,
-        test_storage_service: StorageService
+        self,
+        cli_runner: CliRunner,
+        api_client: TestClient,
+        tmp_path: Path,
+        test_storage_service: StorageService,
     ) -> None:
         """Get without explicit ref uses 'latest'."""
         # Upload a file
@@ -390,9 +413,12 @@ class TestGetCommand:
             result = cli_runner.invoke(
                 cli,
                 [
-                    "--server", "http://test",
-                    "get", "latest/test",
-                    "-o", str(output_file),
+                    "--server",
+                    "http://test",
+                    "get",
+                    "latest/test",
+                    "-o",
+                    str(output_file),
                 ],
             )
 
@@ -411,9 +437,12 @@ class TestGetCommand:
             result = cli_runner.invoke(
                 cli,
                 [
-                    "--server", "http://test",
-                    "get", "nonexistent/artifact",
-                    "-o", str(output_file),
+                    "--server",
+                    "http://test",
+                    "get",
+                    "nonexistent/artifact",
+                    "-o",
+                    str(output_file),
                 ],
             )
 
@@ -433,8 +462,11 @@ class TestGetCommand:
         assert "No server configured" in result.output
 
     def test_get_derives_output_filename_from_path(
-        self, cli_runner: CliRunner, api_client: TestClient, tmp_path: Path,
-        test_storage_service: StorageService
+        self,
+        cli_runner: CliRunner,
+        api_client: TestClient,
+        tmp_path: Path,
+        test_storage_service: StorageService,
     ) -> None:
         """Get without -o derives output filename from artifact path."""
         # Upload a file
@@ -452,8 +484,10 @@ class TestGetCommand:
                 result = cli_runner.invoke(
                     cli,
                     [
-                        "--server", "http://test",
-                        "get", "path/myartifact",
+                        "--server",
+                        "http://test",
+                        "get",
+                        "path/myartifact",
                     ],
                 )
 

--- a/tests/integration/test_cli_query.py
+++ b/tests/integration/test_cli_query.py
@@ -116,9 +116,7 @@ class TestLsCommand:
         assert result.exit_code == 0
         assert "No versions found" in result.output or "No artifact found" in result.output
 
-    def test_ls_shows_tags(
-        self, cli_runner: CliRunner, api_client: TestClient
-    ) -> None:
+    def test_ls_shows_tags(self, cli_runner: CliRunner, api_client: TestClient) -> None:
         """Ls command shows tags for versions."""
         # Upload an artifact (will have 'latest' tag)
         upload_test_artifact(api_client, "test/tags", b"content with tags")
@@ -212,9 +210,7 @@ class TestInfoCommand:
         assert result.exit_code == 0
         assert hash_ref in result.output
 
-    def test_info_not_found(
-        self, cli_runner: CliRunner, api_client: TestClient
-    ) -> None:
+    def test_info_not_found(self, cli_runner: CliRunner, api_client: TestClient) -> None:
         """Info for non-existent artifact returns error."""
         with patch(PATCH_GET_CLIENT) as mock_get_client:
             mock_get_client.return_value = api_client
@@ -238,9 +234,7 @@ class TestInfoCommand:
 class TestUrlCommand:
     """Integration tests for url command."""
 
-    def test_url_outputs_bare_url(
-        self, cli_runner: CliRunner, api_client: TestClient
-    ) -> None:
+    def test_url_outputs_bare_url(self, cli_runner: CliRunner, api_client: TestClient) -> None:
         """Url command outputs bare URL for scripting."""
         upload_data = upload_test_artifact(api_client, "test/url", b"url test content")
         hash_ref = upload_data["hash_ref"]
@@ -260,9 +254,7 @@ class TestUrlCommand:
         assert hash_ref in output
         assert "test/url" in output
 
-    def test_url_suitable_for_curl(
-        self, cli_runner: CliRunner, api_client: TestClient
-    ) -> None:
+    def test_url_suitable_for_curl(self, cli_runner: CliRunner, api_client: TestClient) -> None:
         """Url output is suitable for curl/wget (single line, no extra text)."""
         upload_test_artifact(api_client, "test/curl", b"curl test")
 
@@ -283,9 +275,7 @@ class TestUrlCommand:
         # Should not have any extra text
         assert output.count("http") == 1
 
-    def test_url_resolves_tag_to_hash(
-        self, cli_runner: CliRunner, api_client: TestClient
-    ) -> None:
+    def test_url_resolves_tag_to_hash(self, cli_runner: CliRunner, api_client: TestClient) -> None:
         """Url resolves tag to hash ref in output."""
         upload_data = upload_test_artifact(api_client, "test/resolve", b"resolve test")
         hash_ref = upload_data["hash_ref"]
@@ -303,9 +293,7 @@ class TestUrlCommand:
         assert hash_ref in result.output
         assert ":latest" not in result.output
 
-    def test_url_not_found(
-        self, cli_runner: CliRunner, api_client: TestClient
-    ) -> None:
+    def test_url_not_found(self, cli_runner: CliRunner, api_client: TestClient) -> None:
         """Url for non-existent artifact returns error."""
         with patch(PATCH_GET_CLIENT) as mock_get_client:
             mock_get_client.return_value = api_client

--- a/tests/integration/test_cli_tags.py
+++ b/tests/integration/test_cli_tags.py
@@ -76,9 +76,7 @@ def upload_test_artifact(
 class TestTagCommand:
     """Integration tests for tag command."""
 
-    def test_tag_creates_new_tag(
-        self, cli_runner: CliRunner, api_client: TestClient
-    ) -> None:
+    def test_tag_creates_new_tag(self, cli_runner: CliRunner, api_client: TestClient) -> None:
         """Tag command creates a new tag on an artifact."""
         upload_data = upload_test_artifact(api_client, "test/tag", b"tag test content")
         hash_ref = upload_data["hash_ref"]
@@ -95,9 +93,7 @@ class TestTagCommand:
         assert "v1.0" in result.output
         assert hash_ref in result.output
 
-    def test_tag_on_latest(
-        self, cli_runner: CliRunner, api_client: TestClient
-    ) -> None:
+    def test_tag_on_latest(self, cli_runner: CliRunner, api_client: TestClient) -> None:
         """Tag command works with :latest ref."""
         upload_test_artifact(api_client, "test/latest-tag", b"latest tag test")
 
@@ -112,9 +108,7 @@ class TestTagCommand:
         assert result.exit_code == 0, f"Output: {result.output}"
         assert "stable" in result.output
 
-    def test_tag_shows_all_tags(
-        self, cli_runner: CliRunner, api_client: TestClient
-    ) -> None:
+    def test_tag_shows_all_tags(self, cli_runner: CliRunner, api_client: TestClient) -> None:
         """Tag command displays all tags after creation."""
         upload_test_artifact(api_client, "test/all-tags", b"all tags test")
 
@@ -132,9 +126,7 @@ class TestTagCommand:
         assert "latest" in result.output
         assert "v1.0" in result.output
 
-    def test_tag_not_found(
-        self, cli_runner: CliRunner, api_client: TestClient
-    ) -> None:
+    def test_tag_not_found(self, cli_runner: CliRunner, api_client: TestClient) -> None:
         """Tag on non-existent artifact returns error."""
         with patch(PATCH_GET_CLIENT) as mock_get_client:
             mock_get_client.return_value = api_client
@@ -158,9 +150,7 @@ class TestTagCommand:
 class TestUntagCommand:
     """Integration tests for untag command."""
 
-    def test_untag_removes_tag(
-        self, cli_runner: CliRunner, api_client: TestClient
-    ) -> None:
+    def test_untag_removes_tag(self, cli_runner: CliRunner, api_client: TestClient) -> None:
         """Untag command removes a tag from an artifact."""
         # Upload and create a custom tag
         upload_test_artifact(api_client, "test/untag", b"untag test content")
@@ -182,9 +172,7 @@ class TestUntagCommand:
         assert result.exit_code == 0, f"Output: {result.output}"
         assert "Removed tag 'removeme'" in result.output
 
-    def test_untag_not_found(
-        self, cli_runner: CliRunner, api_client: TestClient
-    ) -> None:
+    def test_untag_not_found(self, cli_runner: CliRunner, api_client: TestClient) -> None:
         """Untag on non-existent tag returns error."""
         upload_test_artifact(api_client, "test/untag-missing", b"untag missing test")
 
@@ -240,9 +228,7 @@ class TestFlushTagCommand:
         assert "Removed tag 'common-tag'" in result.output
         assert "2 artifact" in result.output
 
-    def test_flush_tag_dry_run(
-        self, cli_runner: CliRunner, api_client: TestClient
-    ) -> None:
+    def test_flush_tag_dry_run(self, cli_runner: CliRunner, api_client: TestClient) -> None:
         """Flush-tag dry-run shows what would be affected."""
         # Upload artifact with tag
         upload_test_artifact(api_client, "test/flush-dry", b"dry run test")
@@ -264,9 +250,7 @@ class TestFlushTagCommand:
         assert result.exit_code == 0, f"Output: {result.output}"
         assert "Would remove tag 'to-flush'" in result.output
 
-    def test_flush_tag_no_matches(
-        self, cli_runner: CliRunner, api_client: TestClient
-    ) -> None:
+    def test_flush_tag_no_matches(self, cli_runner: CliRunner, api_client: TestClient) -> None:
         """Flush-tag with no matching artifacts reports 0."""
         # Upload artifact (only has 'latest' tag)
         upload_test_artifact(api_client, "test/flush-none", b"single version")

--- a/tests/integration/test_flush_endpoint.py
+++ b/tests/integration/test_flush_endpoint.py
@@ -64,9 +64,7 @@ def create_tag(client: TestClient, artifact_path: str, ref: str, tag_name: str) 
 class TestDryRunPreview:
     """Tests for dry_run mode returning preview without modification."""
 
-    def test_dry_run_returns_preview_without_modification(
-        self, client: TestClient
-    ) -> None:
+    def test_dry_run_returns_preview_without_modification(self, client: TestClient) -> None:
         """Dry run returns affected artifacts without actually removing tags."""
         # Upload artifacts and create "release" tag on both
         upload_data1 = upload_artifact(client, "flush-test/artifact1", b"content1")
@@ -128,14 +126,10 @@ class TestConfirmedFlush:
         assert data["dry_run"] is False
 
         # Verify tags are actually removed
-        info1 = client.get(
-            f"/api/v1/artifacts/flush-confirm/art1/{upload_data1['hash_ref']}/info"
-        )
+        info1 = client.get(f"/api/v1/artifacts/flush-confirm/art1/{upload_data1['hash_ref']}/info")
         assert "to-flush" not in info1.json()["tags"]
 
-        info2 = client.get(
-            f"/api/v1/artifacts/flush-confirm/art2/{upload_data2['hash_ref']}/info"
-        )
+        info2 = client.get(f"/api/v1/artifacts/flush-confirm/art2/{upload_data2['hash_ref']}/info")
         assert "to-flush" not in info2.json()["tags"]
 
 
@@ -150,9 +144,7 @@ class TestMissingConfirmation:
         data = response.json()
         assert "confirm_walk_filesystem" in data["detail"].lower()
 
-    def test_confirm_walk_filesystem_false_returns_400(
-        self, client: TestClient
-    ) -> None:
+    def test_confirm_walk_filesystem_false_returns_400(self, client: TestClient) -> None:
         """confirm_walk_filesystem=false returns 400."""
         response = client.post(
             "/api/v1/tags/some-tag/flush",
@@ -188,9 +180,7 @@ class TestFlushUnknownTag:
 class TestResponseFormat:
     """Tests for response format and content."""
 
-    def test_response_includes_correct_count_and_artifacts(
-        self, client: TestClient
-    ) -> None:
+    def test_response_includes_correct_count_and_artifacts(self, client: TestClient) -> None:
         """Response includes correct count and affected_artifacts list."""
         # Upload 3 artifacts, only tag 2 of them with "partial"
         upload_data1 = upload_artifact(client, "flush-count/art1", b"content1")

--- a/tests/integration/test_gc_endpoint.py
+++ b/tests/integration/test_gc_endpoint.py
@@ -95,9 +95,7 @@ def _upload_artifact(
 class TestGCEndpointAuth:
     """Tests for GC endpoint authentication and authorization."""
 
-    def test_gc_requires_admin_scope(
-        self, client: TestClient, admin_token: str
-    ) -> None:
+    def test_gc_requires_admin_scope(self, client: TestClient, admin_token: str) -> None:
         """GC endpoint requires admin scope."""
         response = client.post(
             "/api/v1/gc",
@@ -106,9 +104,7 @@ class TestGCEndpointAuth:
 
         assert response.status_code == 200
 
-    def test_gc_with_read_scope_returns_403(
-        self, client: TestClient, read_token: str
-    ) -> None:
+    def test_gc_with_read_scope_returns_403(self, client: TestClient, read_token: str) -> None:
         """GC with read scope returns 403."""
         response = client.post(
             "/api/v1/gc",
@@ -118,9 +114,7 @@ class TestGCEndpointAuth:
         assert response.status_code == 403
         assert "Admin scope required" in response.json()["detail"]
 
-    def test_gc_with_write_scope_returns_403(
-        self, client: TestClient, write_token: str
-    ) -> None:
+    def test_gc_with_write_scope_returns_403(self, client: TestClient, write_token: str) -> None:
         """GC with write scope returns 403."""
         response = client.post(
             "/api/v1/gc",
@@ -139,9 +133,7 @@ class TestGCEndpointAuth:
 class TestGCEndpointFunctionality:
     """Tests for GC endpoint functionality."""
 
-    def test_gc_dry_run_returns_preview(
-        self, client: TestClient, admin_token: str
-    ) -> None:
+    def test_gc_dry_run_returns_preview(self, client: TestClient, admin_token: str) -> None:
         """GC with dry_run returns preview without modification."""
         # Upload an artifact first
         _upload_artifact(client, "gc-test/artifact", b"test content")
@@ -160,9 +152,7 @@ class TestGCEndpointFunctionality:
         assert "blobs_deleted" in data
         assert "space_reclaimed_bytes" in data
 
-    def test_gc_returns_zero_for_tagged_blobs(
-        self, client: TestClient, admin_token: str
-    ) -> None:
+    def test_gc_returns_zero_for_tagged_blobs(self, client: TestClient, admin_token: str) -> None:
         """GC returns zero deleted blobs when all blobs are tagged."""
         # Upload artifact (auto-tagged as "latest")
         _upload_artifact(client, "gc-test/tagged", b"tagged content")
@@ -177,9 +167,7 @@ class TestGCEndpointFunctionality:
         # Should not delete any blobs since they're all tagged
         assert data["blobs_deleted"] == 0
 
-    def test_gc_scans_artifacts(
-        self, client: TestClient, admin_token: str
-    ) -> None:
+    def test_gc_scans_artifacts(self, client: TestClient, admin_token: str) -> None:
         """GC scans uploaded artifacts."""
         # Upload multiple artifacts
         _upload_artifact(client, "gc-test/a1", b"content a1")
@@ -196,9 +184,7 @@ class TestGCEndpointFunctionality:
         assert data["artifacts_scanned"] >= 3
         assert data["blobs_found"] >= 3
 
-    def test_gc_response_format(
-        self, client: TestClient, admin_token: str
-    ) -> None:
+    def test_gc_response_format(self, client: TestClient, admin_token: str) -> None:
         """GC response includes all expected fields."""
         response = client.post(
             "/api/v1/gc",
@@ -217,9 +203,7 @@ class TestGCEndpointFunctionality:
         }
         assert required_fields == set(data.keys())
 
-    def test_gc_empty_storage(
-        self, client: TestClient, admin_token: str
-    ) -> None:
+    def test_gc_empty_storage(self, client: TestClient, admin_token: str) -> None:
         """GC on empty storage returns zero counts."""
         response = client.post(
             "/api/v1/gc",

--- a/tests/integration/test_info_endpoint.py
+++ b/tests/integration/test_info_endpoint.py
@@ -163,9 +163,7 @@ class TestResponseIncludesTags:
         from magpie.storage.paths import artifact_dir_path
         from magpie.storage.symlinks import reconcile_symlinks
 
-        artifact_dir = artifact_dir_path(
-            test_storage_service.config.storage_path, artifact_path
-        )
+        artifact_dir = artifact_dir_path(test_storage_service.config.storage_path, artifact_path)
         manifest = update_tag(artifact_dir, "v1.0", upload_data["hash"])
         reconcile_symlinks(artifact_dir, manifest)
 

--- a/tests/integration/test_storage_service.py
+++ b/tests/integration/test_storage_service.py
@@ -59,9 +59,7 @@ class TestStoreListGetFlow:
         assert retrieved.uploaded_by == info.uploaded_by
 
         # Get by hash_ref
-        retrieved_by_hash = storage_service.get_artifact_info(
-            artifact_path, info.hash_ref
-        )
+        retrieved_by_hash = storage_service.get_artifact_info(artifact_path, info.hash_ref)
         assert retrieved_by_hash.hash == info.hash
 
     def test_store_returns_artifact_info(self, storage_service: StorageService) -> None:
@@ -110,9 +108,7 @@ class TestDuplicateHandling:
         assert info1.hash == info2.hash
         assert info1.hash_ref == info2.hash_ref
 
-    def test_duplicate_preserves_original_metadata(
-        self, storage_service: StorageService
-    ) -> None:
+    def test_duplicate_preserves_original_metadata(self, storage_service: StorageService) -> None:
         """Duplicate upload should preserve original uploader info."""
         artifact_path = "test/preserve"
         content = b"preserve metadata content"
@@ -142,9 +138,7 @@ class TestDuplicateHandling:
 class TestArtifactIsolation:
     """Tests for artifact path isolation."""
 
-    def test_different_artifact_paths_isolated(
-        self, storage_service: StorageService
-    ) -> None:
+    def test_different_artifact_paths_isolated(self, storage_service: StorageService) -> None:
         """Different artifact paths should not interfere with each other."""
         content = b"shared content"
 
@@ -253,9 +247,7 @@ class TestListArtifacts:
         assert artifacts[0].hash == info2.hash
         assert "latest" in artifacts[0].tags
 
-    def test_list_empty_path_returns_empty(
-        self, storage_service: StorageService
-    ) -> None:
+    def test_list_empty_path_returns_empty(self, storage_service: StorageService) -> None:
         """list_artifacts should return empty list for non-existent path."""
         artifacts = storage_service.list_artifacts("nonexistent/path")
         assert artifacts == []
@@ -276,9 +268,7 @@ class TestListArtifacts:
         from magpie.storage.paths import artifact_dir_path
         from magpie.storage.symlinks import reconcile_symlinks
 
-        artifact_dir = artifact_dir_path(
-            storage_service.config.storage_path, artifact_path
-        )
+        artifact_dir = artifact_dir_path(storage_service.config.storage_path, artifact_path)
         manifest = update_tag(artifact_dir, "v1.0", info.hash)  # Use full hash
         reconcile_symlinks(artifact_dir, manifest)
 

--- a/tests/integration/test_tag_endpoints.py
+++ b/tests/integration/test_tag_endpoints.py
@@ -172,9 +172,7 @@ class TestRemoveTag:
         )
 
         # Remove the tag
-        response = client.delete(
-            f"/api/v1/artifacts/{artifact_path}/tags/to-remove"
-        )
+        response = client.delete(f"/api/v1/artifacts/{artifact_path}/tags/to-remove")
 
         assert response.status_code == 204
 
@@ -194,9 +192,7 @@ class TestRemoveTagNonexistent:
         artifact_path = "tag-test/remove-nonexistent"
         upload_artifact(client, artifact_path, b"content for nonexistent tag test")
 
-        response = client.delete(
-            f"/api/v1/artifacts/{artifact_path}/tags/nonexistent-tag"
-        )
+        response = client.delete(f"/api/v1/artifacts/{artifact_path}/tags/nonexistent-tag")
 
         assert response.status_code == 404
         data = response.json()

--- a/tests/integration/test_token_endpoints.py
+++ b/tests/integration/test_token_endpoints.py
@@ -61,9 +61,7 @@ def client(token_service: TokenService) -> TestClient:
 class TestCreateTokenEndpoint:
     """Tests for POST /api/v1/tokens endpoint."""
 
-    def test_create_token_returns_plaintext(
-        self, client: TestClient, admin_token: str
-    ) -> None:
+    def test_create_token_returns_plaintext(self, client: TestClient, admin_token: str) -> None:
         """Create token returns plaintext token (only time visible)."""
         response = client.post(
             "/api/v1/tokens",
@@ -79,9 +77,7 @@ class TestCreateTokenEndpoint:
         assert "token" in data
         assert data["token"].startswith("mgp_")
 
-    def test_create_token_requires_admin_scope(
-        self, client: TestClient, admin_token: str
-    ) -> None:
+    def test_create_token_requires_admin_scope(self, client: TestClient, admin_token: str) -> None:
         """Create token requires admin scope."""
         response = client.post(
             "/api/v1/tokens",
@@ -116,9 +112,7 @@ class TestCreateTokenEndpoint:
 
         assert response.status_code == 403
 
-    def test_create_token_without_auth_returns_401(
-        self, client: TestClient
-    ) -> None:
+    def test_create_token_without_auth_returns_401(self, client: TestClient) -> None:
         """Create token without authorization returns 401."""
         response = client.post(
             "/api/v1/tokens",
@@ -237,9 +231,7 @@ class TestListTokensEndpoint:
             assert "enabled" in token
             assert "created_at" in token
 
-    def test_list_tokens_requires_admin_scope(
-        self, client: TestClient, read_token: str
-    ) -> None:
+    def test_list_tokens_requires_admin_scope(self, client: TestClient, read_token: str) -> None:
         """List tokens requires admin scope."""
         response = client.get(
             "/api/v1/tokens",
@@ -248,9 +240,7 @@ class TestListTokensEndpoint:
 
         assert response.status_code == 403
 
-    def test_list_tokens_without_auth_returns_401(
-        self, client: TestClient
-    ) -> None:
+    def test_list_tokens_without_auth_returns_401(self, client: TestClient) -> None:
         """List tokens without authorization returns 401."""
         response = client.get("/api/v1/tokens")
 

--- a/tests/unit/test_amend_metadata.py
+++ b/tests/unit/test_amend_metadata.py
@@ -55,9 +55,7 @@ class TestAmendMetadataBasic:
         )
 
         # Amend metadata with new source_uri
-        result = storage_service.amend_metadata(
-            artifact_path, hash_ref, source_uri="new-uri"
-        )
+        result = storage_service.amend_metadata(artifact_path, hash_ref, source_uri="new-uri")
 
         assert result.source_uri == "new-uri"
 
@@ -66,18 +64,12 @@ class TestAmendMetadataBasic:
         metadata = read_metadata(artifact_dir, full_hash)
         assert metadata.source_uri == "new-uri"
 
-    def test_amend_metadata_preserves_hash(
-        self, storage_service: StorageService
-    ) -> None:
+    def test_amend_metadata_preserves_hash(self, storage_service: StorageService) -> None:
         """amend_metadata should preserve hash field."""
         artifact_path = "test/preserve-hash"
-        full_hash, hash_ref = store_test_artifact(
-            storage_service, artifact_path, b"content"
-        )
+        full_hash, hash_ref = store_test_artifact(storage_service, artifact_path, b"content")
 
-        result = storage_service.amend_metadata(
-            artifact_path, hash_ref, source_uri="new-uri"
-        )
+        result = storage_service.amend_metadata(artifact_path, hash_ref, source_uri="new-uri")
 
         assert result.hash == full_hash
 
@@ -86,13 +78,9 @@ class TestAmendMetadataBasic:
     ) -> None:
         """amend_metadata should preserve uploaded_by field."""
         artifact_path = "test/preserve-uploader"
-        full_hash, hash_ref = store_test_artifact(
-            storage_service, artifact_path, b"content"
-        )
+        full_hash, hash_ref = store_test_artifact(storage_service, artifact_path, b"content")
 
-        result = storage_service.amend_metadata(
-            artifact_path, hash_ref, source_uri="new-uri"
-        )
+        result = storage_service.amend_metadata(artifact_path, hash_ref, source_uri="new-uri")
 
         assert result.uploaded_by == "test-user"
 
@@ -106,9 +94,7 @@ class TestAmendMetadataBasic:
     ) -> None:
         """amend_metadata should preserve uploaded_at field."""
         artifact_path = "test/preserve-timestamp"
-        full_hash, hash_ref = store_test_artifact(
-            storage_service, artifact_path, b"content"
-        )
+        full_hash, hash_ref = store_test_artifact(storage_service, artifact_path, b"content")
 
         # Get original timestamp
         artifact_dir = artifact_dir_path(test_config.storage_path, artifact_path)
@@ -116,9 +102,7 @@ class TestAmendMetadataBasic:
         original_timestamp = original_metadata.uploaded_at
 
         # Amend metadata
-        result = storage_service.amend_metadata(
-            artifact_path, hash_ref, source_uri="new-uri"
-        )
+        result = storage_service.amend_metadata(artifact_path, hash_ref, source_uri="new-uri")
 
         assert result.uploaded_at == original_timestamp
 
@@ -145,9 +129,7 @@ class TestAmendMetadataBasic:
         metadata = read_metadata(artifact_dir, full_hash)
         assert metadata.source_uri == "original-uri"
 
-    def test_amend_metadata_raises_for_missing_ref(
-        self, storage_service: StorageService
-    ) -> None:
+    def test_amend_metadata_raises_for_missing_ref(self, storage_service: StorageService) -> None:
         """amend_metadata should raise ArtifactNotFoundError for missing ref."""
         artifact_path = "test/missing"
         # Store an artifact so the directory exists
@@ -156,14 +138,10 @@ class TestAmendMetadataBasic:
         with pytest.raises(ArtifactNotFoundError):
             storage_service.amend_metadata(artifact_path, "@deadbeef", source_uri="uri")
 
-    def test_amend_metadata_raises_for_missing_path(
-        self, storage_service: StorageService
-    ) -> None:
+    def test_amend_metadata_raises_for_missing_path(self, storage_service: StorageService) -> None:
         """amend_metadata should raise for non-existent artifact path."""
         with pytest.raises(ArtifactNotFoundError):
-            storage_service.amend_metadata(
-                "nonexistent/path", "@abc123", source_uri="uri"
-            )
+            storage_service.amend_metadata("nonexistent/path", "@abc123", source_uri="uri")
 
 
 class TestAmendMetadataMultiple:
@@ -179,21 +157,15 @@ class TestAmendMetadataMultiple:
         )
 
         # First amend
-        result1 = storage_service.amend_metadata(
-            artifact_path, hash_ref, source_uri="uri-2"
-        )
+        result1 = storage_service.amend_metadata(artifact_path, hash_ref, source_uri="uri-2")
         assert result1.source_uri == "uri-2"
 
         # Second amend
-        result2 = storage_service.amend_metadata(
-            artifact_path, hash_ref, source_uri="uri-3"
-        )
+        result2 = storage_service.amend_metadata(artifact_path, hash_ref, source_uri="uri-3")
         assert result2.source_uri == "uri-3"
 
         # Third amend
-        result3 = storage_service.amend_metadata(
-            artifact_path, hash_ref, source_uri="uri-4"
-        )
+        result3 = storage_service.amend_metadata(artifact_path, hash_ref, source_uri="uri-4")
         assert result3.source_uri == "uri-4"
 
         # Verify final state
@@ -205,9 +177,7 @@ class TestAmendMetadataMultiple:
         assert metadata.hash == full_hash
         assert metadata.uploaded_by == "test-user"
 
-    def test_amend_can_set_and_change_source_uri(
-        self, storage_service: StorageService
-    ) -> None:
+    def test_amend_can_set_and_change_source_uri(self, storage_service: StorageService) -> None:
         """amend_metadata can set source_uri when originally None, then change it."""
         artifact_path = "test/set-then-change"
         _, hash_ref = store_test_artifact(
@@ -219,33 +189,25 @@ class TestAmendMetadataMultiple:
         assert info.source_uri is None
 
         # Set source_uri
-        result1 = storage_service.amend_metadata(
-            artifact_path, hash_ref, source_uri="first-uri"
-        )
+        result1 = storage_service.amend_metadata(artifact_path, hash_ref, source_uri="first-uri")
         assert result1.source_uri == "first-uri"
 
         # Change source_uri
-        result2 = storage_service.amend_metadata(
-            artifact_path, hash_ref, source_uri="second-uri"
-        )
+        result2 = storage_service.amend_metadata(artifact_path, hash_ref, source_uri="second-uri")
         assert result2.source_uri == "second-uri"
 
 
 class TestAmendMetadataArtifactInfo:
     """Tests for ArtifactInfo returned by amend_metadata."""
 
-    def test_amend_returns_complete_artifact_info(
-        self, storage_service: StorageService
-    ) -> None:
+    def test_amend_returns_complete_artifact_info(self, storage_service: StorageService) -> None:
         """amend_metadata should return complete ArtifactInfo."""
         artifact_path = "test/complete-info"
         full_hash, hash_ref = store_test_artifact(
             storage_service, artifact_path, b"content", source_uri="original"
         )
 
-        result = storage_service.amend_metadata(
-            artifact_path, hash_ref, source_uri="updated"
-        )
+        result = storage_service.amend_metadata(artifact_path, hash_ref, source_uri="updated")
 
         assert result.hash == full_hash
         assert result.hash_ref == hash_ref
@@ -254,9 +216,7 @@ class TestAmendMetadataArtifactInfo:
         assert result.source_uri == "updated"
         assert "latest" in result.tags
 
-    def test_amend_preserves_tags_in_result(
-        self, storage_service: StorageService
-    ) -> None:
+    def test_amend_preserves_tags_in_result(self, storage_service: StorageService) -> None:
         """amend_metadata should include all tags in returned ArtifactInfo."""
         artifact_path = "test/with-tags"
         _, hash_ref = store_test_artifact(storage_service, artifact_path, b"content")
@@ -265,9 +225,7 @@ class TestAmendMetadataArtifactInfo:
         storage_service.create_tag(artifact_path, hash_ref, "stable")
         storage_service.create_tag(artifact_path, hash_ref, "v1.0")
 
-        result = storage_service.amend_metadata(
-            artifact_path, hash_ref, source_uri="uri"
-        )
+        result = storage_service.amend_metadata(artifact_path, hash_ref, source_uri="uri")
 
         assert "latest" in result.tags
         assert "stable" in result.tags

--- a/tests/unit/test_auth_validation.py
+++ b/tests/unit/test_auth_validation.py
@@ -45,9 +45,7 @@ def client(token_service: TokenService) -> TestClient:
 class TestValidTokenReturns200:
     """Tests for valid token returning 200 with correct headers."""
 
-    def test_valid_token_returns_200(
-        self, client: TestClient, token_service: TokenService
-    ) -> None:
+    def test_valid_token_returns_200(self, client: TestClient, token_service: TokenService) -> None:
         """Valid token should return 200 OK."""
         plaintext = token_service.create_token("test-user", TokenScope.WRITE)
 
@@ -120,9 +118,7 @@ class TestMissingAuthorizationHeader:
 
         assert response.status_code == 401
 
-    def test_missing_authorization_returns_json_error(
-        self, client: TestClient
-    ) -> None:
+    def test_missing_authorization_returns_json_error(self, client: TestClient) -> None:
         """Missing Authorization header should return JSON error with message."""
         response = client.get("/api/v1/auth/validate")
 
@@ -213,9 +209,7 @@ class TestDisabledTokenReturns401:
 class TestResponseHeadersCorrectValues:
     """Tests for response headers containing correct user and scope values."""
 
-    def test_read_scope_in_header(
-        self, client: TestClient, token_service: TokenService
-    ) -> None:
+    def test_read_scope_in_header(self, client: TestClient, token_service: TokenService) -> None:
         """READ scope token should return 'read' in X-Magpie-Scope header."""
         plaintext = token_service.create_token("read-svc", TokenScope.READ)
 
@@ -227,9 +221,7 @@ class TestResponseHeadersCorrectValues:
         assert response.status_code == 200
         assert response.headers["X-Magpie-Scope"] == "read"
 
-    def test_write_scope_in_header(
-        self, client: TestClient, token_service: TokenService
-    ) -> None:
+    def test_write_scope_in_header(self, client: TestClient, token_service: TokenService) -> None:
         """WRITE scope token should return 'write' in X-Magpie-Scope header."""
         plaintext = token_service.create_token("write-svc", TokenScope.WRITE)
 
@@ -241,9 +233,7 @@ class TestResponseHeadersCorrectValues:
         assert response.status_code == 200
         assert response.headers["X-Magpie-Scope"] == "write"
 
-    def test_admin_scope_in_header(
-        self, client: TestClient, token_service: TokenService
-    ) -> None:
+    def test_admin_scope_in_header(self, client: TestClient, token_service: TokenService) -> None:
         """ADMIN scope token should return 'admin' in X-Magpie-Scope header."""
         plaintext = token_service.create_token("admin-svc", TokenScope.ADMIN)
 
@@ -270,9 +260,7 @@ class TestResponseHeadersCorrectValues:
         assert response.status_code == 200
         assert response.headers["X-Magpie-User"] == token_name
 
-    def test_both_headers_present(
-        self, client: TestClient, token_service: TokenService
-    ) -> None:
+    def test_both_headers_present(self, client: TestClient, token_service: TokenService) -> None:
         """Both X-Magpie-User and X-Magpie-Scope headers should be present."""
         plaintext = token_service.create_token("dual-header", TokenScope.WRITE)
 

--- a/tests/unit/test_blob.py
+++ b/tests/unit/test_blob.py
@@ -55,9 +55,7 @@ class TestGetTempPath:
 class TestStoreBlob:
     """Tests for store_blob function."""
 
-    def test_store_blob_creates_file(
-        self, artifact_dir: Path, test_config: MagpieSettings
-    ) -> None:
+    def test_store_blob_creates_file(self, artifact_dir: Path, test_config: MagpieSettings) -> None:
         """store_blob should create blob file at correct path."""
         content = b"test blob content"
         stream = io.BytesIO(content)
@@ -175,9 +173,7 @@ class TestStoreBlob:
 class TestReadBlob:
     """Tests for read_blob function."""
 
-    def test_read_blob_returns_path(
-        self, artifact_dir: Path, test_config: MagpieSettings
-    ) -> None:
+    def test_read_blob_returns_path(self, artifact_dir: Path, test_config: MagpieSettings) -> None:
         """read_blob should return path for existing blob."""
         content = b"readable content"
         stream = io.BytesIO(content)
@@ -242,9 +238,7 @@ class TestCheckBlobExists:
         result = check_blob_exists(artifact_dir, "nonexistent123")
         assert result is False
 
-    def test_check_with_at_prefix(
-        self, artifact_dir: Path, test_config: MagpieSettings
-    ) -> None:
+    def test_check_with_at_prefix(self, artifact_dir: Path, test_config: MagpieSettings) -> None:
         """check_blob_exists should handle @ prefix."""
         content = b"prefix check content"
         stream = io.BytesIO(content)

--- a/tests/unit/test_cli_config.py
+++ b/tests/unit/test_cli_config.py
@@ -91,9 +91,7 @@ class TestGetServer:
         config_file.write_text('[client]\nserver = "https://config.example.com"')
         monkeypatch.setenv("MAGPIE_SERVER", "https://env.example.com")
 
-        result = get_server(
-            cli_override="https://cli.example.com", config_path=config_file
-        )
+        result = get_server(cli_override="https://cli.example.com", config_path=config_file)
 
         assert result == "https://cli.example.com"
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -101,9 +101,7 @@ class TestMagpieSettingsEnvironmentOverride:
         settings = MagpieSettings()
         assert settings.database_path == Path("/env/db.sqlite")
 
-    def test_derived_paths_use_overridden_storage(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_derived_paths_use_overridden_storage(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Derived paths should use env-overridden storage_path."""
         monkeypatch.setenv("MAGPIE_STORAGE_PATH", "/env/storage")
         settings = MagpieSettings()

--- a/tests/unit/test_ctl_init_gc.py
+++ b/tests/unit/test_ctl_init_gc.py
@@ -373,3 +373,74 @@ class TestGCCommand:
         assert result.exit_code == 0, f"Output: {result.output}"
         assert "Artifacts scanned: 2" in result.output
         assert "Deleted: 2 blob(s)" in result.output
+
+    def test_gc_json_output(
+        self, cli_runner: CliRunner, test_settings: MagpieSettings
+    ) -> None:
+        """GC with --json outputs machine-readable statistics."""
+        test_settings.storage_path.mkdir(parents=True, exist_ok=True)
+        create_artifact_with_blobs(
+            test_settings.storage_path,
+            "test/artifact",
+            tagged_hashes={"latest": "tagged_hash_abc"},
+            untagged_hashes=["old_untagged_xyz"],
+            blob_ages_days={"tagged_hash_abc": 0, "old_untagged_xyz": 100},
+        )
+
+        with patch("magpie.ctl.get_settings", return_value=test_settings):
+            result = cli_runner.invoke(cli, ["gc", "--json"])
+
+        assert result.exit_code == 0, f"Output: {result.output}"
+
+        # Parse JSON output
+        output = json.loads(result.output)
+        assert output["artifacts_scanned"] == 1
+        assert output["blobs_deleted"] == 1
+        assert output["bytes_reclaimed"] > 0
+        assert output["symlinks_checked"] >= 0
+        assert output["symlinks_fixed"] >= 0
+        assert output["dry_run"] is False
+
+    def test_gc_json_dry_run(
+        self, cli_runner: CliRunner, test_settings: MagpieSettings
+    ) -> None:
+        """GC with --json --dry-run shows dry_run: true."""
+        test_settings.storage_path.mkdir(parents=True, exist_ok=True)
+        create_artifact_with_blobs(
+            test_settings.storage_path,
+            "test/artifact",
+            tagged_hashes={"latest": "tagged_hash_abc"},
+            untagged_hashes=["old_untagged_xyz"],
+            blob_ages_days={"tagged_hash_abc": 0, "old_untagged_xyz": 100},
+        )
+
+        with patch("magpie.ctl.get_settings", return_value=test_settings):
+            result = cli_runner.invoke(cli, ["gc", "--json", "--dry-run"])
+
+        assert result.exit_code == 0, f"Output: {result.output}"
+
+        # Parse JSON output
+        output = json.loads(result.output)
+        assert output["dry_run"] is True
+        assert output["blobs_deleted"] == 1  # Would delete count
+
+    def test_gc_quiet_flag(
+        self, cli_runner: CliRunner, test_settings: MagpieSettings
+    ) -> None:
+        """GC with --quiet suppresses progress output."""
+        test_settings.storage_path.mkdir(parents=True, exist_ok=True)
+        create_artifact_with_blobs(
+            test_settings.storage_path,
+            "test/artifact",
+            tagged_hashes={"latest": "tagged_hash_abc"},
+            untagged_hashes=["old_untagged_xyz"],
+            blob_ages_days={"tagged_hash_abc": 0, "old_untagged_xyz": 100},
+        )
+
+        with patch("magpie.ctl.get_settings", return_value=test_settings):
+            result = cli_runner.invoke(cli, ["gc", "--quiet"])
+
+        assert result.exit_code == 0, f"Output: {result.output}"
+        # Still shows summary but no progress bar
+        assert "GC Summary:" in result.output
+        assert "Artifacts scanned:" in result.output

--- a/tests/unit/test_ctl_init_gc.py
+++ b/tests/unit/test_ctl_init_gc.py
@@ -374,9 +374,7 @@ class TestGCCommand:
         assert "Artifacts scanned: 2" in result.output
         assert "Deleted: 2 blob(s)" in result.output
 
-    def test_gc_json_output(
-        self, cli_runner: CliRunner, test_settings: MagpieSettings
-    ) -> None:
+    def test_gc_json_output(self, cli_runner: CliRunner, test_settings: MagpieSettings) -> None:
         """GC with --json outputs machine-readable statistics."""
         test_settings.storage_path.mkdir(parents=True, exist_ok=True)
         create_artifact_with_blobs(
@@ -401,9 +399,7 @@ class TestGCCommand:
         assert output["symlinks_fixed"] >= 0
         assert output["dry_run"] is False
 
-    def test_gc_json_dry_run(
-        self, cli_runner: CliRunner, test_settings: MagpieSettings
-    ) -> None:
+    def test_gc_json_dry_run(self, cli_runner: CliRunner, test_settings: MagpieSettings) -> None:
         """GC with --json --dry-run shows dry_run: true."""
         test_settings.storage_path.mkdir(parents=True, exist_ok=True)
         create_artifact_with_blobs(
@@ -424,9 +420,7 @@ class TestGCCommand:
         assert output["dry_run"] is True
         assert output["blobs_deleted"] == 1  # Would delete count
 
-    def test_gc_quiet_flag(
-        self, cli_runner: CliRunner, test_settings: MagpieSettings
-    ) -> None:
+    def test_gc_quiet_flag(self, cli_runner: CliRunner, test_settings: MagpieSettings) -> None:
         """GC with --quiet suppresses progress output."""
         test_settings.storage_path.mkdir(parents=True, exist_ok=True)
         create_artifact_with_blobs(

--- a/tests/unit/test_ctl_token.py
+++ b/tests/unit/test_ctl_token.py
@@ -129,12 +129,8 @@ class TestTokenList:
         """Token list displays all tokens."""
         with patch("magpie.ctl.get_settings", return_value=test_settings):
             # Create some tokens first
-            cli_runner.invoke(
-                cli, ["token", "create", "--name", "reader", "--scope", "read"]
-            )
-            cli_runner.invoke(
-                cli, ["token", "create", "--name", "writer", "--scope", "write"]
-            )
+            cli_runner.invoke(cli, ["token", "create", "--name", "reader", "--scope", "read"])
+            cli_runner.invoke(cli, ["token", "create", "--name", "writer", "--scope", "write"])
 
             # List tokens
             result = cli_runner.invoke(cli, ["token", "list"])
@@ -150,9 +146,7 @@ class TestTokenList:
     ) -> None:
         """Token list shows enabled status."""
         with patch("magpie.ctl.get_settings", return_value=test_settings):
-            cli_runner.invoke(
-                cli, ["token", "create", "--name", "active-token", "--scope", "read"]
-            )
+            cli_runner.invoke(cli, ["token", "create", "--name", "active-token", "--scope", "read"])
 
             result = cli_runner.invoke(cli, ["token", "list"])
 
@@ -184,6 +178,7 @@ class TestTokenList:
             assert token_line not in result.output
         # No 64-character hex strings (SHA-256 hashes)
         import re
+
         hash_pattern = re.compile(r"[a-f0-9]{64}", re.IGNORECASE)
         assert not hash_pattern.search(result.output)
 
@@ -207,9 +202,7 @@ class TestTokenList:
     ) -> None:
         """Token list shows proper table headers."""
         with patch("magpie.ctl.get_settings", return_value=test_settings):
-            cli_runner.invoke(
-                cli, ["token", "create", "--name", "test", "--scope", "read"]
-            )
+            cli_runner.invoke(cli, ["token", "create", "--name", "test", "--scope", "read"])
             result = cli_runner.invoke(cli, ["token", "list"])
 
         assert result.exit_code == 0
@@ -228,9 +221,7 @@ class TestTokenRevoke:
         """Token revoke removes the token."""
         with patch("magpie.ctl.get_settings", return_value=test_settings):
             # Create a token
-            cli_runner.invoke(
-                cli, ["token", "create", "--name", "to-revoke", "--scope", "read"]
-            )
+            cli_runner.invoke(cli, ["token", "create", "--name", "to-revoke", "--scope", "read"])
 
             # Verify it exists
             list_result1 = cli_runner.invoke(cli, ["token", "list"])
@@ -270,9 +261,7 @@ class TestTokenRevoke:
     ) -> None:
         """Token revoke shows success message with token name."""
         with patch("magpie.ctl.get_settings", return_value=test_settings):
-            cli_runner.invoke(
-                cli, ["token", "create", "--name", "my-token", "--scope", "write"]
-            )
+            cli_runner.invoke(cli, ["token", "create", "--name", "my-token", "--scope", "write"])
 
             result = cli_runner.invoke(cli, ["token", "revoke", "my-token"])
 

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -30,9 +30,7 @@ class TestErrorResponseModel:
 
     def test_serialization_with_detail(self) -> None:
         """ErrorResponse serializes with optional detail field."""
-        response = ErrorResponse(
-            error="TestError", message="Test message", detail={"key": "value"}
-        )
+        response = ErrorResponse(error="TestError", message="Test message", detail={"key": "value"})
         data = response.model_dump()
         assert data["detail"] == {"key": "value"}
 

--- a/tests/unit/test_flush_tag.py
+++ b/tests/unit/test_flush_tag.py
@@ -47,9 +47,7 @@ class TestFlushTagBasic:
         # Create multiple artifacts with the same tag
         paths = ["project/artifact1", "project/artifact2", "other/artifact3"]
         for path in paths:
-            _, hash_ref = store_test_artifact(
-                storage_service, path, f"content for {path}".encode()
-            )
+            _, hash_ref = store_test_artifact(storage_service, path, f"content for {path}".encode())
             storage_service.create_tag(path, hash_ref, "release")
 
         # Verify tags exist
@@ -93,20 +91,14 @@ class TestFlushTagBasic:
     ) -> None:
         """flush_tag should only affect artifacts that have the tag."""
         # Create artifacts - some with target tag, some without
-        _, ref1 = store_test_artifact(
-            storage_service, "with-tag/artifact1", b"content1"
-        )
+        _, ref1 = store_test_artifact(storage_service, "with-tag/artifact1", b"content1")
         storage_service.create_tag("with-tag/artifact1", ref1, "target-tag")
 
-        _, ref2 = store_test_artifact(
-            storage_service, "with-tag/artifact2", b"content2"
-        )
+        _, ref2 = store_test_artifact(storage_service, "with-tag/artifact2", b"content2")
         storage_service.create_tag("with-tag/artifact2", ref2, "target-tag")
 
         # This artifact does NOT have the target tag
-        store_test_artifact(
-            storage_service, "without-tag/artifact", b"content3"
-        )
+        store_test_artifact(storage_service, "without-tag/artifact", b"content3")
 
         # Flush the tag
         result = storage_service.flush_tag("target-tag")
@@ -118,9 +110,7 @@ class TestFlushTagBasic:
         assert "without-tag/artifact" not in result.affected_artifacts
 
         # Verify "latest" tag still exists on artifact without target tag
-        artifact_dir = artifact_dir_path(
-            test_config.storage_path, "without-tag/artifact"
-        )
+        artifact_dir = artifact_dir_path(test_config.storage_path, "without-tag/artifact")
         manifest = read_manifest(artifact_dir)
         assert "latest" in manifest.tags
 
@@ -151,9 +141,7 @@ class TestFlushTagDryRun:
         # Create artifacts with a tag
         paths = ["project/a", "project/b"]
         for path in paths:
-            _, ref = store_test_artifact(
-                storage_service, path, f"content for {path}".encode()
-            )
+            _, ref = store_test_artifact(storage_service, path, f"content for {path}".encode())
             storage_service.create_tag(path, ref, "to-flush")
 
         # Dry run
@@ -174,9 +162,7 @@ class TestFlushTagDryRun:
     ) -> None:
         """dry_run should preview, then actual flush should remove tags."""
         # Create artifact with tag
-        _, ref = store_test_artifact(
-            storage_service, "test/artifact", b"content"
-        )
+        _, ref = store_test_artifact(storage_service, "test/artifact", b"content")
         storage_service.create_tag("test/artifact", ref, "preview-tag")
 
         # Dry run first
@@ -201,9 +187,7 @@ class TestFlushTagDryRun:
     ) -> None:
         """flush_tag with dry_run=True should not remove symlinks."""
         # Create artifact with tag
-        _, ref = store_test_artifact(
-            storage_service, "symlink/test", b"content"
-        )
+        _, ref = store_test_artifact(storage_service, "symlink/test", b"content")
         storage_service.create_tag("symlink/test", ref, "keep-symlink")
 
         artifact_dir = artifact_dir_path(test_config.storage_path, "symlink/test")
@@ -220,18 +204,14 @@ class TestFlushTagDryRun:
 class TestFlushTagEdgeCases:
     """Edge case tests for flush_tag."""
 
-    def test_flush_tag_empty_storage(
-        self, storage_service: StorageService
-    ) -> None:
+    def test_flush_tag_empty_storage(self, storage_service: StorageService) -> None:
         """flush_tag on empty storage should return empty result."""
         result = storage_service.flush_tag("any-tag")
 
         assert result.count == 0
         assert result.affected_artifacts == []
 
-    def test_flush_tag_nested_artifact_paths(
-        self, storage_service: StorageService
-    ) -> None:
+    def test_flush_tag_nested_artifact_paths(self, storage_service: StorageService) -> None:
         """flush_tag should work with deeply nested artifact paths."""
         nested_paths = [
             "a/b/c/artifact",
@@ -240,9 +220,7 @@ class TestFlushTagEdgeCases:
         ]
 
         for path in nested_paths:
-            _, ref = store_test_artifact(
-                storage_service, path, f"content for {path}".encode()
-            )
+            _, ref = store_test_artifact(storage_service, path, f"content for {path}".encode())
             storage_service.create_tag(path, ref, "deep-tag")
 
         result = storage_service.flush_tag("deep-tag")
@@ -256,9 +234,7 @@ class TestFlushTagEdgeCases:
     ) -> None:
         """flush_tag should not affect other tags on the same artifacts."""
         # Create artifact with multiple tags
-        _, ref = store_test_artifact(
-            storage_service, "multi-tag/artifact", b"content"
-        )
+        _, ref = store_test_artifact(storage_service, "multi-tag/artifact", b"content")
         storage_service.create_tag("multi-tag/artifact", ref, "flush-me")
         storage_service.create_tag("multi-tag/artifact", ref, "keep-me")
         storage_service.create_tag("multi-tag/artifact", ref, "also-keep")
@@ -267,22 +243,16 @@ class TestFlushTagEdgeCases:
         storage_service.flush_tag("flush-me")
 
         # Other tags should remain
-        artifact_dir = artifact_dir_path(
-            test_config.storage_path, "multi-tag/artifact"
-        )
+        artifact_dir = artifact_dir_path(test_config.storage_path, "multi-tag/artifact")
         manifest = read_manifest(artifact_dir)
         assert "flush-me" not in manifest.tags
         assert "keep-me" in manifest.tags
         assert "also-keep" in manifest.tags
         assert "latest" in manifest.tags
 
-    def test_flush_result_dataclass_fields(
-        self, storage_service: StorageService
-    ) -> None:
+    def test_flush_result_dataclass_fields(self, storage_service: StorageService) -> None:
         """FlushResult should have correct field values."""
-        _, ref = store_test_artifact(
-            storage_service, "result/test", b"content"
-        )
+        _, ref = store_test_artifact(storage_service, "result/test", b"content")
         storage_service.create_tag("result/test", ref, "check-result")
 
         result = storage_service.flush_tag("check-result")

--- a/tests/unit/test_observability.py
+++ b/tests/unit/test_observability.py
@@ -44,9 +44,7 @@ class TestSentrySetup:
             setup_sentry(test_app, settings)
             mock_init.assert_called_once()
 
-    def test_sentry_uses_production_environment_when_not_debug(
-        self, test_app: FastAPI
-    ) -> None:
+    def test_sentry_uses_production_environment_when_not_debug(self, test_app: FastAPI) -> None:
         """Sentry should use 'production' environment when debug is False."""
         settings = MagpieSettings(sentry_dsn="https://test@sentry.io/123", debug=False)
 
@@ -55,9 +53,7 @@ class TestSentrySetup:
             call_kwargs = mock_init.call_args.kwargs
             assert call_kwargs["environment"] == "production"
 
-    def test_sentry_uses_development_environment_when_debug(
-        self, test_app: FastAPI
-    ) -> None:
+    def test_sentry_uses_development_environment_when_debug(self, test_app: FastAPI) -> None:
         """Sentry should use 'development' environment when debug is True."""
         settings = MagpieSettings(sentry_dsn="https://test@sentry.io/123", debug=True)
 
@@ -99,20 +95,14 @@ class TestOpenTelemetrySetup:
         with (
             patch("opentelemetry.trace.set_tracer_provider"),
             patch("opentelemetry.sdk.resources.Resource.create") as mock_resource,
-            patch(
-                "opentelemetry.instrumentation.fastapi.FastAPIInstrumentor.instrument_app"
-            ),
+            patch("opentelemetry.instrumentation.fastapi.FastAPIInstrumentor.instrument_app"),
         ):
             setup_opentelemetry(test_app, settings)
             mock_resource.assert_called_once_with({"service.name": "custom-service"})
 
-    def test_otel_configures_otlp_exporter_when_endpoint_set(
-        self, test_app: FastAPI
-    ) -> None:
+    def test_otel_configures_otlp_exporter_when_endpoint_set(self, test_app: FastAPI) -> None:
         """OTLP exporter should be configured when otel_endpoint is set."""
-        settings = MagpieSettings(
-            otel_enabled=True, otel_endpoint="http://localhost:4317"
-        )
+        settings = MagpieSettings(otel_enabled=True, otel_endpoint="http://localhost:4317")
 
         with (
             patch("opentelemetry.trace.set_tracer_provider"),
@@ -120,9 +110,7 @@ class TestOpenTelemetrySetup:
                 "opentelemetry.exporter.otlp.proto.grpc.trace_exporter.OTLPSpanExporter"
             ) as mock_exporter,
             patch("opentelemetry.sdk.trace.export.BatchSpanProcessor"),
-            patch(
-                "opentelemetry.instrumentation.fastapi.FastAPIInstrumentor.instrument_app"
-            ),
+            patch("opentelemetry.instrumentation.fastapi.FastAPIInstrumentor.instrument_app"),
         ):
             setup_opentelemetry(test_app, settings)
             mock_exporter.assert_called_once_with(endpoint="http://localhost:4317")
@@ -136,9 +124,7 @@ class TestOpenTelemetrySetup:
             patch(
                 "opentelemetry.exporter.otlp.proto.grpc.trace_exporter.OTLPSpanExporter"
             ) as mock_exporter,
-            patch(
-                "opentelemetry.instrumentation.fastapi.FastAPIInstrumentor.instrument_app"
-            ),
+            patch("opentelemetry.instrumentation.fastapi.FastAPIInstrumentor.instrument_app"),
         ):
             setup_opentelemetry(test_app, settings)
             mock_exporter.assert_not_called()
@@ -147,9 +133,7 @@ class TestOpenTelemetrySetup:
 class TestConfigToggles:
     """Tests for configuration toggles."""
 
-    def test_setup_observability_respects_all_toggles_disabled(
-        self, test_app: FastAPI
-    ) -> None:
+    def test_setup_observability_respects_all_toggles_disabled(self, test_app: FastAPI) -> None:
         """setup_observability should not initialize anything when all disabled."""
         settings = MagpieSettings(sentry_dsn=None, otel_enabled=False)
 
@@ -157,13 +141,9 @@ class TestConfigToggles:
         setup_observability(test_app, settings)
         # If we get here without error, early returns worked
 
-    def test_setup_observability_initializes_both_when_configured(
-        self, test_app: FastAPI
-    ) -> None:
+    def test_setup_observability_initializes_both_when_configured(self, test_app: FastAPI) -> None:
         """setup_observability should initialize both when both are configured."""
-        settings = MagpieSettings(
-            sentry_dsn="https://test@sentry.io/123", otel_enabled=True
-        )
+        settings = MagpieSettings(sentry_dsn="https://test@sentry.io/123", otel_enabled=True)
 
         with (
             patch("sentry_sdk.init") as mock_sentry_init,

--- a/tests/unit/test_storage_utils.py
+++ b/tests/unit/test_storage_utils.py
@@ -27,9 +27,7 @@ class TestComputeHash:
     """Tests for compute_hash function."""
 
     # Known SHA-256 hash for "hello world"
-    HELLO_WORLD_HASH = (
-        "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
-    )
+    HELLO_WORLD_HASH = "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
 
     def test_compute_hash_bytes(self) -> None:
         """compute_hash should return correct SHA-256 for bytes input."""

--- a/tests/unit/test_symlinks.py
+++ b/tests/unit/test_symlinks.py
@@ -103,9 +103,7 @@ class TestRemoveSymlink:
         # Should not raise
         remove_symlink(artifact_dir, "nonexistent")
 
-    def test_remove_symlink_does_not_remove_regular_file(
-        self, artifact_dir: Path
-    ) -> None:
+    def test_remove_symlink_does_not_remove_regular_file(self, artifact_dir: Path) -> None:
         """remove_symlink should only remove symlinks, not regular files."""
         regular_file = artifact_dir / "regular"
         regular_file.write_text("regular content")

--- a/tests/unit/test_symlinks.py
+++ b/tests/unit/test_symlinks.py
@@ -133,12 +133,15 @@ class TestReconcileSymlinks:
             }
         )
 
-        reconcile_symlinks(artifact_dir, manifest)
+        checked, fixed = reconcile_symlinks(artifact_dir, manifest)
 
         assert (artifact_dir / "latest").is_symlink()
         assert (artifact_dir / "v1.0").is_symlink()
         assert (artifact_dir / "latest").read_text() == "content1"
         assert (artifact_dir / "v1.0").read_text() == "content2"
+        # No existing symlinks, 2 created
+        assert checked == 0
+        assert fixed == 2
 
     def test_reconcile_removes_orphan_symlinks(self, artifact_dir: Path) -> None:
         """reconcile_symlinks should remove symlinks not in manifest."""
@@ -236,10 +239,35 @@ class TestReconcileSymlinks:
             }
         )
 
-        reconcile_symlinks(artifact_dir, manifest)
+        checked, fixed = reconcile_symlinks(artifact_dir, manifest)
 
         # Verify results
         assert (artifact_dir / "keep").read_text() == "content1"
         assert (artifact_dir / "update").read_text() == "content2"
         assert (artifact_dir / "add").read_text() == "content3"
         assert not (artifact_dir / "remove").exists()
+        # 3 symlinks checked, 3 fixed (1 added, 1 removed, 1 updated)
+        assert checked == 3
+        assert fixed == 3
+
+    def test_reconcile_returns_stats(self, artifact_dir: Path) -> None:
+        """reconcile_symlinks should return correct statistics."""
+        # Create blobs
+        (artifact_dir / "blobs" / "hash1").write_text("content1")
+        (artifact_dir / "blobs" / "hash2").write_text("content2")
+
+        # Create existing correct symlink
+        create_symlink(artifact_dir, "existing", "hash1")
+
+        manifest = Manifest(
+            tags={
+                "existing": "@hash1",  # Already correct
+                "new": "@hash2",  # New symlink
+            }
+        )
+
+        checked, fixed = reconcile_symlinks(artifact_dir, manifest)
+
+        # 1 existing symlink checked, 1 new created
+        assert checked == 1
+        assert fixed == 1

--- a/tests/unit/test_tag_operations.py
+++ b/tests/unit/test_tag_operations.py
@@ -46,9 +46,7 @@ class TestCreateTag:
     ) -> None:
         """create_tag should create a new tag pointing to a blob."""
         artifact_path = "test/create-tag"
-        full_hash, hash_ref = store_test_artifact(
-            storage_service, artifact_path, b"test content"
-        )
+        full_hash, hash_ref = store_test_artifact(storage_service, artifact_path, b"test content")
 
         # Create a new tag
         info = storage_service.create_tag(artifact_path, hash_ref, "stable")
@@ -62,14 +60,10 @@ class TestCreateTag:
         manifest = read_manifest(artifact_dir)
         assert manifest.tags["stable"] == full_hash
 
-    def test_create_tag_with_full_hash(
-        self, storage_service: StorageService
-    ) -> None:
+    def test_create_tag_with_full_hash(self, storage_service: StorageService) -> None:
         """create_tag should accept full SHA-256 hash."""
         artifact_path = "test/full-hash-tag"
-        full_hash, _ = store_test_artifact(
-            storage_service, artifact_path, b"content"
-        )
+        full_hash, _ = store_test_artifact(storage_service, artifact_path, b"content")
 
         # Create tag using full hash (no @ prefix)
         info = storage_service.create_tag(artifact_path, full_hash, "v1.0")
@@ -84,14 +78,10 @@ class TestCreateTag:
         artifact_path = "test/update-tag"
 
         # Store first version
-        hash1, ref1 = store_test_artifact(
-            storage_service, artifact_path, b"version 1"
-        )
+        hash1, ref1 = store_test_artifact(storage_service, artifact_path, b"version 1")
 
         # Store second version (different content = different hash)
-        hash2, ref2 = store_test_artifact(
-            storage_service, artifact_path, b"version 2"
-        )
+        hash2, ref2 = store_test_artifact(storage_service, artifact_path, b"version 2")
 
         # Create "stable" tag pointing to first version
         storage_service.create_tag(artifact_path, ref1, "stable")
@@ -107,9 +97,7 @@ class TestCreateTag:
         manifest = read_manifest(artifact_dir)
         assert manifest.tags["stable"] == hash2
 
-    def test_create_tag_with_nonexistent_hash_raises(
-        self, storage_service: StorageService
-    ) -> None:
+    def test_create_tag_with_nonexistent_hash_raises(self, storage_service: StorageService) -> None:
         """create_tag should raise ArtifactNotFoundError for non-existent hash."""
         artifact_path = "test/nonexistent-hash"
 
@@ -132,9 +120,7 @@ class TestCreateTag:
     ) -> None:
         """create_tag should return complete ArtifactInfo."""
         artifact_path = "test/complete-info"
-        full_hash, hash_ref = store_test_artifact(
-            storage_service, artifact_path, b"content"
-        )
+        full_hash, hash_ref = store_test_artifact(storage_service, artifact_path, b"content")
 
         info = storage_service.create_tag(artifact_path, hash_ref, "tagged")
 
@@ -153,9 +139,7 @@ class TestRemoveTag:
     ) -> None:
         """remove_tag should remove an existing tag and return True."""
         artifact_path = "test/remove-tag"
-        full_hash, hash_ref = store_test_artifact(
-            storage_service, artifact_path, b"content"
-        )
+        full_hash, hash_ref = store_test_artifact(storage_service, artifact_path, b"content")
 
         # Create a tag to remove
         storage_service.create_tag(artifact_path, hash_ref, "to-remove")
@@ -222,9 +206,7 @@ class TestTagSymlinks:
     ) -> None:
         """create_tag should create a symlink for the new tag."""
         artifact_path = "test/tag-symlink"
-        _, hash_ref = store_test_artifact(
-            storage_service, artifact_path, b"symlink content"
-        )
+        _, hash_ref = store_test_artifact(storage_service, artifact_path, b"symlink content")
 
         storage_service.create_tag(artifact_path, hash_ref, "my-tag")
 
@@ -241,12 +223,8 @@ class TestTagSymlinks:
         artifact_path = "test/update-symlink"
 
         # Store two versions
-        hash1, ref1 = store_test_artifact(
-            storage_service, artifact_path, b"version 1"
-        )
-        hash2, ref2 = store_test_artifact(
-            storage_service, artifact_path, b"version 2"
-        )
+        hash1, ref1 = store_test_artifact(storage_service, artifact_path, b"version 1")
+        hash2, ref2 = store_test_artifact(storage_service, artifact_path, b"version 2")
 
         # Create tag pointing to first version
         storage_service.create_tag(artifact_path, ref1, "switchable")
@@ -265,9 +243,7 @@ class TestTagSymlinks:
     ) -> None:
         """remove_tag should remove the symlink for the tag."""
         artifact_path = "test/remove-symlink"
-        _, hash_ref = store_test_artifact(
-            storage_service, artifact_path, b"content"
-        )
+        _, hash_ref = store_test_artifact(storage_service, artifact_path, b"content")
 
         # Create a tag with symlink
         storage_service.create_tag(artifact_path, hash_ref, "temp-tag")
@@ -286,9 +262,7 @@ class TestTagSymlinks:
     ) -> None:
         """remove_tag should not affect other tag symlinks."""
         artifact_path = "test/preserve-symlinks"
-        _, hash_ref = store_test_artifact(
-            storage_service, artifact_path, b"content"
-        )
+        _, hash_ref = store_test_artifact(storage_service, artifact_path, b"content")
 
         # Create multiple tags
         storage_service.create_tag(artifact_path, hash_ref, "keep-this")

--- a/tests/unit/test_token_service.py
+++ b/tests/unit/test_token_service.py
@@ -27,36 +27,28 @@ def token_service(test_config: MagpieSettings) -> TokenService:
 class TestCreateToken:
     """Tests for TokenService.create_token method."""
 
-    def test_create_token_returns_proper_format(
-        self, token_service: TokenService
-    ) -> None:
+    def test_create_token_returns_proper_format(self, token_service: TokenService) -> None:
         """create_token should return token with mgp_ prefix."""
         token = token_service.create_token("test-token", TokenScope.READ)
 
         assert token.startswith("mgp_")
         assert len(token) > 10  # prefix + random part
 
-    def test_create_token_read_scope_has_mgp_prefix(
-        self, token_service: TokenService
-    ) -> None:
+    def test_create_token_read_scope_has_mgp_prefix(self, token_service: TokenService) -> None:
         """create_token for READ scope should use mgp_ prefix."""
         token = token_service.create_token("read-token", TokenScope.READ)
 
         assert token.startswith("mgp_")
         assert not token.startswith("mgp_ADMIN_")
 
-    def test_create_token_write_scope_has_mgp_prefix(
-        self, token_service: TokenService
-    ) -> None:
+    def test_create_token_write_scope_has_mgp_prefix(self, token_service: TokenService) -> None:
         """create_token for WRITE scope should use mgp_ prefix."""
         token = token_service.create_token("write-token", TokenScope.WRITE)
 
         assert token.startswith("mgp_")
         assert not token.startswith("mgp_ADMIN_")
 
-    def test_create_token_admin_uses_admin_prefix(
-        self, token_service: TokenService
-    ) -> None:
+    def test_create_token_admin_uses_admin_prefix(self, token_service: TokenService) -> None:
         """create_token for ADMIN scope should use mgp_ADMIN_ prefix."""
         token = token_service.create_token("admin-token", TokenScope.ADMIN)
 
@@ -78,18 +70,14 @@ class TestCreateToken:
         assert row["token_hash"] != plaintext
         assert len(row["token_hash"]) == 64  # SHA-256 hex length
 
-    def test_create_token_duplicate_name_raises(
-        self, token_service: TokenService
-    ) -> None:
+    def test_create_token_duplicate_name_raises(self, token_service: TokenService) -> None:
         """create_token should raise ValueError for duplicate name."""
         token_service.create_token("duplicate", TokenScope.READ)
 
         with pytest.raises(ValueError, match="already exists"):
             token_service.create_token("duplicate", TokenScope.WRITE)
 
-    def test_create_token_generates_unique_tokens(
-        self, token_service: TokenService
-    ) -> None:
+    def test_create_token_generates_unique_tokens(self, token_service: TokenService) -> None:
         """create_token should generate unique tokens each time."""
         token1 = token_service.create_token("token1", TokenScope.READ)
         token2 = token_service.create_token("token2", TokenScope.READ)
@@ -100,9 +88,7 @@ class TestCreateToken:
 class TestValidateToken:
     """Tests for TokenService.validate_token method."""
 
-    def test_validate_token_success_returns_token_info(
-        self, token_service: TokenService
-    ) -> None:
+    def test_validate_token_success_returns_token_info(self, token_service: TokenService) -> None:
         """validate_token should return TokenInfo for valid token."""
         plaintext = token_service.create_token("valid-token", TokenScope.WRITE)
 
@@ -113,9 +99,7 @@ class TestValidateToken:
         assert result.name == "valid-token"
         assert result.scope == TokenScope.WRITE
 
-    def test_validate_token_invalid_returns_none(
-        self, token_service: TokenService
-    ) -> None:
+    def test_validate_token_invalid_returns_none(self, token_service: TokenService) -> None:
         """validate_token should return None for invalid token."""
         result = token_service.validate_token("mgp_invalid_token_xyz")
 
@@ -137,9 +121,7 @@ class TestValidateToken:
 
         assert result is None
 
-    def test_validate_token_preserves_scope(
-        self, token_service: TokenService
-    ) -> None:
+    def test_validate_token_preserves_scope(self, token_service: TokenService) -> None:
         """validate_token should return correct scope."""
         read_token = token_service.create_token("read", TokenScope.READ)
         write_token = token_service.create_token("write", TokenScope.WRITE)
@@ -149,9 +131,7 @@ class TestValidateToken:
         assert token_service.validate_token(write_token).scope == TokenScope.WRITE
         assert token_service.validate_token(admin_token).scope == TokenScope.ADMIN
 
-    def test_validate_token_empty_string_returns_none(
-        self, token_service: TokenService
-    ) -> None:
+    def test_validate_token_empty_string_returns_none(self, token_service: TokenService) -> None:
         """validate_token should return None for empty string."""
         result = token_service.validate_token("")
 
@@ -161,9 +141,7 @@ class TestValidateToken:
 class TestRevokeToken:
     """Tests for TokenService.revoke_token method."""
 
-    def test_revoke_token_removes_token(
-        self, token_service: TokenService
-    ) -> None:
+    def test_revoke_token_removes_token(self, token_service: TokenService) -> None:
         """revoke_token should remove the token from database."""
         plaintext = token_service.create_token("to-revoke", TokenScope.READ)
 
@@ -172,9 +150,7 @@ class TestRevokeToken:
         assert result is True
         assert token_service.validate_token(plaintext) is None
 
-    def test_revoke_token_returns_true_on_success(
-        self, token_service: TokenService
-    ) -> None:
+    def test_revoke_token_returns_true_on_success(self, token_service: TokenService) -> None:
         """revoke_token should return True when token is revoked."""
         token_service.create_token("revokable", TokenScope.READ)
 
@@ -182,17 +158,13 @@ class TestRevokeToken:
 
         assert result is True
 
-    def test_revoke_token_returns_false_for_nonexistent(
-        self, token_service: TokenService
-    ) -> None:
+    def test_revoke_token_returns_false_for_nonexistent(self, token_service: TokenService) -> None:
         """revoke_token should return False for non-existent token."""
         result = token_service.revoke_token("nonexistent")
 
         assert result is False
 
-    def test_revoked_token_no_longer_validates(
-        self, token_service: TokenService
-    ) -> None:
+    def test_revoked_token_no_longer_validates(self, token_service: TokenService) -> None:
         """A revoked token should no longer validate."""
         plaintext = token_service.create_token("revoke-validate", TokenScope.WRITE)
 
@@ -209,33 +181,25 @@ class TestRevokeToken:
 class TestHasScope:
     """Tests for TokenService.has_scope method."""
 
-    def test_has_scope_admin_has_all_scopes(
-        self, token_service: TokenService
-    ) -> None:
+    def test_has_scope_admin_has_all_scopes(self, token_service: TokenService) -> None:
         """ADMIN scope should satisfy all required scopes."""
         assert token_service.has_scope(TokenScope.ADMIN, TokenScope.READ) is True
         assert token_service.has_scope(TokenScope.ADMIN, TokenScope.WRITE) is True
         assert token_service.has_scope(TokenScope.ADMIN, TokenScope.ADMIN) is True
 
-    def test_has_scope_write_has_read_and_write(
-        self, token_service: TokenService
-    ) -> None:
+    def test_has_scope_write_has_read_and_write(self, token_service: TokenService) -> None:
         """WRITE scope should satisfy READ and WRITE requirements."""
         assert token_service.has_scope(TokenScope.WRITE, TokenScope.READ) is True
         assert token_service.has_scope(TokenScope.WRITE, TokenScope.WRITE) is True
         assert token_service.has_scope(TokenScope.WRITE, TokenScope.ADMIN) is False
 
-    def test_has_scope_read_only_has_read(
-        self, token_service: TokenService
-    ) -> None:
+    def test_has_scope_read_only_has_read(self, token_service: TokenService) -> None:
         """READ scope should only satisfy READ requirement."""
         assert token_service.has_scope(TokenScope.READ, TokenScope.READ) is True
         assert token_service.has_scope(TokenScope.READ, TokenScope.WRITE) is False
         assert token_service.has_scope(TokenScope.READ, TokenScope.ADMIN) is False
 
-    def test_has_scope_hierarchy_is_correct(
-        self, token_service: TokenService
-    ) -> None:
+    def test_has_scope_hierarchy_is_correct(self, token_service: TokenService) -> None:
         """Scope hierarchy should be: admin > write > read."""
         # Each scope should satisfy itself
         for scope in TokenScope:
@@ -250,9 +214,7 @@ class TestHasScope:
 class TestTokenServiceInitialization:
     """Tests for TokenService initialization."""
 
-    def test_service_initializes_database(
-        self, test_config: MagpieSettings
-    ) -> None:
+    def test_service_initializes_database(self, test_config: MagpieSettings) -> None:
         """TokenService should initialize database on creation."""
         # Database should not exist yet
         assert not test_config.database_path.exists()
@@ -263,9 +225,7 @@ class TestTokenServiceInitialization:
         # Database should now exist
         assert test_config.database_path.exists()
 
-    def test_service_can_be_created_multiple_times(
-        self, test_config: MagpieSettings
-    ) -> None:
+    def test_service_can_be_created_multiple_times(self, test_config: MagpieSettings) -> None:
         """Multiple TokenService instances should work correctly."""
         service1 = TokenService(test_config)
         service2 = TokenService(test_config)

--- a/tests/unit/test_token_storage.py
+++ b/tests/unit/test_token_storage.py
@@ -72,9 +72,7 @@ class TestInitDatabase:
         init_database(db_path)
 
         conn = sqlite3.connect(db_path)
-        cursor = conn.execute(
-            "SELECT name FROM sqlite_master WHERE type='table' AND name='tokens'"
-        )
+        cursor = conn.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='tokens'")
         result = cursor.fetchone()
         conn.close()
 
@@ -106,9 +104,7 @@ class TestInitDatabase:
         init_database(db_path)  # Should not raise
 
         conn = sqlite3.connect(db_path)
-        cursor = conn.execute(
-            "SELECT name FROM sqlite_master WHERE type='table' AND name='tokens'"
-        )
+        cursor = conn.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='tokens'")
         assert cursor.fetchone() is not None
         conn.close()
 
@@ -167,17 +163,13 @@ class TestSaveToken:
 
         save_token(db_conn, token)
 
-        cursor = db_conn.execute(
-            "SELECT * FROM tokens WHERE name = ?", ("full-token",)
-        )
+        cursor = db_conn.execute("SELECT * FROM tokens WHERE name = ?", ("full-token",))
         row = cursor.fetchone()
         assert row["scope"] == "admin"
         assert row["enabled"] == 0
         assert row["created_at"] is not None
 
-    def test_save_token_duplicate_name_raises(
-        self, db_conn: sqlite3.Connection
-    ) -> None:
+    def test_save_token_duplicate_name_raises(self, db_conn: sqlite3.Connection) -> None:
         """save_token should raise error for duplicate name."""
         token1 = make_token(name="duplicate", token_hash="hash1")
         token2 = make_token(name="duplicate", token_hash="hash2")
@@ -187,9 +179,7 @@ class TestSaveToken:
         with pytest.raises(sqlite3.IntegrityError):
             save_token(db_conn, token2)
 
-    def test_save_token_duplicate_hash_raises(
-        self, db_conn: sqlite3.Connection
-    ) -> None:
+    def test_save_token_duplicate_hash_raises(self, db_conn: sqlite3.Connection) -> None:
         """save_token should raise error for duplicate hash."""
         token1 = make_token(name="token1", token_hash="same-hash")
         token2 = make_token(name="token2", token_hash="same-hash")
@@ -203,9 +193,7 @@ class TestSaveToken:
 class TestGetTokenByHash:
     """Tests for get_token_by_hash function."""
 
-    def test_get_token_by_hash_returns_token(
-        self, db_conn: sqlite3.Connection
-    ) -> None:
+    def test_get_token_by_hash_returns_token(self, db_conn: sqlite3.Connection) -> None:
         """get_token_by_hash should return matching token."""
         token = make_token(name="find-me", token_hash="findable-hash")
         save_token(db_conn, token)
@@ -216,17 +204,13 @@ class TestGetTokenByHash:
         assert result.name == "find-me"
         assert result.token_hash == "findable-hash"
 
-    def test_get_token_by_hash_returns_none_for_unknown(
-        self, db_conn: sqlite3.Connection
-    ) -> None:
+    def test_get_token_by_hash_returns_none_for_unknown(self, db_conn: sqlite3.Connection) -> None:
         """get_token_by_hash should return None for unknown hash."""
         result = get_token_by_hash(db_conn, "nonexistent-hash")
 
         assert result is None
 
-    def test_get_token_by_hash_preserves_all_fields(
-        self, db_conn: sqlite3.Connection
-    ) -> None:
+    def test_get_token_by_hash_preserves_all_fields(self, db_conn: sqlite3.Connection) -> None:
         """get_token_by_hash should return token with all fields intact."""
         original = make_token(
             name="complete",
@@ -249,9 +233,7 @@ class TestGetTokenByHash:
 class TestListTokens:
     """Tests for list_tokens function."""
 
-    def test_list_tokens_returns_all_tokens(
-        self, db_conn: sqlite3.Connection
-    ) -> None:
+    def test_list_tokens_returns_all_tokens(self, db_conn: sqlite3.Connection) -> None:
         """list_tokens should return all stored tokens."""
         tokens = [
             make_token(name="token1", token_hash="hash1"),
@@ -267,17 +249,13 @@ class TestListTokens:
         names = {t.name for t in result}
         assert names == {"token1", "token2", "token3"}
 
-    def test_list_tokens_returns_empty_for_no_tokens(
-        self, db_conn: sqlite3.Connection
-    ) -> None:
+    def test_list_tokens_returns_empty_for_no_tokens(self, db_conn: sqlite3.Connection) -> None:
         """list_tokens should return empty list when no tokens exist."""
         result = list_tokens(db_conn)
 
         assert result == []
 
-    def test_list_tokens_includes_disabled_tokens(
-        self, db_conn: sqlite3.Connection
-    ) -> None:
+    def test_list_tokens_includes_disabled_tokens(self, db_conn: sqlite3.Connection) -> None:
         """list_tokens should include disabled tokens."""
         enabled_token = make_token(name="enabled", token_hash="hash1", enabled=True)
         disabled_token = make_token(name="disabled", token_hash="hash2", enabled=False)
@@ -304,9 +282,7 @@ class TestDeleteToken:
         assert result is True
         assert get_token_by_hash(db_conn, "delete-hash") is None
 
-    def test_delete_token_returns_true_on_success(
-        self, db_conn: sqlite3.Connection
-    ) -> None:
+    def test_delete_token_returns_true_on_success(self, db_conn: sqlite3.Connection) -> None:
         """delete_token should return True when token is deleted."""
         token = make_token(name="deletable", token_hash="hash")
         save_token(db_conn, token)
@@ -315,17 +291,13 @@ class TestDeleteToken:
 
         assert result is True
 
-    def test_delete_token_returns_false_for_nonexistent(
-        self, db_conn: sqlite3.Connection
-    ) -> None:
+    def test_delete_token_returns_false_for_nonexistent(self, db_conn: sqlite3.Connection) -> None:
         """delete_token should return False for non-existent token."""
         result = delete_token(db_conn, "nonexistent")
 
         assert result is False
 
-    def test_delete_token_does_not_affect_other_tokens(
-        self, db_conn: sqlite3.Connection
-    ) -> None:
+    def test_delete_token_does_not_affect_other_tokens(self, db_conn: sqlite3.Connection) -> None:
         """delete_token should not affect other tokens."""
         token1 = make_token(name="keep", token_hash="hash1")
         token2 = make_token(name="delete", token_hash="hash2")

--- a/uv.lock
+++ b/uv.lock
@@ -146,6 +146,67 @@ wheels = [
 ]
 
 [[package]]
+name = "coverage"
+version = "7.13.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/23/f9/e92df5e07f3fc8d4c7f9a0f146ef75446bf870351cd37b788cf5897f8079/coverage-7.13.1.tar.gz", hash = "sha256:b7593fe7eb5feaa3fbb461ac79aac9f9fc0387a5ca8080b0c6fe2ca27b091afd", size = 825862, upload-time = "2025-12-28T15:42:56.969Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/a4/e98e689347a1ff1a7f67932ab535cef82eb5e78f32a9e4132e114bbb3a0a/coverage-7.13.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:cb237bfd0ef4d5eb6a19e29f9e528ac67ac3be932ea6b44fb6cc09b9f3ecff78", size = 218951, upload-time = "2025-12-28T15:41:16.653Z" },
+    { url = "https://files.pythonhosted.org/packages/32/33/7cbfe2bdc6e2f03d6b240d23dc45fdaf3fd270aaf2d640be77b7f16989ab/coverage-7.13.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1dcb645d7e34dcbcc96cd7c132b1fc55c39263ca62eb961c064eb3928997363b", size = 219325, upload-time = "2025-12-28T15:41:18.609Z" },
+    { url = "https://files.pythonhosted.org/packages/59/f6/efdabdb4929487baeb7cb2a9f7dac457d9356f6ad1b255be283d58b16316/coverage-7.13.1-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:3d42df8201e00384736f0df9be2ced39324c3907607d17d50d50116c989d84cd", size = 250309, upload-time = "2025-12-28T15:41:20.629Z" },
+    { url = "https://files.pythonhosted.org/packages/12/da/91a52516e9d5aea87d32d1523f9cdcf7a35a3b298e6be05d6509ba3cfab2/coverage-7.13.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fa3edde1aa8807de1d05934982416cb3ec46d1d4d91e280bcce7cca01c507992", size = 252907, upload-time = "2025-12-28T15:41:22.257Z" },
+    { url = "https://files.pythonhosted.org/packages/75/38/f1ea837e3dc1231e086db1638947e00d264e7e8c41aa8ecacf6e1e0c05f4/coverage-7.13.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9edd0e01a343766add6817bc448408858ba6b489039eaaa2018474e4001651a4", size = 254148, upload-time = "2025-12-28T15:41:23.87Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/43/f4f16b881aaa34954ba446318dea6b9ed5405dd725dd8daac2358eda869a/coverage-7.13.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:985b7836931d033570b94c94713c6dba5f9d3ff26045f72c3e5dbc5fe3361e5a", size = 250515, upload-time = "2025-12-28T15:41:25.437Z" },
+    { url = "https://files.pythonhosted.org/packages/84/34/8cba7f00078bd468ea914134e0144263194ce849ec3baad187ffb6203d1c/coverage-7.13.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ffed1e4980889765c84a5d1a566159e363b71d6b6fbaf0bebc9d3c30bc016766", size = 252292, upload-time = "2025-12-28T15:41:28.459Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/a4/cffac66c7652d84ee4ac52d3ccb94c015687d3b513f9db04bfcac2ac800d/coverage-7.13.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:8842af7f175078456b8b17f1b73a0d16a65dcbdc653ecefeb00a56b3c8c298c4", size = 250242, upload-time = "2025-12-28T15:41:30.02Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/78/9a64d462263dde416f3c0067efade7b52b52796f489b1037a95b0dc389c9/coverage-7.13.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:ccd7a6fca48ca9c131d9b0a2972a581e28b13416fc313fb98b6d24a03ce9a398", size = 250068, upload-time = "2025-12-28T15:41:32.007Z" },
+    { url = "https://files.pythonhosted.org/packages/69/c8/a8994f5fece06db7c4a97c8fc1973684e178599b42e66280dded0524ef00/coverage-7.13.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0403f647055de2609be776965108447deb8e384fe4a553c119e3ff6bfbab4784", size = 251846, upload-time = "2025-12-28T15:41:33.946Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/f7/91fa73c4b80305c86598a2d4e54ba22df6bf7d0d97500944af7ef155d9f7/coverage-7.13.1-cp313-cp313-win32.whl", hash = "sha256:549d195116a1ba1e1ae2f5ca143f9777800f6636eab917d4f02b5310d6d73461", size = 221512, upload-time = "2025-12-28T15:41:35.519Z" },
+    { url = "https://files.pythonhosted.org/packages/45/0b/0768b4231d5a044da8f75e097a8714ae1041246bb765d6b5563bab456735/coverage-7.13.1-cp313-cp313-win_amd64.whl", hash = "sha256:5899d28b5276f536fcf840b18b61a9fce23cc3aec1d114c44c07fe94ebeaa500", size = 222321, upload-time = "2025-12-28T15:41:37.371Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/b8/bdcb7253b7e85157282450262008f1366aa04663f3e3e4c30436f596c3e2/coverage-7.13.1-cp313-cp313-win_arm64.whl", hash = "sha256:868a2fae76dfb06e87291bcbd4dcbcc778a8500510b618d50496e520bd94d9b9", size = 220949, upload-time = "2025-12-28T15:41:39.553Z" },
+    { url = "https://files.pythonhosted.org/packages/70/52/f2be52cc445ff75ea8397948c96c1b4ee14f7f9086ea62fc929c5ae7b717/coverage-7.13.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:67170979de0dacac3f3097d02b0ad188d8edcea44ccc44aaa0550af49150c7dc", size = 219643, upload-time = "2025-12-28T15:41:41.567Z" },
+    { url = "https://files.pythonhosted.org/packages/47/79/c85e378eaa239e2edec0c5523f71542c7793fe3340954eafb0bc3904d32d/coverage-7.13.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:f80e2bb21bfab56ed7405c2d79d34b5dc0bc96c2c1d2a067b643a09fb756c43a", size = 219997, upload-time = "2025-12-28T15:41:43.418Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/9b/b1ade8bfb653c0bbce2d6d6e90cc6c254cbb99b7248531cc76253cb4da6d/coverage-7.13.1-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:f83351e0f7dcdb14d7326c3d8d8c4e915fa685cbfdc6281f9470d97a04e9dfe4", size = 261296, upload-time = "2025-12-28T15:41:45.207Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/af/ebf91e3e1a2473d523e87e87fd8581e0aa08741b96265730e2d79ce78d8d/coverage-7.13.1-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:bb3f6562e89bad0110afbe64e485aac2462efdce6232cdec7862a095dc3412f6", size = 263363, upload-time = "2025-12-28T15:41:47.163Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/8b/fb2423526d446596624ac7fde12ea4262e66f86f5120114c3cfd0bb2befa/coverage-7.13.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:77545b5dcda13b70f872c3b5974ac64c21d05e65b1590b441c8560115dc3a0d1", size = 265783, upload-time = "2025-12-28T15:41:49.03Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/26/ef2adb1e22674913b89f0fe7490ecadcef4a71fa96f5ced90c60ec358789/coverage-7.13.1-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a4d240d260a1aed814790bbe1f10a5ff31ce6c21bc78f0da4a1e8268d6c80dbd", size = 260508, upload-time = "2025-12-28T15:41:51.035Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/7d/f0f59b3404caf662e7b5346247883887687c074ce67ba453ea08c612b1d5/coverage-7.13.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:d2287ac9360dec3837bfdad969963a5d073a09a85d898bd86bea82aa8876ef3c", size = 263357, upload-time = "2025-12-28T15:41:52.631Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/b1/29896492b0b1a047604d35d6fa804f12818fa30cdad660763a5f3159e158/coverage-7.13.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:0d2c11f3ea4db66b5cbded23b20185c35066892c67d80ec4be4bab257b9ad1e0", size = 260978, upload-time = "2025-12-28T15:41:54.589Z" },
+    { url = "https://files.pythonhosted.org/packages/48/f2/971de1238a62e6f0a4128d37adadc8bb882ee96afbe03ff1570291754629/coverage-7.13.1-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:3fc6a169517ca0d7ca6846c3c5392ef2b9e38896f61d615cb75b9e7134d4ee1e", size = 259877, upload-time = "2025-12-28T15:41:56.263Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/fc/0474efcbb590ff8628830e9aaec5f1831594874360e3251f1fdec31d07a3/coverage-7.13.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:d10a2ed46386e850bb3de503a54f9fe8192e5917fcbb143bfef653a9355e9a53", size = 262069, upload-time = "2025-12-28T15:41:58.093Z" },
+    { url = "https://files.pythonhosted.org/packages/88/4f/3c159b7953db37a7b44c0eab8a95c37d1aa4257c47b4602c04022d5cb975/coverage-7.13.1-cp313-cp313t-win32.whl", hash = "sha256:75a6f4aa904301dab8022397a22c0039edc1f51e90b83dbd4464b8a38dc87842", size = 222184, upload-time = "2025-12-28T15:41:59.763Z" },
+    { url = "https://files.pythonhosted.org/packages/58/a5/6b57d28f81417f9335774f20679d9d13b9a8fb90cd6160957aa3b54a2379/coverage-7.13.1-cp313-cp313t-win_amd64.whl", hash = "sha256:309ef5706e95e62578cda256b97f5e097916a2c26247c287bbe74794e7150df2", size = 223250, upload-time = "2025-12-28T15:42:01.52Z" },
+    { url = "https://files.pythonhosted.org/packages/81/7c/160796f3b035acfbb58be80e02e484548595aa67e16a6345e7910ace0a38/coverage-7.13.1-cp313-cp313t-win_arm64.whl", hash = "sha256:92f980729e79b5d16d221038dbf2e8f9a9136afa072f9d5d6ed4cb984b126a09", size = 221521, upload-time = "2025-12-28T15:42:03.275Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/8e/ba0e597560c6563fc0adb902fda6526df5d4aa73bb10adf0574d03bd2206/coverage-7.13.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:97ab3647280d458a1f9adb85244e81587505a43c0c7cff851f5116cd2814b894", size = 218996, upload-time = "2025-12-28T15:42:04.978Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/8e/764c6e116f4221dc7aa26c4061181ff92edb9c799adae6433d18eeba7a14/coverage-7.13.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:8f572d989142e0908e6acf57ad1b9b86989ff057c006d13b76c146ec6a20216a", size = 219326, upload-time = "2025-12-28T15:42:06.691Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/a6/6130dc6d8da28cdcbb0f2bf8865aeca9b157622f7c0031e48c6cf9a0e591/coverage-7.13.1-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:d72140ccf8a147e94274024ff6fd8fb7811354cf7ef88b1f0a988ebaa5bc774f", size = 250374, upload-time = "2025-12-28T15:42:08.786Z" },
+    { url = "https://files.pythonhosted.org/packages/82/2b/783ded568f7cd6b677762f780ad338bf4b4750205860c17c25f7c708995e/coverage-7.13.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:d3c9f051b028810f5a87c88e5d6e9af3c0ff32ef62763bf15d29f740453ca909", size = 252882, upload-time = "2025-12-28T15:42:10.515Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/b2/9808766d082e6a4d59eb0cc881a57fc1600eb2c5882813eefff8254f71b5/coverage-7.13.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f398ba4df52d30b1763f62eed9de5620dcde96e6f491f4c62686736b155aa6e4", size = 254218, upload-time = "2025-12-28T15:42:12.208Z" },
+    { url = "https://files.pythonhosted.org/packages/44/ea/52a985bb447c871cb4d2e376e401116520991b597c85afdde1ea9ef54f2c/coverage-7.13.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:132718176cc723026d201e347f800cd1a9e4b62ccd3f82476950834dad501c75", size = 250391, upload-time = "2025-12-28T15:42:14.21Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/1d/125b36cc12310718873cfc8209ecfbc1008f14f4f5fa0662aa608e579353/coverage-7.13.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9e549d642426e3579b3f4b92d0431543b012dcb6e825c91619d4e93b7363c3f9", size = 252239, upload-time = "2025-12-28T15:42:16.292Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/16/10c1c164950cade470107f9f14bbac8485f8fb8515f515fca53d337e4a7f/coverage-7.13.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:90480b2134999301eea795b3a9dbf606c6fbab1b489150c501da84a959442465", size = 250196, upload-time = "2025-12-28T15:42:18.54Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/c6/cd860fac08780c6fd659732f6ced1b40b79c35977c1356344e44d72ba6c4/coverage-7.13.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e825dbb7f84dfa24663dd75835e7257f8882629fc11f03ecf77d84a75134b864", size = 250008, upload-time = "2025-12-28T15:42:20.365Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/a8c58d3d38f82a5711e1e0a67268362af48e1a03df27c03072ac30feefcf/coverage-7.13.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:623dcc6d7a7ba450bbdbeedbaa0c42b329bdae16491af2282f12a7e809be7eb9", size = 251671, upload-time = "2025-12-28T15:42:22.114Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/bc/fd4c1da651d037a1e3d53e8cb3f8182f4b53271ffa9a95a2e211bacc0349/coverage-7.13.1-cp314-cp314-win32.whl", hash = "sha256:6e73ebb44dca5f708dc871fe0b90cf4cff1a13f9956f747cc87b535a840386f5", size = 221777, upload-time = "2025-12-28T15:42:23.919Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/50/71acabdc8948464c17e90b5ffd92358579bd0910732c2a1c9537d7536aa6/coverage-7.13.1-cp314-cp314-win_amd64.whl", hash = "sha256:be753b225d159feb397bd0bf91ae86f689bad0da09d3b301478cd39b878ab31a", size = 222592, upload-time = "2025-12-28T15:42:25.619Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/c8/a6fb943081bb0cc926499c7907731a6dc9efc2cbdc76d738c0ab752f1a32/coverage-7.13.1-cp314-cp314-win_arm64.whl", hash = "sha256:228b90f613b25ba0019361e4ab81520b343b622fc657daf7e501c4ed6a2366c0", size = 221169, upload-time = "2025-12-28T15:42:27.629Z" },
+    { url = "https://files.pythonhosted.org/packages/16/61/d5b7a0a0e0e40d62e59bc8c7aa1afbd86280d82728ba97f0673b746b78e2/coverage-7.13.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:60cfb538fe9ef86e5b2ab0ca8fc8d62524777f6c611dcaf76dc16fbe9b8e698a", size = 219730, upload-time = "2025-12-28T15:42:29.306Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/2c/8881326445fd071bb49514d1ce97d18a46a980712b51fee84f9ab42845b4/coverage-7.13.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:57dfc8048c72ba48a8c45e188d811e5efd7e49b387effc8fb17e97936dde5bf6", size = 220001, upload-time = "2025-12-28T15:42:31.319Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/d7/50de63af51dfa3a7f91cc37ad8fcc1e244b734232fbc8b9ab0f3c834a5cd/coverage-7.13.1-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:3f2f725aa3e909b3c5fdb8192490bdd8e1495e85906af74fe6e34a2a77ba0673", size = 261370, upload-time = "2025-12-28T15:42:32.992Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/2c/d31722f0ec918fd7453b2758312729f645978d212b410cd0f7c2aed88a94/coverage-7.13.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9ee68b21909686eeb21dfcba2c3b81fee70dcf38b140dcd5aa70680995fa3aa5", size = 263485, upload-time = "2025-12-28T15:42:34.759Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/7a/2c114fa5c5fc08ba0777e4aec4c97e0b4a1afcb69c75f1f54cff78b073ab/coverage-7.13.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:724b1b270cb13ea2e6503476e34541a0b1f62280bc997eab443f87790202033d", size = 265890, upload-time = "2025-12-28T15:42:36.517Z" },
+    { url = "https://files.pythonhosted.org/packages/65/d9/f0794aa1c74ceabc780fe17f6c338456bbc4e96bd950f2e969f48ac6fb20/coverage-7.13.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:916abf1ac5cf7eb16bc540a5bf75c71c43a676f5c52fcb9fe75a2bd75fb944e8", size = 260445, upload-time = "2025-12-28T15:42:38.646Z" },
+    { url = "https://files.pythonhosted.org/packages/49/23/184b22a00d9bb97488863ced9454068c79e413cb23f472da6cbddc6cfc52/coverage-7.13.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:776483fd35b58d8afe3acbd9988d5de592ab6da2d2a865edfdbc9fdb43e7c486", size = 263357, upload-time = "2025-12-28T15:42:40.788Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/bd/58af54c0c9199ea4190284f389005779d7daf7bf3ce40dcd2d2b2f96da69/coverage-7.13.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:b6f3b96617e9852703f5b633ea01315ca45c77e879584f283c44127f0f1ec564", size = 260959, upload-time = "2025-12-28T15:42:42.808Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/2a/6839294e8f78a4891bf1df79d69c536880ba2f970d0ff09e7513d6e352e9/coverage-7.13.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:bd63e7b74661fed317212fab774e2a648bc4bb09b35f25474f8e3325d2945cd7", size = 259792, upload-time = "2025-12-28T15:42:44.818Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/c3/528674d4623283310ad676c5af7414b9850ab6d55c2300e8aa4b945ec554/coverage-7.13.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:933082f161bbb3e9f90d00990dc956120f608cdbcaeea15c4d897f56ef4fe416", size = 262123, upload-time = "2025-12-28T15:42:47.108Z" },
+    { url = "https://files.pythonhosted.org/packages/06/c5/8c0515692fb4c73ac379d8dc09b18eaf0214ecb76ea6e62467ba7a1556ff/coverage-7.13.1-cp314-cp314t-win32.whl", hash = "sha256:18be793c4c87de2965e1c0f060f03d9e5aff66cfeae8e1dbe6e5b88056ec153f", size = 222562, upload-time = "2025-12-28T15:42:49.144Z" },
+    { url = "https://files.pythonhosted.org/packages/05/0e/c0a0c4678cb30dac735811db529b321d7e1c9120b79bd728d4f4d6b010e9/coverage-7.13.1-cp314-cp314t-win_amd64.whl", hash = "sha256:0e42e0ec0cd3e0d851cb3c91f770c9301f48647cb2877cb78f74bdaa07639a79", size = 223670, upload-time = "2025-12-28T15:42:51.218Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/5f/b177aa0011f354abf03a8f30a85032686d290fdeed4222b27d36b4372a50/coverage-7.13.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eaecf47ef10c72ece9a2a92118257da87e460e113b83cc0d2905cbbe931792b4", size = 221707, upload-time = "2025-12-28T15:42:53.034Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/48/d9f421cb8da5afaa1a64570d9989e00fb7955e6acddc5a12979f7666ef60/coverage-7.13.1-py3-none-any.whl", hash = "sha256:2016745cb3ba554469d02819d78958b571792bb68e31302610e898f80dd3a573", size = 210722, upload-time = "2025-12-28T15:42:54.901Z" },
+]
+
+[[package]]
 name = "distlib"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -342,6 +403,7 @@ dev = [
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
     { name = "ruff" },
 ]
 
@@ -365,6 +427,7 @@ dev = [
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
     { name = "ruff" },
 ]
 
@@ -742,6 +805,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "7.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage" },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/f7/c933acc76f5208b3b00089573cf6a2bc26dc80a8aece8f52bb7d6b1855ca/pytest_cov-7.0.0.tar.gz", hash = "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1", size = 54328, upload-time = "2025-09-09T10:57:02.113Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ee/49/1377b49de7d0c1ce41292161ea0f721913fa8722c19fb9c1e3aa0367eecb/pytest_cov-7.0.0-py3-none-any.whl", hash = "sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861", size = 22424, upload-time = "2025-09-09T10:57:00.695Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Implements issue #34 to enhance the `magpie-ctl gc` command with two key features:

### Progress Bar for TTY Output
- Shows progress bar when stdout is a TTY and not in quiet mode
- Uses `click.progressbar()` for the artifact scanning phase
- Displays current artifact path being processed
- Respects `--quiet` flag to suppress progress output

### Machine-Readable JSON Output
- Adds `--json` flag to output structured statistics
- JSON output includes:
  - `artifacts_scanned`: Total artifacts processed
  - `blobs_deleted`: Number of blobs removed/would be removed
  - `bytes_reclaimed`: Bytes freed by GC
  - `symlinks_checked`: Number of symlinks examined
  - `symlinks_fixed`: Number of symlinks created/removed/updated
  - `dry_run`: Boolean indicating if this was a dry run
- Suppresses human-readable output when JSON mode is active

### Additional Improvements
- Enhanced `reconcile_symlinks()` to return `(checked, fixed)` statistics tuple
- Added `symlinks_checked` and `symlinks_fixed` metrics to human-readable output
- Updated all callers of `reconcile_symlinks()` to handle new return value
- Comprehensive unit tests for all new functionality

## Test Plan

- [x] Unit tests pass for GC command with JSON output
- [x] Unit tests pass for GC command with quiet flag
- [x] Unit tests pass for symlink statistics
- [x] All existing GC tests still pass
- [x] All unit tests pass (284 tests)
- [x] Linting passes with ruff

## Examples

```bash
# Normal GC with progress bar (if TTY)
magpie-ctl gc

# JSON output for automation
magpie-ctl gc --json

# Dry run with JSON
magpie-ctl gc --json --dry-run

# Quiet mode (no progress)
magpie-ctl gc --quiet
```

Generated with Claude Code w/ Opus 4.5