### PR TITLE
Fix inconsistent path/ref separator in CLI commands

### DIFF
--- a/src/magpie/cli/commands/__init__.py
+++ b/src/magpie/cli/commands/__init__.py
@@ -6,9 +6,24 @@ from magpie.cli.commands.gc import gc
 from magpie.cli.commands.get import get
 from magpie.cli.commands.info import info
 from magpie.cli.commands.ls import ls
+from magpie.cli.commands.parse import ParseError, parse_artifact_path, parse_artifact_ref
 from magpie.cli.commands.push import push
 from magpie.cli.commands.tag import tag
 from magpie.cli.commands.untag import untag
 from magpie.cli.commands.url import url
 
-__all__ = ["amend", "flush_tag", "gc", "get", "info", "ls", "push", "tag", "untag", "url"]
+__all__ = [
+    "amend",
+    "flush_tag",
+    "gc",
+    "get",
+    "info",
+    "ls",
+    "parse_artifact_path",
+    "parse_artifact_ref",
+    "ParseError",
+    "push",
+    "tag",
+    "untag",
+    "url",
+]

--- a/src/magpie/cli/commands/amend.py
+++ b/src/magpie/cli/commands/amend.py
@@ -40,13 +40,13 @@ def amend(ctx: CLIContext, artifact_ref: str, source_uri: str | None) -> None:
         raise click.ClickException("No metadata updates specified. Use --source-uri to update.")
 
     try:
-        path, ref = parse_artifact_ref(artifact_ref)
+        parsed = parse_artifact_ref(artifact_ref)
     except ParseError as e:
         raise click.ClickException(str(e))
 
     with ctx.get_client() as client:
         if ctx.debug:
-            click.echo(f"Amending metadata for {path}:{ref}...", err=True)
+            click.echo(f"Amending metadata for {parsed.path}:{parsed.ref}...", err=True)
 
         # Build request body
         body: dict[str, str | None] = {}
@@ -55,19 +55,19 @@ def amend(ctx: CLIContext, artifact_ref: str, source_uri: str | None) -> None:
             body["source_uri"] = source_uri if source_uri else None
 
         response = client.patch(
-            f"/api/v1/artifacts/{path}/{ref}",
+            f"/api/v1/artifacts/{parsed.path}/{parsed.ref}",
             json=body,
         )
 
         if response.status_code == 404:
-            raise click.ClickException(f"Artifact not found: {path}:{ref}")
+            raise click.ClickException(f"Artifact not found: {parsed.path}:{parsed.ref}")
         if response.status_code != 200:
             _handle_error(response)
 
         data = response.json()
 
     # Display updated metadata
-    click.echo(f"Updated: {path}:{data['hash_ref']}")
+    click.echo(f"Updated: {parsed.path}:{data['hash_ref']}")
     click.echo(f"  Source URI: {data.get('source_uri') or '(none)'}")
     click.echo(f"  Tags: {', '.join(data.get('tags', []))}")
 

--- a/src/magpie/cli/commands/amend.py
+++ b/src/magpie/cli/commands/amend.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     import httpx
 
 from magpie.cli import CLIContext
-from magpie.cli.commands.get import parse_artifact_ref
+from magpie.cli.commands.parse import ParseError, parse_artifact_ref
 
 
 @click.command()
@@ -39,7 +39,10 @@ def amend(ctx: CLIContext, artifact_ref: str, source_uri: str | None) -> None:
     if source_uri is None:
         raise click.ClickException("No metadata updates specified. Use --source-uri to update.")
 
-    path, ref = parse_artifact_ref(artifact_ref)
+    try:
+        path, ref = parse_artifact_ref(artifact_ref)
+    except ParseError as e:
+        raise click.ClickException(str(e))
 
     with ctx.get_client() as client:
         if ctx.debug:

--- a/src/magpie/cli/commands/get.py
+++ b/src/magpie/cli/commands/get.py
@@ -12,29 +12,7 @@ if TYPE_CHECKING:
     import httpx
 
 from magpie.cli import CLIContext
-
-
-def parse_artifact_ref(artifact_ref: str) -> tuple[str, str]:
-    """Parse artifact reference into path and ref.
-
-    Format: path:ref or path (defaults to "latest")
-
-    Examples:
-        "images/ubuntu:latest" -> ("images/ubuntu", "latest")
-        "images/ubuntu:@abc123" -> ("images/ubuntu", "@abc123")
-        "images/ubuntu" -> ("images/ubuntu", "latest")
-
-    Args:
-        artifact_ref: Artifact reference string.
-
-    Returns:
-        Tuple of (path, ref).
-    """
-    if ":" in artifact_ref:
-        # Split on last colon to support paths with colons
-        idx = artifact_ref.rfind(":")
-        return artifact_ref[:idx], artifact_ref[idx + 1 :]
-    return artifact_ref, "latest"
+from magpie.cli.commands.parse import ParseError, parse_artifact_ref
 
 
 @click.command()
@@ -64,7 +42,10 @@ def get(
     if not ctx.server:
         raise click.ClickException("No server configured. Use --server or set MAGPIE_SERVER.")
 
-    path, ref = parse_artifact_ref(artifact_ref)
+    try:
+        path, ref = parse_artifact_ref(artifact_ref)
+    except ParseError as e:
+        raise click.ClickException(str(e))
 
     with ctx.get_client() as client:
         # Fetch metadata to get hash for verification

--- a/src/magpie/cli/commands/get.py
+++ b/src/magpie/cli/commands/get.py
@@ -43,19 +43,19 @@ def get(
         raise click.ClickException("No server configured. Use --server or set MAGPIE_SERVER.")
 
     try:
-        path, ref = parse_artifact_ref(artifact_ref)
+        parsed = parse_artifact_ref(artifact_ref)
     except ParseError as e:
         raise click.ClickException(str(e))
 
     with ctx.get_client() as client:
         # Fetch metadata to get hash for verification
         if ctx.debug:
-            click.echo(f"Fetching metadata for {path}:{ref}...", err=True)
+            click.echo(f"Fetching metadata for {parsed.path}:{parsed.ref}...", err=True)
 
-        info_response = client.get(f"/api/v1/artifacts/{path}/{ref}/info")
+        info_response = client.get(f"/api/v1/artifacts/{parsed.path}/{parsed.ref}/info")
 
         if info_response.status_code == 404:
-            raise click.ClickException(f"Artifact not found: {path}:{ref}")
+            raise click.ClickException(f"Artifact not found: {parsed.path}:{parsed.ref}")
         if info_response.status_code != 200:
             _handle_error(info_response, "metadata fetch")
 
@@ -70,9 +70,9 @@ def get(
         # Download the artifact
         # Hash refs use blobs/ subdirectory, tags are symlinks at root
         if hash_ref.startswith("@"):
-            download_url = f"/artifacts/{path}/blobs/{hash_ref.lstrip('@')}"
+            download_url = f"/artifacts/{parsed.path}/blobs/{hash_ref.lstrip('@')}"
         else:
-            download_url = f"/artifacts/{path}/{hash_ref}"
+            download_url = f"/artifacts/{parsed.path}/{hash_ref}"
 
         if ctx.debug:
             click.echo(f"Downloading from {download_url}...", err=True)
@@ -100,7 +100,7 @@ def get(
     # Determine output path
     if output is None:
         # Derive from artifact path (use last component)
-        output = Path(path.split("/")[-1])
+        output = Path(parsed.path.split("/")[-1])
 
     # Write file
     output.write_bytes(content)

--- a/src/magpie/cli/commands/info.py
+++ b/src/magpie/cli/commands/info.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     import httpx
 
 from magpie.cli import CLIContext
-from magpie.cli.commands.get import parse_artifact_ref
+from magpie.cli.commands.parse import ParseError, parse_artifact_ref
 
 
 @click.command()
@@ -33,7 +33,10 @@ def info(ctx: CLIContext, artifact_ref: str) -> None:
     if not ctx.server:
         raise click.ClickException("No server configured. Use --server or set MAGPIE_SERVER.")
 
-    path, ref = parse_artifact_ref(artifact_ref)
+    try:
+        path, ref = parse_artifact_ref(artifact_ref)
+    except ParseError as e:
+        raise click.ClickException(str(e))
 
     with ctx.get_client() as client:
         if ctx.debug:

--- a/src/magpie/cli/commands/info.py
+++ b/src/magpie/cli/commands/info.py
@@ -34,18 +34,18 @@ def info(ctx: CLIContext, artifact_ref: str) -> None:
         raise click.ClickException("No server configured. Use --server or set MAGPIE_SERVER.")
 
     try:
-        path, ref = parse_artifact_ref(artifact_ref)
+        parsed = parse_artifact_ref(artifact_ref)
     except ParseError as e:
         raise click.ClickException(str(e))
 
     with ctx.get_client() as client:
         if ctx.debug:
-            click.echo(f"Fetching info for {path}:{ref}...", err=True)
+            click.echo(f"Fetching info for {parsed.path}:{parsed.ref}...", err=True)
 
-        response = client.get(f"/api/v1/artifacts/{path}/{ref}/info")
+        response = client.get(f"/api/v1/artifacts/{parsed.path}/{parsed.ref}/info")
 
         if response.status_code == 404:
-            raise click.ClickException(f"Artifact not found: {path}:{ref}")
+            raise click.ClickException(f"Artifact not found: {parsed.path}:{parsed.ref}")
         if response.status_code != 200:
             _handle_error(response)
 

--- a/src/magpie/cli/commands/ls.py
+++ b/src/magpie/cli/commands/ls.py
@@ -10,6 +10,7 @@ if TYPE_CHECKING:
     import httpx
 
 from magpie.cli import CLIContext
+from magpie.cli.commands.parse import ParseError, parse_artifact_path
 
 
 @click.command(name="ls")
@@ -29,14 +30,20 @@ def ls(ctx: CLIContext, artifact_path: str) -> None:
     if not ctx.server:
         raise click.ClickException("No server configured. Use --server or set MAGPIE_SERVER.")
 
+    # Parse path, stripping any ref if accidentally provided
+    try:
+        path = parse_artifact_path(artifact_path)
+    except ParseError as e:
+        raise click.ClickException(str(e))
+
     with ctx.get_client() as client:
         if ctx.debug:
-            click.echo(f"Listing versions for {artifact_path}...", err=True)
+            click.echo(f"Listing versions for {path}...", err=True)
 
-        response = client.get(f"/api/v1/artifacts/{artifact_path}")
+        response = client.get(f"/api/v1/artifacts/{path}")
 
         if response.status_code == 404:
-            click.echo(f"No artifact found at: {artifact_path}")
+            click.echo(f"No artifact found at: {path}")
             return
         if response.status_code != 200:
             _handle_error(response)
@@ -46,7 +53,7 @@ def ls(ctx: CLIContext, artifact_path: str) -> None:
     versions = data.get("versions", [])
 
     if not versions:
-        click.echo(f"No versions found for: {artifact_path}")
+        click.echo(f"No versions found for: {path}")
         return
 
     # Print table header

--- a/src/magpie/cli/commands/parse.py
+++ b/src/magpie/cli/commands/parse.py
@@ -7,12 +7,15 @@ and ref:
     path:ref
 
 Examples:
-    images/ubuntu:latest       -> (images/ubuntu, latest)
-    images/ubuntu:@abc12345    -> (images/ubuntu, @abc12345)
-    images/ubuntu              -> (images/ubuntu, latest)  [default ref]
+    images/ubuntu:latest       -> ArtifactRef("images/ubuntu", "latest")
+    images/ubuntu:@abc12345    -> ArtifactRef("images/ubuntu", "@abc12345")
+    images/ubuntu              -> ArtifactRef("images/ubuntu", "latest")  [default ref]
 
 The @ prefix is used for hash references (short hashes), while bare names
 are tag references.
+
+---
+AI-generated: This module was authored with Claude Code (Opus 4.5).
 """
 
 from __future__ import annotations
@@ -56,7 +59,7 @@ class ArtifactRef:
         return self.ref.startswith("@")
 
 
-def parse_artifact_ref(artifact_ref: str, default_ref: str = "latest") -> tuple[str, str]:
+def parse_artifact_ref(artifact_ref: str, default_ref: str = "latest") -> ArtifactRef:
     """Parse artifact reference into path and ref.
 
     Format: path:ref or path (defaults to provided default_ref)
@@ -65,17 +68,17 @@ def parse_artifact_ref(artifact_ref: str, default_ref: str = "latest") -> tuple[
     canonical format that should be used consistently across all CLI commands.
 
     Examples:
-        "images/ubuntu:latest" -> ("images/ubuntu", "latest")
-        "images/ubuntu:@abc12345" -> ("images/ubuntu", "@abc12345")
-        "images/ubuntu" -> ("images/ubuntu", "latest")
-        "project/images/ubuntu:v1.0" -> ("project/images/ubuntu", "v1.0")
+        "images/ubuntu:latest" -> ArtifactRef(path="images/ubuntu", ref="latest")
+        "images/ubuntu:@abc12345" -> ArtifactRef(path="images/ubuntu", ref="@abc12345")
+        "images/ubuntu" -> ArtifactRef(path="images/ubuntu", ref="latest")
+        "project/images/ubuntu:v1.0" -> ArtifactRef(path="project/images/ubuntu", ref="v1.0")
 
     Args:
         artifact_ref: Artifact reference string in path:ref format.
         default_ref: Default ref if none specified (default: "latest").
 
     Returns:
-        Tuple of (path, ref).
+        ArtifactRef with parsed path and ref.
 
     Raises:
         ParseError: If the reference format is invalid.
@@ -87,7 +90,7 @@ def parse_artifact_ref(artifact_ref: str, default_ref: str = "latest") -> tuple[
     _validate_no_double_colon(artifact_ref)
 
     if ":" in artifact_ref:
-        # Split on last colon to support paths with colons (edge case)
+        # Split on last colon to find the path-ref separator colon
         idx = artifact_ref.rfind(":")
         path = artifact_ref[:idx]
         ref = artifact_ref[idx + 1 :]
@@ -106,7 +109,7 @@ def parse_artifact_ref(artifact_ref: str, default_ref: str = "latest") -> tuple[
     # Validate ref
     _validate_ref(ref)
 
-    return path, ref
+    return ArtifactRef(path=path, ref=ref)
 
 
 def parse_artifact_path(artifact_input: str) -> str:
@@ -132,6 +135,9 @@ def parse_artifact_path(artifact_input: str) -> str:
     """
     if not artifact_input:
         raise ParseError("Artifact path cannot be empty")
+
+    # Check for common mistakes
+    _validate_no_double_colon(artifact_input)
 
     # Normalize: strip leading slashes
     path = artifact_input.lstrip("/")

--- a/src/magpie/cli/commands/parse.py
+++ b/src/magpie/cli/commands/parse.py
@@ -1,0 +1,223 @@
+"""Artifact reference parsing utilities for CLI commands.
+
+This module provides consistent parsing of artifact references across all CLI
+commands. The canonical format uses colon (:) as the separator between path
+and ref:
+
+    path:ref
+
+Examples:
+    images/ubuntu:latest       -> (images/ubuntu, latest)
+    images/ubuntu:@abc12345    -> (images/ubuntu, @abc12345)
+    images/ubuntu              -> (images/ubuntu, latest)  [default ref]
+
+The @ prefix is used for hash references (short hashes), while bare names
+are tag references.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+# Pattern for validating hash refs: @ followed by 8 hex characters
+HASH_REF_PATTERN = re.compile(r"^@[0-9a-f]{8}$")
+
+# Pattern for valid tag names: alphanumeric, dash, underscore, dot
+# Must start with alphanumeric
+TAG_PATTERN = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._-]*$")
+
+# Pattern for valid path components: same as tags
+PATH_COMPONENT_PATTERN = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._-]*$")
+
+
+class ParseError(Exception):
+    """Error parsing artifact reference."""
+
+    pass
+
+
+@dataclass
+class ArtifactRef:
+    """Parsed artifact reference.
+
+    Attributes:
+        path: Artifact path (e.g., "images/ubuntu").
+        ref: Reference to a specific version - either a tag name (e.g., "latest")
+             or a hash ref (e.g., "@abc12345").
+    """
+
+    path: str
+    ref: str
+
+    @property
+    def is_hash_ref(self) -> bool:
+        """Check if ref is a hash reference (starts with @)."""
+        return self.ref.startswith("@")
+
+
+def parse_artifact_ref(artifact_ref: str, default_ref: str = "latest") -> tuple[str, str]:
+    """Parse artifact reference into path and ref.
+
+    Format: path:ref or path (defaults to provided default_ref)
+
+    Uses colon (:) as the separator between path and ref. This is the
+    canonical format that should be used consistently across all CLI commands.
+
+    Examples:
+        "images/ubuntu:latest" -> ("images/ubuntu", "latest")
+        "images/ubuntu:@abc12345" -> ("images/ubuntu", "@abc12345")
+        "images/ubuntu" -> ("images/ubuntu", "latest")
+        "project/images/ubuntu:v1.0" -> ("project/images/ubuntu", "v1.0")
+
+    Args:
+        artifact_ref: Artifact reference string in path:ref format.
+        default_ref: Default ref if none specified (default: "latest").
+
+    Returns:
+        Tuple of (path, ref).
+
+    Raises:
+        ParseError: If the reference format is invalid.
+    """
+    if not artifact_ref:
+        raise ParseError("Artifact reference cannot be empty")
+
+    # Check for common mistakes
+    _validate_no_double_colon(artifact_ref)
+
+    if ":" in artifact_ref:
+        # Split on last colon to support paths with colons (edge case)
+        idx = artifact_ref.rfind(":")
+        path = artifact_ref[:idx]
+        ref = artifact_ref[idx + 1 :]
+
+        if not path:
+            raise ParseError(f"Empty path in reference: {artifact_ref}")
+        if not ref:
+            raise ParseError(f"Empty ref after colon in reference: {artifact_ref}")
+    else:
+        path = artifact_ref
+        ref = default_ref
+
+    # Validate path
+    _validate_path(path)
+
+    # Validate ref
+    _validate_ref(ref)
+
+    return path, ref
+
+
+def parse_artifact_path(artifact_input: str) -> str:
+    """Parse artifact path, stripping any ref if accidentally provided.
+
+    This is for commands that only accept a path (like `ls`). If the user
+    provides a ref (path:ref format), the ref is stripped and only the
+    path is returned.
+
+    Examples:
+        "images/ubuntu" -> "images/ubuntu"
+        "images/ubuntu:latest" -> "images/ubuntu" (ref stripped)
+
+    Args:
+        artifact_input: Artifact path or path:ref string.
+
+    Returns:
+        Just the artifact path.
+
+    Raises:
+        ParseError: If the path format is invalid.
+    """
+    if not artifact_input:
+        raise ParseError("Artifact path cannot be empty")
+
+    # If there's a colon, extract just the path
+    if ":" in artifact_input:
+        idx = artifact_input.rfind(":")
+        path = artifact_input[:idx]
+        # Note: We silently accept and strip the ref for UX
+    else:
+        path = artifact_input
+
+    if not path:
+        raise ParseError(f"Empty path in input: {artifact_input}")
+
+    # Validate path
+    _validate_path(path)
+
+    return path
+
+
+def _validate_no_double_colon(artifact_ref: str) -> None:
+    """Check for double colon which indicates a parsing error.
+
+    This catches cases like "path/artifact:latest:latest" which could happen
+    if a ref is accidentally appended twice.
+    """
+    if artifact_ref.count(":") > 1:
+        raise ParseError(
+            f"Multiple colons in reference '{artifact_ref}'. "
+            f"Expected format: path:ref (e.g., 'images/ubuntu:latest')"
+        )
+
+
+def _validate_path(path: str) -> None:
+    """Validate artifact path format.
+
+    Path components must be alphanumeric (with dash, underscore, dot allowed).
+    Each component must start with an alphanumeric character.
+    """
+    if not path:
+        raise ParseError("Path cannot be empty")
+
+    # Split path into components
+    components = path.split("/")
+
+    for component in components:
+        if not component:
+            raise ParseError(f"Empty component in path '{path}' (double slash?)")
+
+        if not PATH_COMPONENT_PATTERN.match(component):
+            raise ParseError(
+                f"Invalid path component '{component}' in '{path}'. "
+                f"Components must start with alphanumeric and contain only "
+                f"alphanumeric, dash, underscore, or dot characters."
+            )
+
+
+def _validate_ref(ref: str) -> None:
+    """Validate ref format (tag name or hash ref).
+
+    Hash refs start with @ followed by 8 hex characters.
+    Tag names are alphanumeric with dash, underscore, dot allowed.
+    """
+    if not ref:
+        raise ParseError("Ref cannot be empty")
+
+    if ref.startswith("@"):
+        # Hash ref - must be @ followed by 8 hex chars
+        if not HASH_REF_PATTERN.match(ref):
+            # Provide helpful error for common mistakes
+            if len(ref) < 9:
+                raise ParseError(
+                    f"Invalid hash ref '{ref}'. Hash refs must be @ followed by "
+                    f"exactly 8 hex characters (e.g., '@abc12345')."
+                )
+            elif len(ref) > 9:
+                raise ParseError(
+                    f"Hash ref '{ref}' is too long. Use the short form with "
+                    f"8 hex characters (e.g., '@{ref[1:9]}')."
+                )
+            else:
+                raise ParseError(
+                    f"Invalid hash ref '{ref}'. Must contain only hex characters "
+                    f"(0-9, a-f) after the @ symbol."
+                )
+    else:
+        # Tag name
+        if not TAG_PATTERN.match(ref):
+            raise ParseError(
+                f"Invalid tag name '{ref}'. Tags must start with alphanumeric "
+                f"and contain only alphanumeric, dash, underscore, or dot characters."
+            )

--- a/src/magpie/cli/commands/tag.py
+++ b/src/magpie/cli/commands/tag.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     import httpx
 
 from magpie.cli import CLIContext
-from magpie.cli.commands.get import parse_artifact_ref
+from magpie.cli.commands.parse import ParseError, parse_artifact_ref
 
 
 @click.command()
@@ -34,7 +34,10 @@ def tag(ctx: CLIContext, artifact_ref: str, tag_name: str) -> None:
     if not ctx.server:
         raise click.ClickException("No server configured. Use --server or set MAGPIE_SERVER.")
 
-    path, ref = parse_artifact_ref(artifact_ref)
+    try:
+        path, ref = parse_artifact_ref(artifact_ref)
+    except ParseError as e:
+        raise click.ClickException(str(e))
 
     with ctx.get_client() as client:
         if ctx.debug:

--- a/src/magpie/cli/commands/tag.py
+++ b/src/magpie/cli/commands/tag.py
@@ -35,21 +35,21 @@ def tag(ctx: CLIContext, artifact_ref: str, tag_name: str) -> None:
         raise click.ClickException("No server configured. Use --server or set MAGPIE_SERVER.")
 
     try:
-        path, ref = parse_artifact_ref(artifact_ref)
+        parsed = parse_artifact_ref(artifact_ref)
     except ParseError as e:
         raise click.ClickException(str(e))
 
     with ctx.get_client() as client:
         if ctx.debug:
-            click.echo(f"Creating tag '{tag_name}' on {path}:{ref}...", err=True)
+            click.echo(f"Creating tag '{tag_name}' on {parsed.path}:{parsed.ref}...", err=True)
 
         response = client.post(
-            f"/api/v1/artifacts/{path}/{ref}/tags",
+            f"/api/v1/artifacts/{parsed.path}/{parsed.ref}/tags",
             json={"tag_name": tag_name},
         )
 
         if response.status_code == 404:
-            raise click.ClickException(f"Artifact not found: {path}:{ref}")
+            raise click.ClickException(f"Artifact not found: {parsed.path}:{parsed.ref}")
         if response.status_code != 200:
             _handle_error(response)
 

--- a/src/magpie/cli/commands/url.py
+++ b/src/magpie/cli/commands/url.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     import httpx
 
 from magpie.cli import CLIContext
-from magpie.cli.commands.get import parse_artifact_ref
+from magpie.cli.commands.parse import ParseError, parse_artifact_ref
 
 
 @click.command()
@@ -35,7 +35,10 @@ def url(ctx: CLIContext, artifact_ref: str) -> None:
     if not ctx.server:
         raise click.ClickException("No server configured. Use --server or set MAGPIE_SERVER.")
 
-    path, ref = parse_artifact_ref(artifact_ref)
+    try:
+        path, ref = parse_artifact_ref(artifact_ref)
+    except ParseError as e:
+        raise click.ClickException(str(e))
 
     with ctx.get_client() as client:
         if ctx.debug:

--- a/src/magpie/cli/commands/url.py
+++ b/src/magpie/cli/commands/url.py
@@ -36,19 +36,19 @@ def url(ctx: CLIContext, artifact_ref: str) -> None:
         raise click.ClickException("No server configured. Use --server or set MAGPIE_SERVER.")
 
     try:
-        path, ref = parse_artifact_ref(artifact_ref)
+        parsed = parse_artifact_ref(artifact_ref)
     except ParseError as e:
         raise click.ClickException(str(e))
 
     with ctx.get_client() as client:
         if ctx.debug:
-            click.echo(f"Resolving {path}:{ref}...", err=True)
+            click.echo(f"Resolving {parsed.path}:{parsed.ref}...", err=True)
 
         # Get info to resolve ref to hash_ref
-        response = client.get(f"/api/v1/artifacts/{path}/{ref}/info")
+        response = client.get(f"/api/v1/artifacts/{parsed.path}/{parsed.ref}/info")
 
         if response.status_code == 404:
-            raise click.ClickException(f"Artifact not found: {path}:{ref}")
+            raise click.ClickException(f"Artifact not found: {parsed.path}:{parsed.ref}")
         if response.status_code != 200:
             _handle_error(response)
 
@@ -56,7 +56,7 @@ def url(ctx: CLIContext, artifact_ref: str) -> None:
         hash_ref = data["hash_ref"]
 
     # Output bare URL (no newline issues - click.echo adds one)
-    download_url = f"{ctx.server}/artifacts/{path}/{hash_ref}"
+    download_url = f"{ctx.server}/artifacts/{parsed.path}/{hash_ref}"
     click.echo(download_url)
 
 

--- a/tests/integration/test_cli_push_get.py
+++ b/tests/integration/test_cli_push_get.py
@@ -16,7 +16,7 @@ from click.testing import CliRunner
 from fastapi.testclient import TestClient
 
 from magpie.cli import cli
-from magpie.cli.commands.get import parse_artifact_ref
+from magpie.cli.commands.parse import parse_artifact_ref
 from magpie.config import MagpieSettings
 from magpie.server.app import app
 from magpie.server.deps import get_storage_service

--- a/tests/integration/test_cli_push_get.py
+++ b/tests/integration/test_cli_push_get.py
@@ -133,27 +133,27 @@ class TestParseArtifactRef:
 
     def test_parse_with_ref(self) -> None:
         """Parse artifact reference with explicit ref."""
-        path, ref = parse_artifact_ref("images/ubuntu:latest")
-        assert path == "images/ubuntu"
-        assert ref == "latest"
+        result = parse_artifact_ref("images/ubuntu:latest")
+        assert result.path == "images/ubuntu"
+        assert result.ref == "latest"
 
     def test_parse_with_hash_ref(self) -> None:
         """Parse artifact reference with hash ref."""
-        path, ref = parse_artifact_ref("images/ubuntu:@abc12345")
-        assert path == "images/ubuntu"
-        assert ref == "@abc12345"
+        result = parse_artifact_ref("images/ubuntu:@abc12345")
+        assert result.path == "images/ubuntu"
+        assert result.ref == "@abc12345"
 
     def test_parse_without_ref_defaults_to_latest(self) -> None:
         """Parse artifact reference without ref defaults to latest."""
-        path, ref = parse_artifact_ref("images/ubuntu")
-        assert path == "images/ubuntu"
-        assert ref == "latest"
+        result = parse_artifact_ref("images/ubuntu")
+        assert result.path == "images/ubuntu"
+        assert result.ref == "latest"
 
     def test_parse_nested_path_with_ref(self) -> None:
         """Parse nested path with ref."""
-        path, ref = parse_artifact_ref("project/images/ubuntu:v1.0")
-        assert path == "project/images/ubuntu"
-        assert ref == "v1.0"
+        result = parse_artifact_ref("project/images/ubuntu:v1.0")
+        assert result.path == "project/images/ubuntu"
+        assert result.ref == "v1.0"
 
 
 class TestPushCommand:

--- a/tests/unit/test_parse.py
+++ b/tests/unit/test_parse.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 
 from magpie.cli.commands.parse import (
+    ArtifactRef,
     ParseError,
     parse_artifact_path,
     parse_artifact_ref,
@@ -16,57 +17,57 @@ class TestParseArtifactRef:
 
     def test_parse_with_tag_ref(self) -> None:
         """Parse artifact reference with tag ref."""
-        path, ref = parse_artifact_ref("images/ubuntu:latest")
-        assert path == "images/ubuntu"
-        assert ref == "latest"
+        result = parse_artifact_ref("images/ubuntu:latest")
+        assert result.path == "images/ubuntu"
+        assert result.ref == "latest"
 
     def test_parse_with_hash_ref(self) -> None:
         """Parse artifact reference with hash ref."""
-        path, ref = parse_artifact_ref("images/ubuntu:@abc12345")
-        assert path == "images/ubuntu"
-        assert ref == "@abc12345"
+        result = parse_artifact_ref("images/ubuntu:@abc12345")
+        assert result.path == "images/ubuntu"
+        assert result.ref == "@abc12345"
 
     def test_parse_without_ref_defaults_to_latest(self) -> None:
         """Parse artifact reference without ref defaults to latest."""
-        path, ref = parse_artifact_ref("images/ubuntu")
-        assert path == "images/ubuntu"
-        assert ref == "latest"
+        result = parse_artifact_ref("images/ubuntu")
+        assert result.path == "images/ubuntu"
+        assert result.ref == "latest"
 
     def test_parse_with_custom_default_ref(self) -> None:
         """Parse with custom default ref."""
-        path, ref = parse_artifact_ref("images/ubuntu", default_ref="stable")
-        assert path == "images/ubuntu"
-        assert ref == "stable"
+        result = parse_artifact_ref("images/ubuntu", default_ref="stable")
+        assert result.path == "images/ubuntu"
+        assert result.ref == "stable"
 
     def test_parse_nested_path_with_ref(self) -> None:
         """Parse nested path with ref."""
-        path, ref = parse_artifact_ref("project/images/ubuntu:v1.0")
-        assert path == "project/images/ubuntu"
-        assert ref == "v1.0"
+        result = parse_artifact_ref("project/images/ubuntu:v1.0")
+        assert result.path == "project/images/ubuntu"
+        assert result.ref == "v1.0"
 
     def test_parse_deeply_nested_path(self) -> None:
         """Parse deeply nested path."""
-        path, ref = parse_artifact_ref("org/team/project/component:release-2.0")
-        assert path == "org/team/project/component"
-        assert ref == "release-2.0"
+        result = parse_artifact_ref("org/team/project/component:release-2.0")
+        assert result.path == "org/team/project/component"
+        assert result.ref == "release-2.0"
 
     def test_parse_simple_path(self) -> None:
         """Parse simple single-component path."""
-        path, ref = parse_artifact_ref("myartifact:v1")
-        assert path == "myartifact"
-        assert ref == "v1"
+        result = parse_artifact_ref("myartifact:v1")
+        assert result.path == "myartifact"
+        assert result.ref == "v1"
 
     def test_parse_path_with_dashes_and_underscores(self) -> None:
         """Parse path with dashes and underscores."""
-        path, ref = parse_artifact_ref("my-project/my_artifact:stable-release")
-        assert path == "my-project/my_artifact"
-        assert ref == "stable-release"
+        result = parse_artifact_ref("my-project/my_artifact:stable-release")
+        assert result.path == "my-project/my_artifact"
+        assert result.ref == "stable-release"
 
     def test_parse_path_with_dots(self) -> None:
         """Parse path with dots."""
-        path, ref = parse_artifact_ref("com.example/artifact.v2:1.0.0")
-        assert path == "com.example/artifact.v2"
-        assert ref == "1.0.0"
+        result = parse_artifact_ref("com.example/artifact.v2:1.0.0")
+        assert result.path == "com.example/artifact.v2"
+        assert result.ref == "1.0.0"
 
 
 class TestParseArtifactRefErrors:
@@ -123,18 +124,18 @@ class TestParseArtifactRefHashRefs:
 
     def test_valid_hash_ref(self) -> None:
         """Valid 8-char hex hash ref parses correctly."""
-        path, ref = parse_artifact_ref("images/ubuntu:@a1b2c3d4")
-        assert ref == "@a1b2c3d4"
+        result = parse_artifact_ref("images/ubuntu:@a1b2c3d4")
+        assert result.ref == "@a1b2c3d4"
 
     def test_valid_hash_ref_all_digits(self) -> None:
         """Hash ref with all digits parses correctly."""
-        path, ref = parse_artifact_ref("images/ubuntu:@12345678")
-        assert ref == "@12345678"
+        result = parse_artifact_ref("images/ubuntu:@12345678")
+        assert result.ref == "@12345678"
 
     def test_valid_hash_ref_all_letters(self) -> None:
         """Hash ref with all hex letters parses correctly."""
-        path, ref = parse_artifact_ref("images/ubuntu:@abcdefab")
-        assert ref == "@abcdefab"
+        result = parse_artifact_ref("images/ubuntu:@abcdefab")
+        assert result.ref == "@abcdefab"
 
     def test_hash_ref_too_short_raises_error(self) -> None:
         """Hash ref shorter than 8 chars raises error."""
@@ -200,49 +201,80 @@ class TestParseArtifactPath:
         with pytest.raises(ParseError, match="Invalid path component"):
             parse_artifact_path("-invalid/path")
 
+    def test_double_colon_raises_error(self) -> None:
+        """Double colon raises ParseError for parse_artifact_path."""
+        with pytest.raises(ParseError, match="Multiple colons"):
+            parse_artifact_path("images/ubuntu:latest:v1")
+
+
+class TestArtifactRefDataclass:
+    """Tests for ArtifactRef dataclass."""
+
+    def test_is_hash_ref_true_for_hash(self) -> None:
+        """is_hash_ref returns True for hash refs."""
+        result = parse_artifact_ref("images/ubuntu:@abc12345")
+        assert result.is_hash_ref is True
+
+    def test_is_hash_ref_false_for_tag(self) -> None:
+        """is_hash_ref returns False for tag refs."""
+        result = parse_artifact_ref("images/ubuntu:latest")
+        assert result.is_hash_ref is False
+
+    def test_artifact_ref_equality(self) -> None:
+        """ArtifactRef dataclass supports equality."""
+        ref1 = ArtifactRef(path="images/ubuntu", ref="latest")
+        ref2 = ArtifactRef(path="images/ubuntu", ref="latest")
+        assert ref1 == ref2
+
+    def test_artifact_ref_repr(self) -> None:
+        """ArtifactRef has readable repr."""
+        ref = ArtifactRef(path="images/ubuntu", ref="latest")
+        assert "images/ubuntu" in repr(ref)
+        assert "latest" in repr(ref)
+
 
 class TestParseEdgeCases:
     """Edge case tests for parsing."""
 
     def test_single_component_path(self) -> None:
         """Single component (no slashes) path."""
-        path, ref = parse_artifact_ref("artifact:v1")
-        assert path == "artifact"
-        assert ref == "v1"
+        result = parse_artifact_ref("artifact:v1")
+        assert result.path == "artifact"
+        assert result.ref == "v1"
 
     def test_single_component_path_no_ref(self) -> None:
         """Single component path without ref."""
-        path, ref = parse_artifact_ref("artifact")
-        assert path == "artifact"
-        assert ref == "latest"
+        result = parse_artifact_ref("artifact")
+        assert result.path == "artifact"
+        assert result.ref == "latest"
 
     def test_numeric_path_component(self) -> None:
         """Numeric path component is valid."""
-        path, ref = parse_artifact_ref("v2/images/ubuntu:latest")
-        assert path == "v2/images/ubuntu"
-        assert ref == "latest"
+        result = parse_artifact_ref("v2/images/ubuntu:latest")
+        assert result.path == "v2/images/ubuntu"
+        assert result.ref == "latest"
 
     def test_numeric_tag(self) -> None:
         """Numeric tag is valid."""
-        path, ref = parse_artifact_ref("images/ubuntu:20230101")
-        assert path == "images/ubuntu"
-        assert ref == "20230101"
+        result = parse_artifact_ref("images/ubuntu:20230101")
+        assert result.path == "images/ubuntu"
+        assert result.ref == "20230101"
 
     def test_very_long_path(self) -> None:
         """Very long path parses correctly."""
         long_path = "/".join(f"component{i}" for i in range(10))
-        path, ref = parse_artifact_ref(f"{long_path}:latest")
-        assert path == long_path
-        assert ref == "latest"
+        result = parse_artifact_ref(f"{long_path}:latest")
+        assert result.path == long_path
+        assert result.ref == "latest"
 
     def test_tag_with_version_dots(self) -> None:
         """Tag with version-style dots parses correctly."""
-        path, ref = parse_artifact_ref("images/ubuntu:22.04.1")
-        assert path == "images/ubuntu"
-        assert ref == "22.04.1"
+        result = parse_artifact_ref("images/ubuntu:22.04.1")
+        assert result.path == "images/ubuntu"
+        assert result.ref == "22.04.1"
 
     def test_semver_tag(self) -> None:
         """Semantic version tag parses correctly."""
-        path, ref = parse_artifact_ref("app/release:v1.2.3-rc1")
-        assert path == "app/release"
-        assert ref == "v1.2.3-rc1"
+        result = parse_artifact_ref("app/release:v1.2.3-rc1")
+        assert result.path == "app/release"
+        assert result.ref == "v1.2.3-rc1"

--- a/tests/unit/test_parse.py
+++ b/tests/unit/test_parse.py
@@ -1,0 +1,248 @@
+"""Unit tests for artifact reference parsing."""
+
+from __future__ import annotations
+
+import pytest
+
+from magpie.cli.commands.parse import (
+    ParseError,
+    parse_artifact_path,
+    parse_artifact_ref,
+)
+
+
+class TestParseArtifactRef:
+    """Tests for parse_artifact_ref function."""
+
+    def test_parse_with_tag_ref(self) -> None:
+        """Parse artifact reference with tag ref."""
+        path, ref = parse_artifact_ref("images/ubuntu:latest")
+        assert path == "images/ubuntu"
+        assert ref == "latest"
+
+    def test_parse_with_hash_ref(self) -> None:
+        """Parse artifact reference with hash ref."""
+        path, ref = parse_artifact_ref("images/ubuntu:@abc12345")
+        assert path == "images/ubuntu"
+        assert ref == "@abc12345"
+
+    def test_parse_without_ref_defaults_to_latest(self) -> None:
+        """Parse artifact reference without ref defaults to latest."""
+        path, ref = parse_artifact_ref("images/ubuntu")
+        assert path == "images/ubuntu"
+        assert ref == "latest"
+
+    def test_parse_with_custom_default_ref(self) -> None:
+        """Parse with custom default ref."""
+        path, ref = parse_artifact_ref("images/ubuntu", default_ref="stable")
+        assert path == "images/ubuntu"
+        assert ref == "stable"
+
+    def test_parse_nested_path_with_ref(self) -> None:
+        """Parse nested path with ref."""
+        path, ref = parse_artifact_ref("project/images/ubuntu:v1.0")
+        assert path == "project/images/ubuntu"
+        assert ref == "v1.0"
+
+    def test_parse_deeply_nested_path(self) -> None:
+        """Parse deeply nested path."""
+        path, ref = parse_artifact_ref("org/team/project/component:release-2.0")
+        assert path == "org/team/project/component"
+        assert ref == "release-2.0"
+
+    def test_parse_simple_path(self) -> None:
+        """Parse simple single-component path."""
+        path, ref = parse_artifact_ref("myartifact:v1")
+        assert path == "myartifact"
+        assert ref == "v1"
+
+    def test_parse_path_with_dashes_and_underscores(self) -> None:
+        """Parse path with dashes and underscores."""
+        path, ref = parse_artifact_ref("my-project/my_artifact:stable-release")
+        assert path == "my-project/my_artifact"
+        assert ref == "stable-release"
+
+    def test_parse_path_with_dots(self) -> None:
+        """Parse path with dots."""
+        path, ref = parse_artifact_ref("com.example/artifact.v2:1.0.0")
+        assert path == "com.example/artifact.v2"
+        assert ref == "1.0.0"
+
+
+class TestParseArtifactRefErrors:
+    """Tests for error handling in parse_artifact_ref."""
+
+    def test_empty_reference_raises_error(self) -> None:
+        """Empty reference raises ParseError."""
+        with pytest.raises(ParseError, match="cannot be empty"):
+            parse_artifact_ref("")
+
+    def test_double_colon_raises_error(self) -> None:
+        """Double colon raises ParseError with helpful message."""
+        with pytest.raises(ParseError, match="Multiple colons"):
+            parse_artifact_ref("images/ubuntu:latest:latest")
+
+    def test_empty_path_raises_error(self) -> None:
+        """Empty path (just :ref) raises ParseError."""
+        with pytest.raises(ParseError, match="Empty path"):
+            parse_artifact_ref(":latest")
+
+    def test_empty_ref_after_colon_raises_error(self) -> None:
+        """Empty ref after colon raises ParseError."""
+        with pytest.raises(ParseError, match="Empty ref after colon"):
+            parse_artifact_ref("images/ubuntu:")
+
+    def test_double_slash_in_path_raises_error(self) -> None:
+        """Double slash in path raises ParseError."""
+        with pytest.raises(ParseError, match="Empty component"):
+            parse_artifact_ref("images//ubuntu:latest")
+
+    def test_invalid_path_component_starting_char(self) -> None:
+        """Path component starting with non-alphanumeric raises error."""
+        with pytest.raises(ParseError, match="Invalid path component"):
+            parse_artifact_ref("-invalid/path:latest")
+
+    def test_invalid_path_component_special_char(self) -> None:
+        """Path component with special characters raises error."""
+        with pytest.raises(ParseError, match="Invalid path component"):
+            parse_artifact_ref("invalid@path/artifact:latest")
+
+    def test_invalid_tag_name_starting_char(self) -> None:
+        """Tag starting with non-alphanumeric raises error."""
+        with pytest.raises(ParseError, match="Invalid tag name"):
+            parse_artifact_ref("images/ubuntu:-invalid")
+
+    def test_invalid_tag_name_special_char(self) -> None:
+        """Tag with special characters raises error."""
+        with pytest.raises(ParseError, match="Invalid tag name"):
+            parse_artifact_ref("images/ubuntu:my@tag")
+
+
+class TestParseArtifactRefHashRefs:
+    """Tests for hash ref parsing."""
+
+    def test_valid_hash_ref(self) -> None:
+        """Valid 8-char hex hash ref parses correctly."""
+        path, ref = parse_artifact_ref("images/ubuntu:@a1b2c3d4")
+        assert ref == "@a1b2c3d4"
+
+    def test_valid_hash_ref_all_digits(self) -> None:
+        """Hash ref with all digits parses correctly."""
+        path, ref = parse_artifact_ref("images/ubuntu:@12345678")
+        assert ref == "@12345678"
+
+    def test_valid_hash_ref_all_letters(self) -> None:
+        """Hash ref with all hex letters parses correctly."""
+        path, ref = parse_artifact_ref("images/ubuntu:@abcdefab")
+        assert ref == "@abcdefab"
+
+    def test_hash_ref_too_short_raises_error(self) -> None:
+        """Hash ref shorter than 8 chars raises error."""
+        with pytest.raises(ParseError, match="exactly 8 hex characters"):
+            parse_artifact_ref("images/ubuntu:@abc123")
+
+    def test_hash_ref_too_long_raises_error(self) -> None:
+        """Hash ref longer than 8 chars raises error with suggestion."""
+        with pytest.raises(ParseError, match="too long.*@a1b2c3d4"):
+            parse_artifact_ref("images/ubuntu:@a1b2c3d4e5f6")
+
+    def test_hash_ref_invalid_chars_raises_error(self) -> None:
+        """Hash ref with non-hex chars raises error."""
+        with pytest.raises(ParseError, match="hex characters"):
+            parse_artifact_ref("images/ubuntu:@abcdefgh")
+
+    def test_hash_ref_uppercase_raises_error(self) -> None:
+        """Hash ref with uppercase raises error (must be lowercase)."""
+        with pytest.raises(ParseError, match="hex characters"):
+            parse_artifact_ref("images/ubuntu:@ABCD1234")
+
+
+class TestParseArtifactPath:
+    """Tests for parse_artifact_path function."""
+
+    def test_parse_simple_path(self) -> None:
+        """Parse simple path."""
+        path = parse_artifact_path("images/ubuntu")
+        assert path == "images/ubuntu"
+
+    def test_parse_path_strips_ref(self) -> None:
+        """Parse path with ref strips the ref."""
+        path = parse_artifact_path("images/ubuntu:latest")
+        assert path == "images/ubuntu"
+
+    def test_parse_path_strips_hash_ref(self) -> None:
+        """Parse path with hash ref strips the ref."""
+        path = parse_artifact_path("images/ubuntu:@abc12345")
+        assert path == "images/ubuntu"
+
+    def test_parse_nested_path(self) -> None:
+        """Parse nested path."""
+        path = parse_artifact_path("project/images/ubuntu")
+        assert path == "project/images/ubuntu"
+
+    def test_parse_nested_path_strips_ref(self) -> None:
+        """Parse nested path with ref strips the ref."""
+        path = parse_artifact_path("project/images/ubuntu:v1.0")
+        assert path == "project/images/ubuntu"
+
+    def test_empty_path_raises_error(self) -> None:
+        """Empty path raises ParseError."""
+        with pytest.raises(ParseError, match="cannot be empty"):
+            parse_artifact_path("")
+
+    def test_only_ref_raises_error(self) -> None:
+        """Only a ref (no path) raises ParseError."""
+        with pytest.raises(ParseError, match="Empty path"):
+            parse_artifact_path(":latest")
+
+    def test_invalid_path_component_raises_error(self) -> None:
+        """Invalid path component raises ParseError."""
+        with pytest.raises(ParseError, match="Invalid path component"):
+            parse_artifact_path("-invalid/path")
+
+
+class TestParseEdgeCases:
+    """Edge case tests for parsing."""
+
+    def test_single_component_path(self) -> None:
+        """Single component (no slashes) path."""
+        path, ref = parse_artifact_ref("artifact:v1")
+        assert path == "artifact"
+        assert ref == "v1"
+
+    def test_single_component_path_no_ref(self) -> None:
+        """Single component path without ref."""
+        path, ref = parse_artifact_ref("artifact")
+        assert path == "artifact"
+        assert ref == "latest"
+
+    def test_numeric_path_component(self) -> None:
+        """Numeric path component is valid."""
+        path, ref = parse_artifact_ref("v2/images/ubuntu:latest")
+        assert path == "v2/images/ubuntu"
+        assert ref == "latest"
+
+    def test_numeric_tag(self) -> None:
+        """Numeric tag is valid."""
+        path, ref = parse_artifact_ref("images/ubuntu:20230101")
+        assert path == "images/ubuntu"
+        assert ref == "20230101"
+
+    def test_very_long_path(self) -> None:
+        """Very long path parses correctly."""
+        long_path = "/".join(f"component{i}" for i in range(10))
+        path, ref = parse_artifact_ref(f"{long_path}:latest")
+        assert path == long_path
+        assert ref == "latest"
+
+    def test_tag_with_version_dots(self) -> None:
+        """Tag with version-style dots parses correctly."""
+        path, ref = parse_artifact_ref("images/ubuntu:22.04.1")
+        assert path == "images/ubuntu"
+        assert ref == "22.04.1"
+
+    def test_semver_tag(self) -> None:
+        """Semantic version tag parses correctly."""
+        path, ref = parse_artifact_ref("app/release:v1.2.3-rc1")
+        assert path == "app/release"
+        assert ref == "v1.2.3-rc1"


### PR DESCRIPTION
## Summary

- Create dedicated `parse.py` module with `parse_artifact_ref()` and `parse_artifact_path()` functions
- Implement consistent colon (`:`) separator for all CLI commands that take artifact references
- Add validation for `@hash` refs (exactly 8 hex characters)
- Update `ls` command to strip refs if accidentally provided (e.g., `magpie ls images/ubuntu:latest` now works correctly)
- Add helpful error messages for common parsing mistakes

## Test plan

- [x] All 540 existing tests pass
- [x] Added 40 new unit tests for parsing in `tests/unit/test_parse.py`
- [x] Tested error messages for:
  - Double colons (`path:ref:ref`)
  - Invalid hash refs (wrong length, non-hex chars)
  - Invalid path components
  - Invalid tag names

Fixes #22

---
Generated with Claude Code (Claude Opus 4.5)