### PR TITLE
Revert PR #42 - superseded by PR #52

### DIFF
--- a/src/magpie/server/routes/upload.py
+++ b/src/magpie/server/routes/upload.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, Header, HTTPException, UploadFile, status
+from fastapi import APIRouter, Depends, Header, UploadFile
 from pydantic import BaseModel
 
 from magpie.server.deps import get_storage_service
@@ -14,28 +14,6 @@ from magpie.storage.service import StorageService
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
-
-# Reserved path segments that conflict with internal storage structure
-RESERVED_SEGMENTS = frozenset({"blobs", "metadata", ".magpie"})
-
-
-def validate_artifact_path(path: str) -> None:
-    """Validate that artifact path doesn't use reserved segments.
-
-    Args:
-        path: The artifact path to validate.
-
-    Raises:
-        HTTPException 400: If path contains reserved segments.
-    """
-    segments = path.split("/")
-    for original_segment in segments:
-        if original_segment in RESERVED_SEGMENTS:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"Path contains reserved segment '{original_segment}'. "
-                f"Reserved segments: {', '.join(sorted(RESERVED_SEGMENTS))}",
-            )
 
 
 class UploadResponse(BaseModel):
@@ -79,12 +57,8 @@ async def upload_artifact(
         and duplicate detection status.
 
     Raises:
-        HTTPException 400: If path contains reserved segments.
         StorageError: If storage operation fails.
     """
-    # Validate path doesn't use reserved segments
-    validate_artifact_path(path)
-
     # Use X-Magpie-User header if present (authenticated via Caddy)
     # Fall back to query parameter for direct API access
     if x_magpie_user is not None:

--- a/tests/integration/test_upload_endpoint.py
+++ b/tests/integration/test_upload_endpoint.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import pytest
 from fastapi.testclient import TestClient
 
-from magpie.config import MagpieSettings
+from magpie.config import MagpieSettings, get_settings
 from magpie.server.app import app
 from magpie.server.deps import get_storage_service
 from magpie.storage.service import StorageService
@@ -306,73 +306,3 @@ class TestAuthHeaderHandling:
         # Verify anonymous was used as default
         info = test_storage_service.get_artifact_info("auth/anonymous-test", "latest")
         assert info.uploaded_by == "anonymous"
-
-
-class TestPathValidation:
-    """Tests for artifact path validation."""
-
-    def test_reserved_segment_blobs_rejected(self, client: TestClient) -> None:
-        """Upload with 'blobs' in path is rejected."""
-        content = b"test content"
-        files = {"file": ("artifact.bin", io.BytesIO(content), "application/octet-stream")}
-
-        response = client.post("/api/v1/upload/test/blobs/evil", files=files)
-
-        assert response.status_code == 400
-        assert "reserved" in response.json()["detail"].lower()
-        assert "blobs" in response.json()["detail"]
-
-    def test_reserved_segment_metadata_rejected(self, client: TestClient) -> None:
-        """Upload with 'metadata' in path is rejected."""
-        content = b"test content"
-        files = {"file": ("artifact.bin", io.BytesIO(content), "application/octet-stream")}
-
-        response = client.post("/api/v1/upload/metadata/test", files=files)
-
-        assert response.status_code == 400
-        assert "reserved" in response.json()["detail"].lower()
-        assert "metadata" in response.json()["detail"]
-
-    def test_reserved_segment_dotmagpie_rejected(self, client: TestClient) -> None:
-        """Upload with '.magpie' in path is rejected."""
-        content = b"test content"
-        files = {"file": ("artifact.bin", io.BytesIO(content), "application/octet-stream")}
-
-        response = client.post("/api/v1/upload/test/.magpie/config", files=files)
-
-        assert response.status_code == 400
-        assert "reserved" in response.json()["detail"].lower()
-        assert ".magpie" in response.json()["detail"]
-
-    def test_reserved_segment_case_sensitive(self, client: TestClient) -> None:
-        """Reserved segments are blocked case-sensitively - only exact matches are rejected."""
-        content = b"test content"
-
-        # Test uppercase BLOBS - should be ALLOWED (case-sensitive validation)
-        files = {"file": ("artifact.bin", io.BytesIO(content), "application/octet-stream")}
-        response = client.post("/api/v1/upload/test/BLOBS/allowed", files=files)
-        assert response.status_code == 200
-
-        # Test mixed-case Metadata - should be ALLOWED
-        files = {"file": ("artifact.bin", io.BytesIO(content), "application/octet-stream")}
-        response = client.post("/api/v1/upload/Metadata/allowed", files=files)
-        assert response.status_code == 200
-
-        # Test mixed-case Blobs - should be ALLOWED
-        files = {"file": ("artifact.bin", io.BytesIO(content), "application/octet-stream")}
-        response = client.post("/api/v1/upload/Blobs/allowed", files=files)
-        assert response.status_code == 200
-
-        # Test uppercase .MAGPIE - should be ALLOWED
-        files = {"file": ("artifact.bin", io.BytesIO(content), "application/octet-stream")}
-        response = client.post("/api/v1/upload/test/.MAGPIE/allowed", files=files)
-        assert response.status_code == 200
-
-    def test_valid_path_accepted(self, client: TestClient) -> None:
-        """Valid paths without reserved segments are accepted."""
-        content = b"test content"
-        files = {"file": ("artifact.bin", io.BytesIO(content), "application/octet-stream")}
-
-        response = client.post("/api/v1/upload/project/component/artifact", files=files)
-
-        assert response.status_code == 200

--- a/tests/integration/test_upload_endpoint.py
+++ b/tests/integration/test_upload_endpoint.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import pytest
 from fastapi.testclient import TestClient
 
-from magpie.config import MagpieSettings, get_settings
+from magpie.config import MagpieSettings
 from magpie.server.app import app
 from magpie.server.deps import get_storage_service
 from magpie.storage.service import StorageService


### PR DESCRIPTION
## Summary

This PR reverts the changes from PR #42 (commit 2994f556f29437e2ac12c53df90f9dddc056745b) which added reserved path segment validation.

## Reason for Revert

PR #52 provides a more comprehensive implementation that:
- Handles reserved path segments
- Prevents artifact path nesting conflicts
- Provides a complete solution to issue #36

By reverting PR #42, we make way for the superior implementation in PR #52 to be merged cleanly.

## Changes

This revert removes the following changes that were introduced in PR #42:
- Reserved path segment validation in `src/magpie/server/routes/upload.py`
- Associated tests in `tests/integration/test_upload_endpoint.py`

## Related

- Reverts: #42
- Superseded by: #52
- Addresses: #36

Generated with Claude Code (Sonnet 4.5)