### PR TITLE
GC output now distinguishes symlinks checked vs fixed

### DIFF
--- a/src/magpie/cli/commands/gc.py
+++ b/src/magpie/cli/commands/gc.py
@@ -72,6 +72,8 @@ def gc(ctx: CLIContext, dry_run: bool) -> None:
 
     click.echo(f"  Artifacts scanned: {data['artifacts_scanned']}")
     click.echo(f"  Blobs found: {data['blobs_found']}")
+    click.echo(f"  Symlinks checked: {data['symlinks_checked']}")
+    click.echo(f"  Symlinks fixed: {data['symlinks_fixed']}")
 
     action = "Would delete" if dry_run else "Deleted"
     click.echo(f"  {action}: {data['blobs_deleted']} blob(s)")

--- a/src/magpie/ctl/commands/gc.py
+++ b/src/magpie/ctl/commands/gc.py
@@ -78,7 +78,9 @@ def gc(
     untagged_blobs = 0
     deleted_blobs = 0
     deleted_bytes = 0
-    reconciled_artifacts = 0
+    symlinks_checked = 0
+    symlinks_fixed = 0
+    symlinks_fixed_details: list[str] = []
 
     now = datetime.now(timezone.utc)
 
@@ -97,8 +99,20 @@ def gc(
         tagged_hashes = {h[:8] for h in manifest.tags.values()}
 
         # Reconcile symlinks for this artifact
-        reconcile_symlinks(artifact_dir, manifest)
-        reconciled_artifacts += 1
+        stats = reconcile_symlinks(artifact_dir, manifest)
+        symlinks_checked += stats.checked
+        symlinks_fixed += stats.fixed
+
+        # Build detail string if there were fixes for this artifact
+        if stats.fixed > 0:
+            details_parts = []
+            if stats.created_tags:
+                details_parts.append(f"created '{', '.join(stats.created_tags)}'")
+            if stats.removed_tags:
+                details_parts.append(f"removed '{', '.join(stats.removed_tags)}'")
+            if stats.updated_tags:
+                details_parts.append(f"updated '{', '.join(stats.updated_tags)}'")
+            symlinks_fixed_details.append(f"{artifact_path}: {', '.join(details_parts)}")
 
         if reconcile_only:
             continue
@@ -169,7 +183,14 @@ def gc(
     click.echo(f"  Artifacts scanned: {total_artifacts}")
     click.echo(f"  Blobs found: {total_blobs_found}")
     click.echo(f"  Untagged blobs: {untagged_blobs}")
-    click.echo(f"  Symlinks reconciled: {reconciled_artifacts} artifact(s)")
+    click.echo(f"  Symlinks checked: {symlinks_checked}")
+
+    # Display symlinks fixed with optional details
+    if symlinks_fixed == 0:
+        click.echo(f"  Symlinks fixed: {symlinks_fixed}")
+    else:
+        details_str = "; ".join(symlinks_fixed_details)
+        click.echo(f"  Symlinks fixed: {symlinks_fixed} ({details_str})")
 
     if not reconcile_only:
         action = "Would delete" if dry_run else "Deleted"

--- a/src/magpie/server/routes/gc.py
+++ b/src/magpie/server/routes/gc.py
@@ -26,6 +26,8 @@ class GCResponse(BaseModel):
     blobs_found: int
     blobs_deleted: int
     space_reclaimed_bytes: int
+    symlinks_checked: int
+    symlinks_fixed: int
 
 
 @router.post("/api/v1/gc")
@@ -62,6 +64,8 @@ async def trigger_gc(
     total_blobs_found = 0
     deleted_blobs = 0
     deleted_bytes = 0
+    symlinks_checked = 0
+    symlinks_fixed = 0
 
     now = datetime.now(timezone.utc)
 
@@ -76,7 +80,9 @@ async def trigger_gc(
             tagged_hashes = set(manifest.tags.values())
 
             # Reconcile symlinks for this artifact
-            reconcile_symlinks(artifact_dir, manifest)
+            stats = reconcile_symlinks(artifact_dir, manifest)
+            symlinks_checked += stats.checked
+            symlinks_fixed += stats.fixed
 
             # Find all blobs in blobs/ directory
             blobs_dir = artifact_dir / "blobs"
@@ -125,6 +131,8 @@ async def trigger_gc(
         blobs_found=total_blobs_found,
         blobs_deleted=deleted_blobs,
         space_reclaimed_bytes=deleted_bytes,
+        symlinks_checked=symlinks_checked,
+        symlinks_fixed=symlinks_fixed,
     )
 
 

--- a/src/magpie/storage/symlinks.py
+++ b/src/magpie/storage/symlinks.py
@@ -2,9 +2,38 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 from pathlib import Path
 
 from magpie.storage.manifest import Manifest
+
+
+@dataclass
+class ReconcileStats:
+    """Statistics from symlink reconciliation operation.
+
+    Attributes:
+        checked: Number of symlinks checked.
+        created: Number of symlinks created.
+        removed: Number of orphan symlinks removed.
+        updated: Number of symlinks updated (pointing to wrong target).
+        created_tags: List of tag names that were created.
+        removed_tags: List of tag names that were removed.
+        updated_tags: List of tag names that were updated.
+    """
+
+    checked: int = 0
+    created: int = 0
+    removed: int = 0
+    updated: int = 0
+    created_tags: list[str] = field(default_factory=list)
+    removed_tags: list[str] = field(default_factory=list)
+    updated_tags: list[str] = field(default_factory=list)
+
+    @property
+    def fixed(self) -> int:
+        """Total number of symlinks fixed (created + removed + updated)."""
+        return self.created + self.removed + self.updated
 
 
 def create_symlink(artifact_dir: Path, tag_name: str, hash_ref: str) -> None:
@@ -53,7 +82,7 @@ def remove_symlink(artifact_dir: Path, tag_name: str) -> None:
         symlink_path.unlink()
 
 
-def reconcile_symlinks(artifact_dir: Path, manifest: Manifest) -> None:
+def reconcile_symlinks(artifact_dir: Path, manifest: Manifest) -> ReconcileStats:
     """Reconcile symlinks to match manifest tags exactly.
 
     Creates missing symlinks for tags in manifest, removes orphan symlinks
@@ -62,7 +91,12 @@ def reconcile_symlinks(artifact_dir: Path, manifest: Manifest) -> None:
     Args:
         artifact_dir: Path to artifact directory.
         manifest: Manifest containing authoritative tag mappings.
+
+    Returns:
+        ReconcileStats with counts of checked/created/removed/updated symlinks.
     """
+    stats = ReconcileStats()
+
     # Get set of expected tag names from manifest
     expected_tags = set(manifest.tags.keys())
 
@@ -73,19 +107,26 @@ def reconcile_symlinks(artifact_dir: Path, manifest: Manifest) -> None:
             if item.is_symlink():
                 existing_symlinks.add(item.name)
 
+    # Total symlinks to check = expected tags + orphan symlinks
+    stats.checked = len(expected_tags) + len(existing_symlinks - expected_tags)
+
     # Create missing symlinks
     missing_tags = expected_tags - existing_symlinks
-    for tag_name in missing_tags:
+    for tag_name in sorted(missing_tags):
         hash_ref = manifest.tags[tag_name]
         create_symlink(artifact_dir, tag_name, hash_ref)
+        stats.created += 1
+        stats.created_tags.append(tag_name)
 
     # Remove orphan symlinks (symlinks not in manifest)
     orphan_symlinks = existing_symlinks - expected_tags
-    for tag_name in orphan_symlinks:
+    for tag_name in sorted(orphan_symlinks):
         remove_symlink(artifact_dir, tag_name)
+        stats.removed += 1
+        stats.removed_tags.append(tag_name)
 
     # Update existing symlinks that point to wrong target
-    for tag_name in expected_tags & existing_symlinks:
+    for tag_name in sorted(expected_tags & existing_symlinks):
         symlink_path = artifact_dir / tag_name
         expected_target = Path("blobs") / manifest.tags[tag_name].lstrip("@")[:8]
 
@@ -94,6 +135,12 @@ def reconcile_symlinks(artifact_dir: Path, manifest: Manifest) -> None:
             current_target = symlink_path.readlink()
             if current_target != expected_target:
                 create_symlink(artifact_dir, tag_name, manifest.tags[tag_name])
+                stats.updated += 1
+                stats.updated_tags.append(tag_name)
         except OSError:
             # If we can't read the symlink, recreate it
             create_symlink(artifact_dir, tag_name, manifest.tags[tag_name])
+            stats.updated += 1
+            stats.updated_tags.append(tag_name)
+
+    return stats

--- a/tests/integration/test_cli_gc.py
+++ b/tests/integration/test_cli_gc.py
@@ -141,6 +141,8 @@ class TestGCCommand:
         assert "GC Complete:" in result.output
         assert "Artifacts scanned:" in result.output
         assert "Blobs found:" in result.output
+        assert "Symlinks checked:" in result.output
+        assert "Symlinks fixed:" in result.output
 
     def test_gc_dry_run(
         self, cli_runner: CliRunner, api_client: TestClient, admin_token: str
@@ -218,6 +220,8 @@ class TestGCCommand:
         assert result.exit_code == 0
         assert "Artifacts scanned:" in result.output
         assert "Blobs found:" in result.output
+        assert "Symlinks checked:" in result.output
+        assert "Symlinks fixed:" in result.output
         assert "Deleted:" in result.output
 
     def test_gc_unauthorized_shows_error(

--- a/tests/integration/test_gc_endpoint.py
+++ b/tests/integration/test_gc_endpoint.py
@@ -216,6 +216,8 @@ class TestGCEndpointFunctionality:
             "blobs_found",
             "blobs_deleted",
             "space_reclaimed_bytes",
+            "symlinks_checked",
+            "symlinks_fixed",
         }
         assert required_fields == set(data.keys())
 
@@ -232,6 +234,8 @@ class TestGCEndpointFunctionality:
         assert data["blobs_found"] == 0
         assert data["blobs_deleted"] == 0
         assert data["space_reclaimed_bytes"] == 0
+        assert data["symlinks_checked"] == 0
+        assert data["symlinks_fixed"] == 0
 
 
 class TestGCDeletesUntaggedBlobs:

--- a/tests/unit/test_ctl_init_gc.py
+++ b/tests/unit/test_ctl_init_gc.py
@@ -302,7 +302,9 @@ class TestGCCommand:
             result = cli_runner.invoke(cli, ["gc", "--reconcile-only"])
 
         assert result.exit_code == 0, f"Output: {result.output}"
-        assert "Symlinks reconciled: 1 artifact(s)" in result.output
+        # Should show symlinks checked and fixed counts
+        assert "Symlinks checked: 1" in result.output
+        assert "Symlinks fixed: 1" in result.output
         # Blob should still exist
         assert blob_file.exists()
         # Symlink should exist pointing to blob

--- a/tests/unit/test_symlinks.py
+++ b/tests/unit/test_symlinks.py
@@ -7,7 +7,12 @@ from pathlib import Path
 import pytest
 
 from magpie.storage.manifest import Manifest
-from magpie.storage.symlinks import create_symlink, reconcile_symlinks, remove_symlink
+from magpie.storage.symlinks import (
+    ReconcileStats,
+    create_symlink,
+    reconcile_symlinks,
+    remove_symlink,
+)
 
 
 @pytest.fixture
@@ -115,6 +120,31 @@ class TestRemoveSymlink:
         assert regular_file.read_text() == "regular content"
 
 
+class TestReconcileStats:
+    """Tests for ReconcileStats dataclass."""
+
+    def test_default_values(self) -> None:
+        """ReconcileStats should have zero defaults."""
+        stats = ReconcileStats()
+        assert stats.checked == 0
+        assert stats.created == 0
+        assert stats.removed == 0
+        assert stats.updated == 0
+        assert stats.created_tags == []
+        assert stats.removed_tags == []
+        assert stats.updated_tags == []
+
+    def test_fixed_property(self) -> None:
+        """ReconcileStats.fixed should sum created, removed, updated."""
+        stats = ReconcileStats(created=2, removed=1, updated=3)
+        assert stats.fixed == 6
+
+    def test_fixed_property_zero(self) -> None:
+        """ReconcileStats.fixed should be 0 when no changes."""
+        stats = ReconcileStats(checked=5)
+        assert stats.fixed == 0
+
+
 class TestReconcileSymlinks:
     """Tests for reconcile_symlinks function."""
 
@@ -131,12 +161,18 @@ class TestReconcileSymlinks:
             }
         )
 
-        reconcile_symlinks(artifact_dir, manifest)
+        stats = reconcile_symlinks(artifact_dir, manifest)
 
         assert (artifact_dir / "latest").is_symlink()
         assert (artifact_dir / "v1.0").is_symlink()
         assert (artifact_dir / "latest").read_text() == "content1"
         assert (artifact_dir / "v1.0").read_text() == "content2"
+        # Verify stats
+        assert stats.checked == 2
+        assert stats.created == 2
+        assert stats.removed == 0
+        assert stats.updated == 0
+        assert sorted(stats.created_tags) == ["latest", "v1.0"]
 
     def test_reconcile_removes_orphan_symlinks(self, artifact_dir: Path) -> None:
         """reconcile_symlinks should remove symlinks not in manifest."""
@@ -146,10 +182,16 @@ class TestReconcileSymlinks:
 
         manifest = Manifest(tags={})  # Empty manifest
 
-        reconcile_symlinks(artifact_dir, manifest)
+        stats = reconcile_symlinks(artifact_dir, manifest)
 
         assert not (artifact_dir / "old-tag").exists()
         assert not (artifact_dir / "another-old").exists()
+        # Verify stats
+        assert stats.checked == 2
+        assert stats.created == 0
+        assert stats.removed == 2
+        assert stats.updated == 0
+        assert sorted(stats.removed_tags) == ["another-old", "old-tag"]
 
     def test_reconcile_preserves_correct_symlinks(self, artifact_dir: Path) -> None:
         """reconcile_symlinks should preserve symlinks that match manifest."""
@@ -161,11 +203,17 @@ class TestReconcileSymlinks:
 
         manifest = Manifest(tags={"latest": f"@{hash_ref}"})
 
-        reconcile_symlinks(artifact_dir, manifest)
+        stats = reconcile_symlinks(artifact_dir, manifest)
 
         # Symlink should still exist and be correct
         assert (artifact_dir / "latest").is_symlink()
         assert (artifact_dir / "latest").read_text() == "content"
+        # Verify stats - checked but not fixed
+        assert stats.checked == 1
+        assert stats.created == 0
+        assert stats.removed == 0
+        assert stats.updated == 0
+        assert stats.fixed == 0
 
     def test_reconcile_ignores_regular_files(self, artifact_dir: Path) -> None:
         """reconcile_symlinks should not delete non-symlink files."""
@@ -179,29 +227,38 @@ class TestReconcileSymlinks:
 
         manifest = Manifest(tags={})  # Empty manifest
 
-        reconcile_symlinks(artifact_dir, manifest)
+        stats = reconcile_symlinks(artifact_dir, manifest)
 
         # Regular file and directory should still exist
         assert regular_file.exists()
         assert regular_file.read_text() == "This is a readme"
         assert subdir.is_dir()
+        # Verify stats - nothing to check or fix
+        assert stats.checked == 0
+        assert stats.fixed == 0
 
     def test_reconcile_updates_wrong_symlinks(self, artifact_dir: Path) -> None:
         """reconcile_symlinks should update symlinks pointing to wrong target."""
-        (artifact_dir / "blobs" / "old123").write_text("old")
-        (artifact_dir / "blobs" / "new456").write_text("new")
+        (artifact_dir / "blobs" / "old12345").write_text("old")
+        (artifact_dir / "blobs" / "new45678").write_text("new")
 
         # Create symlink pointing to old blob
-        create_symlink(artifact_dir, "latest", "old123")
+        create_symlink(artifact_dir, "latest", "old12345")
         assert (artifact_dir / "latest").read_text() == "old"
 
         # Manifest says latest should point to new blob
-        manifest = Manifest(tags={"latest": "@new456"})
+        manifest = Manifest(tags={"latest": "@new45678"})
 
-        reconcile_symlinks(artifact_dir, manifest)
+        stats = reconcile_symlinks(artifact_dir, manifest)
 
         # Symlink should now point to new blob
         assert (artifact_dir / "latest").read_text() == "new"
+        # Verify stats
+        assert stats.checked == 1
+        assert stats.created == 0
+        assert stats.removed == 0
+        assert stats.updated == 1
+        assert stats.updated_tags == ["latest"]
 
     def test_reconcile_handles_empty_artifact_dir(self, tmp_path: Path) -> None:
         """reconcile_symlinks should handle non-existent artifact directory."""
@@ -209,35 +266,60 @@ class TestReconcileSymlinks:
         manifest = Manifest(tags={"latest": "@abc12345"})
 
         # Should not raise, should create symlink
-        reconcile_symlinks(artifact_dir, manifest)
+        stats = reconcile_symlinks(artifact_dir, manifest)
 
         assert (artifact_dir / "latest").is_symlink()
+        # Verify stats
+        assert stats.checked == 1
+        assert stats.created == 1
+        assert stats.created_tags == ["latest"]
 
     def test_reconcile_full_scenario(self, artifact_dir: Path) -> None:
         """reconcile_symlinks should handle add, remove, update in one call."""
         # Setup blobs
-        (artifact_dir / "blobs" / "hash1").write_text("content1")
-        (artifact_dir / "blobs" / "hash2").write_text("content2")
-        (artifact_dir / "blobs" / "hash3").write_text("content3")
+        (artifact_dir / "blobs" / "hash1xxx").write_text("content1")
+        (artifact_dir / "blobs" / "hash2xxx").write_text("content2")
+        (artifact_dir / "blobs" / "hash3xxx").write_text("content3")
 
         # Create initial symlinks
-        create_symlink(artifact_dir, "keep", "hash1")  # Will be preserved
-        create_symlink(artifact_dir, "update", "hash1")  # Will be updated
-        create_symlink(artifact_dir, "remove", "hash1")  # Will be removed
+        create_symlink(artifact_dir, "keep", "hash1xxx")  # Will be preserved
+        create_symlink(artifact_dir, "update", "hash1xxx")  # Will be updated
+        create_symlink(artifact_dir, "remove", "hash1xxx")  # Will be removed
 
         manifest = Manifest(
             tags={
-                "keep": "@hash1",  # Same target
-                "update": "@hash2",  # Different target
-                "add": "@hash3",  # New tag
+                "keep": "@hash1xxx",  # Same target
+                "update": "@hash2xxx",  # Different target
+                "add": "@hash3xxx",  # New tag
                 # "remove" not in manifest - should be removed
             }
         )
 
-        reconcile_symlinks(artifact_dir, manifest)
+        stats = reconcile_symlinks(artifact_dir, manifest)
 
         # Verify results
         assert (artifact_dir / "keep").read_text() == "content1"
         assert (artifact_dir / "update").read_text() == "content2"
         assert (artifact_dir / "add").read_text() == "content3"
         assert not (artifact_dir / "remove").exists()
+        # Verify stats
+        assert stats.checked == 4  # 3 manifest tags + 1 orphan
+        assert stats.created == 1
+        assert stats.removed == 1
+        assert stats.updated == 1
+        assert stats.fixed == 3
+        assert stats.created_tags == ["add"]
+        assert stats.removed_tags == ["remove"]
+        assert stats.updated_tags == ["update"]
+
+    def test_reconcile_returns_stats_for_no_changes(self, artifact_dir: Path) -> None:
+        """reconcile_symlinks should return stats even when no changes needed."""
+        manifest = Manifest(tags={})
+
+        stats = reconcile_symlinks(artifact_dir, manifest)
+
+        assert stats.checked == 0
+        assert stats.created == 0
+        assert stats.removed == 0
+        assert stats.updated == 0
+        assert stats.fixed == 0


### PR DESCRIPTION
## Summary
- Add `ReconcileStats` dataclass to track symlinks checked/created/removed/updated
- Update `reconcile_symlinks()` to return detailed stats with affected tag names
- Update CTL, CLI, and server GC commands to display "Symlinks checked" and "Symlinks fixed" separately

## Before
```
Symlinks reconciled: 2 artifact(s)
```

## After
```
Symlinks checked: 2
Symlinks fixed: 0
```

Or when fixes are made:
```
Symlinks checked: 2
Symlinks fixed: 1 (test/myartifact: created 'latest', removed 'stale-tag')
```

## Test plan
- [x] Unit tests for `ReconcileStats` dataclass
- [x] Unit tests for `reconcile_symlinks()` returning stats
- [x] Integration tests for GC endpoint including new response fields
- [x] Integration tests for CLI GC command output
- [x] Unit tests for CTL GC command output

Fixes #33

Generated with [Claude Code](https://claude.ai/code)