### PR TITLE
Fix: CLI 'ls' shows all blobs including untagged ones

### DIFF
--- a/src/magpie/storage/service.py
+++ b/src/magpie/storage/service.py
@@ -145,6 +145,7 @@ class StorageService:
 
         Returns:
             List of ArtifactInfo for each unique blob, with tags grouped by hash.
+            Includes blobs without tags (shown with empty tags list).
             Returns empty list if artifact path doesn't exist.
         """
         artifact_dir = artifact_dir_path(self.config.storage_path, artifact_path)
@@ -152,25 +153,35 @@ class StorageService:
         if not artifact_dir.exists():
             return []
 
-        manifest = read_manifest(artifact_dir)
-
-        if not manifest.tags:
+        metadata_dir = artifact_dir / "metadata"
+        if not metadata_dir.exists():
             return []
 
-        # Group tags by hash (manifest stores full hashes)
+        # Read manifest to build hash-to-tags mapping
+        manifest = read_manifest(artifact_dir)
         hash_to_tags: dict[str, list[str]] = {}
         for tag_name, full_hash in manifest.tags.items():
             if full_hash not in hash_to_tags:
                 hash_to_tags[full_hash] = []
             hash_to_tags[full_hash].append(tag_name)
 
-        # Build ArtifactInfo for each unique hash
+        # Enumerate all metadata files to find all blobs (including untagged)
         results: list[ArtifactInfo] = []
-        for full_hash, tags in hash_to_tags.items():
+        for metadata_file in metadata_dir.iterdir():
+            if not metadata_file.suffix == ".json":
+                continue
+
+            # Extract short hash from filename (e.g., "abc12345.json" -> "abc12345")
+            short_hash_name = metadata_file.stem
+            hash_ref = f"@{short_hash_name}"
+
             try:
-                # Metadata is indexed by short hash (first 8 chars)
-                hash_ref = short_hash(full_hash)
                 metadata = read_metadata(artifact_dir, hash_ref)
+                full_hash = metadata.hash
+
+                # Look up tags for this hash (empty list if untagged)
+                tags = hash_to_tags.get(full_hash, [])
+
                 info = ArtifactInfo(
                     hash=full_hash,
                     hash_ref=hash_ref,
@@ -181,7 +192,7 @@ class StorageService:
                 )
                 results.append(info)
             except ArtifactNotFoundError:
-                # Skip blobs with missing metadata
+                # Skip files that can't be read as metadata
                 continue
 
         return results

--- a/src/magpie/storage/service.py
+++ b/src/magpie/storage/service.py
@@ -168,7 +168,9 @@ class StorageService:
         # Enumerate all metadata files to find all blobs (including untagged)
         results: list[ArtifactInfo] = []
         for metadata_file in metadata_dir.iterdir():
-            if not metadata_file.suffix == ".json":
+            if not metadata_file.is_file():
+                continue
+            if metadata_file.suffix != ".json":
                 continue
 
             # Extract short hash from filename (e.g., "abc12345.json" -> "abc12345")

--- a/tests/integration/test_list_endpoint.py
+++ b/tests/integration/test_list_endpoint.py
@@ -101,11 +101,10 @@ class TestMultipleVersions:
     def test_list_multiple_versions(
         self, client: TestClient, test_storage_service: StorageService
     ) -> None:
-        """List artifact with multiple distinct versions shows latest only.
+        """List artifact with multiple distinct versions shows all versions.
 
-        Note: The storage system only keeps tags in manifest. When a new version
-        is uploaded, "latest" tag moves to the new version, and the old version
-        loses its tag (becomes orphaned from listing perspective).
+        All blobs are listed, including those that have lost their tags.
+        The version with "latest" tag shows it, untagged versions show empty tags.
         """
         artifact_path = "multi/version"
 
@@ -113,6 +112,7 @@ class TestMultipleVersions:
         files1 = {"file": ("v1.bin", io.BytesIO(b"version 1 content"), "application/octet-stream")}
         response1 = client.post(f"/api/v1/upload/{artifact_path}", files=files1)
         assert response1.status_code == 200
+        data1 = response1.json()
 
         # Upload second version (different content)
         files2 = {"file": ("v2.bin", io.BytesIO(b"version 2 content"), "application/octet-stream")}
@@ -120,15 +120,24 @@ class TestMultipleVersions:
         assert response2.status_code == 200
         data2 = response2.json()
 
-        # List should show only the version with "latest" tag
+        # List should show all versions
         response = client.get(f"/api/v1/artifacts/{artifact_path}")
         assert response.status_code == 200
         data = response.json()
 
-        # Only one version visible (the one with "latest" tag)
-        assert len(data["versions"]) == 1
-        assert data["versions"][0]["hash"] == data2["hash"]
-        assert "latest" in data["versions"][0]["tags"]
+        # Both versions should be visible
+        assert len(data["versions"]) == 2
+
+        # Build lookup by hash
+        versions_by_hash = {v["hash"]: v for v in data["versions"]}
+
+        # v1 should be untagged (empty list)
+        assert data1["hash"] in versions_by_hash
+        assert versions_by_hash[data1["hash"]]["tags"] == []
+
+        # v2 should have "latest" tag
+        assert data2["hash"] in versions_by_hash
+        assert "latest" in versions_by_hash[data2["hash"]]["tags"]
 
     def test_duplicate_upload_same_version(self, client: TestClient) -> None:
         """Duplicate upload doesn't create additional versions."""

--- a/tests/integration/test_storage_service.py
+++ b/tests/integration/test_storage_service.py
@@ -237,15 +237,22 @@ class TestListArtifacts:
             uploaded_by="user",
         )
 
-        # List should show latest points to version 2
+        # List should return both versions
         artifacts = storage_service.list_artifacts(artifact_path)
 
-        # Should have 2 unique blobs (v1 has no tags anymore, v2 has latest)
-        # Actually, v1 loses its "latest" tag when v2 is stored
-        # So only v2 should appear in list since v1 has no tags
-        assert len(artifacts) == 1
-        assert artifacts[0].hash == info2.hash
-        assert "latest" in artifacts[0].tags
+        # Should have 2 unique blobs (v1 untagged, v2 has latest)
+        assert len(artifacts) == 2
+
+        # Find each version by hash
+        artifacts_by_hash = {a.hash: a for a in artifacts}
+
+        # v1 should exist but have no tags (empty list)
+        assert info1.hash in artifacts_by_hash
+        assert artifacts_by_hash[info1.hash].tags == []
+
+        # v2 should have "latest" tag
+        assert info2.hash in artifacts_by_hash
+        assert "latest" in artifacts_by_hash[info2.hash].tags
 
     def test_list_empty_path_returns_empty(self, storage_service: StorageService) -> None:
         """list_artifacts should return empty list for non-existent path."""
@@ -277,6 +284,60 @@ class TestListArtifacts:
         assert len(artifacts) == 1
         assert "latest" in artifacts[0].tags
         assert "v1.0" in artifacts[0].tags
+
+    def test_list_shows_untagged_blobs(self, storage_service: StorageService) -> None:
+        """list_artifacts should show blobs that have lost all tags."""
+        artifact_path = "test/untagged"
+
+        # Store first version (gets "latest" tag)
+        info1, _ = storage_service.store_artifact(
+            artifact_path=artifact_path,
+            file_stream=io.BytesIO(b"version 1"),
+            uploaded_by="user1",
+        )
+
+        # Store second version (steals "latest" tag, v1 becomes untagged)
+        info2, _ = storage_service.store_artifact(
+            artifact_path=artifact_path,
+            file_stream=io.BytesIO(b"version 2"),
+            uploaded_by="user2",
+        )
+
+        # Both versions should appear in list
+        artifacts = storage_service.list_artifacts(artifact_path)
+        assert len(artifacts) == 2
+
+        # Verify v1 has empty tags list (not missing, just empty)
+        v1 = next(a for a in artifacts if a.hash == info1.hash)
+        assert v1.tags == []
+        assert v1.uploaded_by == "user1"
+
+        # Verify v2 has latest tag
+        v2 = next(a for a in artifacts if a.hash == info2.hash)
+        assert v2.tags == ["latest"]
+        assert v2.uploaded_by == "user2"
+
+    def test_list_after_untag_shows_orphaned_blob(
+        self, storage_service: StorageService
+    ) -> None:
+        """list_artifacts should show blobs after their only tag is removed."""
+        artifact_path = "test/untag-orphan"
+
+        # Store artifact (gets "latest" tag)
+        info, _ = storage_service.store_artifact(
+            artifact_path=artifact_path,
+            file_stream=io.BytesIO(b"content"),
+            uploaded_by="user",
+        )
+
+        # Remove the only tag
+        storage_service.remove_tag(artifact_path, "latest")
+
+        # Blob should still appear in list with empty tags
+        artifacts = storage_service.list_artifacts(artifact_path)
+        assert len(artifacts) == 1
+        assert artifacts[0].hash == info.hash
+        assert artifacts[0].tags == []
 
 
 class TestEdgeCases:

--- a/tests/integration/test_storage_service.py
+++ b/tests/integration/test_storage_service.py
@@ -317,9 +317,7 @@ class TestListArtifacts:
         assert v2.tags == ["latest"]
         assert v2.uploaded_by == "user2"
 
-    def test_list_after_untag_shows_orphaned_blob(
-        self, storage_service: StorageService
-    ) -> None:
+    def test_list_after_untag_shows_orphaned_blob(self, storage_service: StorageService) -> None:
         """list_artifacts should show blobs after their only tag is removed."""
         artifact_path = "test/untag-orphan"
 


### PR DESCRIPTION
## Summary

- Modified `list_artifacts()` in storage service to enumerate metadata files directly instead of only iterating over manifest tags
- This ensures untagged blobs (those that have lost their "latest" tag to newer uploads) are still visible in listings
- Updated existing tests to match new expected behavior (all blobs visible, not just tagged ones)
- Added new tests specifically for the untagged blob listing behavior

## Test plan

- [x] Verify `test_list_returns_all_versions` passes - confirms both v1 (untagged) and v2 (latest) appear
- [x] Verify `test_list_shows_untagged_blobs` passes - confirms blobs that lose tags are still listed
- [x] Verify `test_list_after_untag_shows_orphaned_blob` passes - confirms blobs remain after explicit untag
- [x] Verify `test_list_multiple_versions` endpoint test passes - confirms API returns all versions
- [x] All 518 unit and integration tests pass

Closes #18

---

Generated with [Claude Code](https://claude.com/claude-code)