### PR TITLE
Make storage path configurable via MAGPIE_DATA_DIR env var

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,11 @@
 # - magpie: FastAPI backend for API operations (internal port 8000)
 #
 # Volumes:
-# - ./data/artifacts: Shared storage for artifact blobs and symlinks
+# - ${MAGPIE_DATA_DIR:-./data/artifacts}: Shared storage for artifact blobs and symlinks
 # - caddy_data/caddy_config: Caddy's internal state and certificates
+#
+# Configuration:
+# - MAGPIE_DATA_DIR: Host path for artifact storage (default: ./data/artifacts)
 
 services:
   # Caddy reverse proxy - handles routing and static file serving
@@ -19,7 +22,7 @@ services:
       - "8443:443"   # HTTPS (auto-TLS in production)
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile:ro
-      - ./data/artifacts:/data/artifacts:ro  # Read-only for static serving
+      - ${MAGPIE_DATA_DIR:-./data/artifacts}:/data/artifacts:ro  # Read-only for static serving
       - caddy_data:/data
       - caddy_config:/config
     depends_on:
@@ -31,7 +34,7 @@ services:
   magpie:
     build: .
     volumes:
-      - ./data/artifacts:/data/artifacts  # Read-write for uploads
+      - ${MAGPIE_DATA_DIR:-./data/artifacts}:/data/artifacts  # Read-write for uploads
     environment:
       - MAGPIE_STORAGE_PATH=/data/artifacts
       - MAGPIE_DEBUG=true


### PR DESCRIPTION
## Summary
- Makes the docker-compose.yml storage volume path configurable via the `MAGPIE_DATA_DIR` environment variable
- Uses `${MAGPIE_DATA_DIR:-./data/artifacts}` pattern with default for backward compatibility
- Applies to both caddy (:ro) and magpie volume mounts as specified in issue #9

## Test plan
- [ ] Verify docker-compose.yml syntax is valid: `docker compose config --quiet`
- [ ] Test default behavior (no env var set): `docker compose up` should use `./data/artifacts`
- [ ] Test custom path: `MAGPIE_DATA_DIR=/custom/path docker compose config` should show `/custom/path:/data/artifacts`
- [ ] Verify both caddy and magpie services use the same host path

Closes #9

---
Generated with Claude Code (Claude Opus 4.5)