### PR TITLE
Make exposed ports configurable via environment variables

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 # Magpie Artifact Storage - Docker Compose Configuration
 #
 # Services:
-# - caddy: Reverse proxy and static file server (port 8080/8443)
+# - caddy: Reverse proxy and static file server (ports configurable via env vars)
 # - magpie: FastAPI backend for API operations (internal port 8000)
 #
 # Volumes:
@@ -15,8 +15,8 @@ services:
   caddy:
     image: caddy:2-alpine
     ports:
-      - "8080:80"    # HTTP
-      - "8443:443"   # HTTPS (auto-TLS in production)
+      - "${MAGPIE_HTTP_PORT:-8080}:80"    # HTTP
+      - "${MAGPIE_HTTPS_PORT:-8443}:443"  # HTTPS (auto-TLS in production)
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile:ro
       - ./data/artifacts:/data/artifacts:ro  # Read-only for static serving

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -216,8 +216,30 @@ docker compose up -d
 ```
 
 Services:
-- **Caddy** (port 8080): Reverse proxy, TLS termination, static file serving
+- **Caddy** (port 8080 by default): Reverse proxy, TLS termination, static file serving
 - **Magpie** (internal): FastAPI backend for API operations
+
+### Port Configuration
+
+The HTTP and HTTPS ports can be customized via environment variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MAGPIE_HTTP_PORT` | `8080` | External HTTP port |
+| `MAGPIE_HTTPS_PORT` | `8443` | External HTTPS port |
+
+Example with custom ports:
+
+```bash
+MAGPIE_HTTP_PORT=80 MAGPIE_HTTPS_PORT=443 docker compose up -d
+```
+
+Or create a `.env` file in the same directory as `docker-compose.yml`:
+
+```bash
+MAGPIE_HTTP_PORT=80
+MAGPIE_HTTPS_PORT=443
+```
 
 ### First-Time Initialization
 
@@ -402,6 +424,8 @@ The artifact was already stored; the existing hash was returned.
 |----------|-------|-------------|
 | `MAGPIE_SERVER` | Client | Server URL |
 | `MAGPIE_TOKEN` | Client | Auth token |
+| `MAGPIE_HTTP_PORT` | Deploy | External HTTP port (default: 8080) |
+| `MAGPIE_HTTPS_PORT` | Deploy | External HTTPS port (default: 8443) |
 | `MAGPIE_STORAGE_PATH` | Server | Storage directory |
 | `MAGPIE_RETENTION_DAYS` | Server | GC retention period |
 | `MAGPIE_DEBUG` | Both | Enable debug mode |


### PR DESCRIPTION
## Summary
- Make HTTP and HTTPS ports configurable using `MAGPIE_HTTP_PORT` and `MAGPIE_HTTPS_PORT` environment variables
- Default values remain 8080 and 8443 for backward compatibility
- Updated header comment to reflect the configurable nature of ports

Fixes #10

## Test plan
- [ ] Verify default behavior: `docker-compose up` should expose ports 8080 and 8443
- [ ] Verify custom ports: `MAGPIE_HTTP_PORT=9080 MAGPIE_HTTPS_PORT=9443 docker-compose up` should expose ports 9080 and 9443

---
*Generated with Claude Code (Claude Opus 4.5)*