### PR TITLE
Add progress bars for push/get operations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "sentry-sdk[fastapi]",
     "opentelemetry-instrumentation-fastapi",
     "opentelemetry-exporter-otlp",
+    "rich",
 ]
 
 [project.scripts]

--- a/src/magpie/cli/commands/get.py
+++ b/src/magpie/cli/commands/get.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
     import httpx
 
 from magpie.cli import CLIContext
+from magpie.cli.progress import transfer_progress
 
 
 def parse_artifact_ref(artifact_ref: str) -> tuple[str, str]:
@@ -41,12 +42,14 @@ def parse_artifact_ref(artifact_ref: str) -> tuple[str, str]:
 @click.argument("artifact_ref")
 @click.option("-o", "--output", type=click.Path(path_type=Path), help="Output file path.")
 @click.option("--no-verify", is_flag=True, help="Skip SHA-256 verification.")
+@click.option("--quiet", "-q", is_flag=True, help="Suppress progress output.")
 @click.pass_obj
 def get(
     ctx: CLIContext,
     artifact_ref: str,
     output: Path | None,
     no_verify: bool,
+    quiet: bool,
 ) -> None:
     """Download an artifact from the server.
 
@@ -67,7 +70,7 @@ def get(
     path, ref = parse_artifact_ref(artifact_ref)
 
     with ctx.get_client() as client:
-        # Fetch metadata to get hash for verification
+        # Fetch metadata to get hash and size for verification/progress
         if ctx.debug:
             click.echo(f"Fetching metadata for {path}:{ref}...", err=True)
 
@@ -81,10 +84,12 @@ def get(
         info = info_response.json()
         expected_hash = info["hash"]
         hash_ref = info["hash_ref"]
+        file_size = info.get("size", 0)
 
         if ctx.debug:
             click.echo(f"Hash: {expected_hash}", err=True)
             click.echo(f"Hash ref: {hash_ref}", err=True)
+            click.echo(f"Size: {file_size} bytes", err=True)
 
         # Download the artifact
         # Hash refs use blobs/ subdirectory, tags are symlinks at root
@@ -96,14 +101,28 @@ def get(
         if ctx.debug:
             click.echo(f"Downloading from {download_url}...", err=True)
 
-        download_response = client.get(download_url)
+        # Use streaming download with progress
+        chunks: list[bytes] = []
+        with client.stream("GET", download_url) as response:
+            if response.status_code == 404:
+                raise click.ClickException(f"Artifact blob not found: {hash_ref}")
+            if response.status_code != 200:
+                # Read response body for error message
+                response.read()
+                _handle_error(response, "download")
 
-        if download_response.status_code == 404:
-            raise click.ClickException(f"Artifact blob not found: {hash_ref}")
-        if download_response.status_code != 200:
-            _handle_error(download_response, "download")
+            # Get content length from header if available (may be more accurate)
+            content_length = response.headers.get("content-length")
+            if content_length:
+                file_size = int(content_length)
 
-        content = download_response.content
+            with transfer_progress("Downloading", file_size, quiet=quiet) as (progress, task_id):
+                for chunk in response.iter_bytes():
+                    chunks.append(chunk)
+                    if progress is not None and task_id is not None:
+                        progress.update(task_id, advance=len(chunk))
+
+        content = b"".join(chunks)
 
     # Verify hash unless --no-verify
     if not no_verify:

--- a/src/magpie/cli/commands/push.py
+++ b/src/magpie/cli/commands/push.py
@@ -3,14 +3,45 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, BinaryIO
 
 import click
 
 if TYPE_CHECKING:
     import httpx
+    from rich.progress import Progress, TaskID
 
 from magpie.cli import CLIContext
+from magpie.cli.progress import transfer_progress
+
+
+class ProgressFileWrapper:
+    """File wrapper that reports read progress to rich progress bar."""
+
+    def __init__(
+        self,
+        file: BinaryIO,
+        progress: "Progress | None",
+        task_id: "TaskID | None",
+    ) -> None:
+        self._file = file
+        self._progress = progress
+        self._task_id = task_id
+
+    def read(self, size: int = -1) -> bytes:
+        """Read bytes and update progress."""
+        data = self._file.read(size)
+        if self._progress is not None and self._task_id is not None:
+            self._progress.update(self._task_id, advance=len(data))
+        return data
+
+    def seek(self, offset: int, whence: int = 0) -> int:
+        """Seek in file (needed for multipart encoding)."""
+        return self._file.seek(offset, whence)
+
+    def tell(self) -> int:
+        """Return current position."""
+        return self._file.tell()
 
 
 @click.command()
@@ -18,6 +49,7 @@ from magpie.cli import CLIContext
 @click.option("--to", "artifact_path", required=True, help="Artifact path on server.")
 @click.option("--source-uri", help="Source URI for provenance tracking.")
 @click.option("--no-latest", is_flag=True, help="Don't auto-tag as latest.")
+@click.option("--quiet", "-q", is_flag=True, help="Suppress progress output.")
 @click.pass_obj
 def push(
     ctx: CLIContext,
@@ -25,6 +57,7 @@ def push(
     artifact_path: str,
     source_uri: str | None,
     no_latest: bool,
+    quiet: bool,
 ) -> None:
     """Upload an artifact to the server.
 
@@ -46,24 +79,28 @@ def push(
     if no_latest:
         params["no_latest"] = "true"
 
-    # Upload file
-    with ctx.get_client() as client:
-        with file.open("rb") as f:
-            files = {"file": (file.name, f, "application/octet-stream")}
+    file_size = file.stat().st_size
 
-            if ctx.debug:
-                click.echo(f"Uploading {file} to {artifact_path}...", err=True)
+    if ctx.debug:
+        click.echo(f"Uploading {file} ({file_size} bytes) to {artifact_path}...", err=True)
 
-            response = client.post(
-                f"/api/v1/upload/{artifact_path}",
-                files=files,
-                params=params if params else None,
-            )
+    # Upload file with progress
+    with transfer_progress("Uploading", file_size, quiet=quiet) as (progress, task_id):
+        with ctx.get_client() as client:
+            with file.open("rb") as f:
+                wrapped_file = ProgressFileWrapper(f, progress, task_id)
+                files = {"file": (file.name, wrapped_file, "application/octet-stream")}
 
-        if response.status_code != 200:
-            _handle_error(response)
+                response = client.post(
+                    f"/api/v1/upload/{artifact_path}",
+                    files=files,
+                    params=params if params else None,
+                )
 
-        data = response.json()
+            if response.status_code != 200:
+                _handle_error(response)
+
+            data = response.json()
 
     # Display results
     if data.get("is_duplicate"):

--- a/src/magpie/cli/progress.py
+++ b/src/magpie/cli/progress.py
@@ -1,0 +1,66 @@
+"""Progress bar utilities for CLI file transfers."""
+
+from __future__ import annotations
+
+import sys
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Generator
+
+if TYPE_CHECKING:
+    from rich.progress import Progress, TaskID
+
+
+def is_tty() -> bool:
+    """Check if stdout is a TTY (interactive terminal).
+
+    Returns:
+        True if stdout is a TTY, False otherwise.
+    """
+    return sys.stdout.isatty()
+
+
+@contextmanager
+def transfer_progress(
+    description: str,
+    total_bytes: int,
+    quiet: bool = False,
+) -> Generator[tuple["Progress | None", "TaskID | None"], None, None]:
+    """Context manager for file transfer progress display.
+
+    Only shows progress bar in TTY environments and when not quiet.
+
+    Args:
+        description: Description to show (e.g., "Uploading", "Downloading").
+        total_bytes: Total number of bytes to transfer.
+        quiet: If True, suppress progress output entirely.
+
+    Yields:
+        Tuple of (Progress instance or None, TaskID or None).
+        Both are None when progress display is suppressed.
+    """
+    if quiet or not is_tty():
+        yield None, None
+        return
+
+    from rich.progress import (
+        BarColumn,
+        DownloadColumn,
+        Progress,
+        SpinnerColumn,
+        TextColumn,
+        TimeRemainingColumn,
+        TransferSpeedColumn,
+    )
+
+    progress = Progress(
+        SpinnerColumn(),
+        TextColumn("[bold blue]{task.description}"),
+        BarColumn(),
+        DownloadColumn(),
+        TransferSpeedColumn(),
+        TimeRemainingColumn(),
+    )
+
+    with progress:
+        task_id = progress.add_task(description, total=total_bytes)
+        yield progress, task_id

--- a/tests/integration/test_cli_push_get.py
+++ b/tests/integration/test_cli_push_get.py
@@ -67,10 +67,10 @@ class MockStreamResponse:
         self._content = content
         self.headers = {"content-length": str(len(content))}
 
-    def iter_bytes(self) -> list[bytes]:
+    def iter_bytes(self):
         """Yield content in chunks."""
-        # Return content in a single chunk for simplicity
-        return [self._content]
+        # Yield content in a single chunk for simplicity
+        yield self._content
 
     def read(self) -> bytes:
         """Read full response body."""
@@ -540,3 +540,142 @@ class TestGetCommand:
                 # Should derive "myartifact" from "path/myartifact"
                 assert Path("myartifact").exists()
                 assert Path("myartifact").read_bytes() == test_content
+
+    def test_get_quiet_flag_suppresses_progress(
+        self,
+        cli_runner: CliRunner,
+        api_client: TestClient,
+        tmp_path: Path,
+        test_storage_service: StorageService,
+    ) -> None:
+        """Get with --quiet flag suppresses progress output."""
+        # Upload a file
+        test_content = b"content for quiet test"
+        files = {"file": ("artifact.bin", io.BytesIO(test_content), "application/octet-stream")}
+        api_client.post("/api/v1/upload/quiet/test", files=files)
+
+        output_file = tmp_path / "quiet.bin"
+
+        mock_client = MockClientWithDownload(api_client, test_storage_service)
+
+        with patch(PATCH_GET_CLIENT) as mock_get_client:
+            mock_get_client.return_value = mock_client
+
+            # Test with --quiet flag
+            result = cli_runner.invoke(
+                cli,
+                [
+                    "--server",
+                    "http://test",
+                    "get",
+                    "quiet/test",
+                    "-o",
+                    str(output_file),
+                    "--quiet",
+                ],
+            )
+
+        assert result.exit_code == 0
+        assert output_file.exists()
+        # Progress bar output should not appear (only final "Downloaded:" message)
+        assert "Downloaded:" in result.output
+
+    def test_get_progress_suppressed_when_not_tty(
+        self,
+        cli_runner: CliRunner,
+        api_client: TestClient,
+        tmp_path: Path,
+        test_storage_service: StorageService,
+    ) -> None:
+        """Get suppresses progress when stdout is not a TTY."""
+        # Upload a file
+        test_content = b"content for non-tty test"
+        files = {"file": ("artifact.bin", io.BytesIO(test_content), "application/octet-stream")}
+        api_client.post("/api/v1/upload/nontty/test", files=files)
+
+        output_file = tmp_path / "nontty.bin"
+
+        mock_client = MockClientWithDownload(api_client, test_storage_service)
+
+        with patch(PATCH_GET_CLIENT) as mock_get_client:
+            mock_get_client.return_value = mock_client
+
+            # CliRunner by default simulates non-TTY environment
+            result = cli_runner.invoke(
+                cli,
+                [
+                    "--server",
+                    "http://test",
+                    "get",
+                    "nontty/test",
+                    "-o",
+                    str(output_file),
+                ],
+            )
+
+        assert result.exit_code == 0
+        assert output_file.exists()
+        # Should still get the Downloaded message
+        assert "Downloaded:" in result.output
+
+
+class TestPushQuietFlag:
+    """Tests for push command --quiet flag and TTY detection."""
+
+    def test_push_quiet_flag_suppresses_progress(
+        self, cli_runner: CliRunner, api_client: TestClient, tmp_path: Path
+    ) -> None:
+        """Push with --quiet flag suppresses progress output."""
+        test_file = tmp_path / "quiet_push.bin"
+        test_content = b"quiet push content"
+        test_file.write_bytes(test_content)
+
+        with patch(PATCH_GET_CLIENT) as mock_get_client:
+            mock_get_client.return_value = api_client
+
+            result = cli_runner.invoke(
+                cli,
+                [
+                    "--server",
+                    "http://test",
+                    "push",
+                    str(test_file),
+                    "--to",
+                    "quiet/push-test",
+                    "--quiet",
+                ],
+            )
+
+        assert result.exit_code == 0, f"Exit code: {result.exit_code}, Output: {result.output}"
+        # Should still get the Uploaded/Duplicate and Hash ref messages
+        assert "Uploaded:" in result.output or "Duplicate:" in result.output
+        assert "Hash ref:" in result.output
+
+    def test_push_progress_suppressed_when_not_tty(
+        self, cli_runner: CliRunner, api_client: TestClient, tmp_path: Path
+    ) -> None:
+        """Push suppresses progress when stdout is not a TTY."""
+        test_file = tmp_path / "nontty_push.bin"
+        test_content = b"non-tty push content"
+        test_file.write_bytes(test_content)
+
+        with patch(PATCH_GET_CLIENT) as mock_get_client:
+            mock_get_client.return_value = api_client
+
+            # CliRunner by default simulates non-TTY environment
+            result = cli_runner.invoke(
+                cli,
+                [
+                    "--server",
+                    "http://test",
+                    "push",
+                    str(test_file),
+                    "--to",
+                    "nontty/push-test",
+                ],
+            )
+
+        assert result.exit_code == 0, f"Exit code: {result.exit_code}, Output: {result.output}"
+        # Should still get the Uploaded/Duplicate and Hash ref messages
+        assert "Uploaded:" in result.output or "Duplicate:" in result.output
+        assert "Hash ref:" in result.output

--- a/tests/integration/test_cli_push_get.py
+++ b/tests/integration/test_cli_push_get.py
@@ -59,6 +59,30 @@ def cli_runner() -> CliRunner:
     return CliRunner()
 
 
+class MockStreamResponse:
+    """Mock streaming response for download tests."""
+
+    def __init__(self, status_code: int, content: bytes) -> None:
+        self.status_code = status_code
+        self._content = content
+        self.headers = {"content-length": str(len(content))}
+
+    def iter_bytes(self) -> list[bytes]:
+        """Yield content in chunks."""
+        # Return content in a single chunk for simplicity
+        return [self._content]
+
+    def read(self) -> bytes:
+        """Read full response body."""
+        return self._content
+
+    def __enter__(self) -> "MockStreamResponse":
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        pass
+
+
 class MockClientWithDownload:
     """Wrapper around TestClient that handles download endpoints.
 
@@ -77,12 +101,20 @@ class MockClientWithDownload:
             return self._handle_download(url)
         return self.api_client.get(url)
 
+    def stream(self, method: str, url: str) -> MockStreamResponse:
+        """Handle streaming requests for downloads."""
+        if method == "GET" and url.startswith("/artifacts/"):
+            return self._handle_stream_download(url)
+        # For non-artifact requests, delegate to api_client
+        response = self.api_client.get(url)
+        return MockStreamResponse(response.status_code, response.content)
+
     def post(self, url: str, **kwargs: object) -> "httpx.Response":
         """Delegate POST to api_client."""
         return self.api_client.post(url, **kwargs)
 
-    def _handle_download(self, url: str) -> MagicMock:
-        """Handle download from /artifacts/{path}/{hash_ref} or /artifacts/{path}/blobs/{hash}."""
+    def _get_download_content(self, url: str) -> tuple[int, bytes]:
+        """Get download content and status code for a URL."""
         from magpie.storage.blob import read_blob
         from magpie.storage.paths import artifact_dir_path
 
@@ -110,16 +142,22 @@ class MockClientWithDownload:
             artifact_dir = artifact_dir_path(self.storage_service.config.storage_path, path)
             blob_file = read_blob(artifact_dir, info.hash)
             content = blob_file.read_bytes()
-
-            response = MagicMock()
-            response.status_code = 200
-            response.content = content
-            return response
+            return 200, content
         except Exception:
-            response = MagicMock()
-            response.status_code = 404
-            response.content = b""
-            return response
+            return 404, b""
+
+    def _handle_download(self, url: str) -> MagicMock:
+        """Handle download from /artifacts/{path}/{hash_ref} or /artifacts/{path}/blobs/{hash}."""
+        status_code, content = self._get_download_content(url)
+        response = MagicMock()
+        response.status_code = status_code
+        response.content = content
+        return response
+
+    def _handle_stream_download(self, url: str) -> MockStreamResponse:
+        """Handle streaming download from /artifacts/ URLs."""
+        status_code, content = self._get_download_content(url)
+        return MockStreamResponse(status_code, content)
 
     def __enter__(self) -> "MockClientWithDownload":
         return self
@@ -361,17 +399,20 @@ class TestGetCommand:
             "hash_ref": upload_data["hash_ref"],
         }
 
-        # Mock download response with corrupted content
-        download_response = MagicMock()
-        download_response.status_code = 200
-        download_response.content = b"CORRUPTED CONTENT"
-
         def mock_get(url: str) -> MagicMock:
             if "/info" in url:
                 return info_response
-            return download_response
+            # Fallback for any other GET requests
+            fallback = MagicMock()
+            fallback.status_code = 404
+            return fallback
+
+        # Mock streaming response with corrupted content
+        def mock_stream(method: str, url: str) -> MockStreamResponse:
+            return MockStreamResponse(200, b"CORRUPTED CONTENT")
 
         mock_client.get = mock_get
+        mock_client.stream = mock_stream
         mock_client.__enter__ = MagicMock(return_value=mock_client)
         mock_client.__exit__ = MagicMock(return_value=None)
 

--- a/tests/unit/test_cli_progress.py
+++ b/tests/unit/test_cli_progress.py
@@ -1,0 +1,75 @@
+"""Unit tests for CLI progress bar behavior."""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import patch
+
+from magpie.cli.progress import is_tty, transfer_progress
+
+
+class TestIsTty:
+    """Tests for is_tty function."""
+
+    def test_is_tty_returns_true_when_stdout_is_tty(self) -> None:
+        """Test that is_tty returns True when stdout.isatty() is True."""
+        with patch.object(sys.stdout, "isatty", return_value=True):
+            assert is_tty() is True
+
+    def test_is_tty_returns_false_when_stdout_is_not_tty(self) -> None:
+        """Test that is_tty returns False when stdout.isatty() is False."""
+        with patch.object(sys.stdout, "isatty", return_value=False):
+            assert is_tty() is False
+
+
+class TestTransferProgress:
+    """Tests for transfer_progress context manager."""
+
+    def test_progress_suppressed_with_quiet_flag(self) -> None:
+        """Test that progress is suppressed when quiet=True."""
+        with patch("magpie.cli.progress.is_tty", return_value=True):
+            with transfer_progress("Test", 1000, quiet=True) as (progress, task_id):
+                assert progress is None
+                assert task_id is None
+
+    def test_progress_suppressed_when_not_tty(self) -> None:
+        """Test that progress is suppressed when stdout is not a TTY."""
+        with patch("magpie.cli.progress.is_tty", return_value=False):
+            with transfer_progress("Test", 1000, quiet=False) as (progress, task_id):
+                assert progress is None
+                assert task_id is None
+
+    def test_progress_displayed_in_tty_mode(self) -> None:
+        """Test that progress is displayed in normal TTY conditions."""
+        with patch("magpie.cli.progress.is_tty", return_value=True):
+            with transfer_progress("Test", 1000, quiet=False) as (progress, task_id):
+                # Progress should be a rich Progress instance (not None)
+                assert progress is not None
+                assert task_id is not None
+                # Verify we can update the progress (basic functionality check)
+                progress.update(task_id, advance=100)
+
+    def test_progress_suppressed_when_both_quiet_and_not_tty(self) -> None:
+        """Test that progress is suppressed when both quiet=True and not TTY."""
+        with patch("magpie.cli.progress.is_tty", return_value=False):
+            with transfer_progress("Test", 1000, quiet=True) as (progress, task_id):
+                assert progress is None
+                assert task_id is None
+
+    def test_progress_description_passed_correctly(self) -> None:
+        """Test that description is passed to progress bar correctly."""
+        with patch("magpie.cli.progress.is_tty", return_value=True):
+            with transfer_progress("Uploading", 5000, quiet=False) as (progress, task_id):
+                assert progress is not None
+                # Get the task to verify description
+                task = progress.tasks[task_id]
+                assert task.description == "Uploading"
+                assert task.total == 5000
+
+    def test_progress_total_bytes_passed_correctly(self) -> None:
+        """Test that total_bytes is passed to progress bar correctly."""
+        with patch("magpie.cli.progress.is_tty", return_value=True):
+            with transfer_progress("Downloading", 123456, quiet=False) as (progress, task_id):
+                assert progress is not None
+                task = progress.tasks[task_id]
+                assert task.total == 123456

--- a/uv.lock
+++ b/uv.lock
@@ -393,6 +393,7 @@ dependencies = [
     { name = "opentelemetry-instrumentation-fastapi" },
     { name = "pydantic-settings" },
     { name = "python-multipart" },
+    { name = "rich" },
     { name = "sentry-sdk", extra = ["fastapi"] },
     { name = "uvicorn", extra = ["standard"] },
 ]
@@ -417,6 +418,7 @@ requires-dist = [
     { name = "opentelemetry-instrumentation-fastapi" },
     { name = "pydantic-settings" },
     { name = "python-multipart" },
+    { name = "rich" },
     { name = "sentry-sdk", extras = ["fastapi"] },
     { name = "uvicorn", extras = ["standard"] },
 ]


### PR DESCRIPTION
## Summary
- Implement `rich.progress`-based progress bars for file transfers in the CLI
- Progress is only displayed in TTY environments
- Add `--quiet/-q` flag to suppress progress output for scripting use cases

Closes #19

## Changes
- Add `rich` as a dependency in `pyproject.toml`
- Create `src/magpie/cli/progress.py` utility module with:
  - `is_tty()` function to detect terminal environment
  - `transfer_progress()` context manager for progress display
- Update `magpie push`:
  - Add `--quiet/-q` flag
  - Wrap file reads with `ProgressFileWrapper` that reports upload progress
- Update `magpie get`:
  - Add `--quiet/-q` flag
  - Switch to streaming downloads with progress updates
- Update test mocks to support new streaming behavior in `get` command

## Test plan
- [x] Run unit and integration tests: `uv run pytest tests/unit/ tests/integration/` (500 passed)
- [x] Run linting: `uv run ruff check src/ tests/` (all checks passed)
- [ ] Manual test with large file in TTY to verify progress bar display
- [ ] Manual test with pipe to verify progress bar is suppressed
- [ ] Manual test with --quiet flag to verify it suppresses progress

Generated with [Claude Code](https://claude.ai/code) using Claude Opus 4.5