### PR TITLE
GC should remove empty artifact directories

### DIFF
--- a/src/magpie/ctl/commands/gc.py
+++ b/src/magpie/ctl/commands/gc.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import click
 
 from magpie.ctl import CTLContext
+from magpie.storage.cleanup import CleanupStats, cleanup_artifact_directories
 from magpie.storage.manifest import read_manifest
 from magpie.storage.metadata import read_metadata
 from magpie.storage.symlinks import reconcile_symlinks
@@ -79,8 +80,12 @@ def gc(
     deleted_blobs = 0
     deleted_bytes = 0
     reconciled_artifacts = 0
+    cleanup_stats = CleanupStats()
 
     now = datetime.now(timezone.utc)
+
+    # Collect artifact directories for cleanup pass (after blob deletion)
+    artifact_dirs_to_cleanup: list[Path] = []
 
     # Find all artifact directories (containing .magpie manifest)
     for manifest_file in storage_path.rglob(".magpie"):
@@ -99,6 +104,9 @@ def gc(
         # Reconcile symlinks for this artifact
         reconcile_symlinks(artifact_dir, manifest)
         reconciled_artifacts += 1
+
+        # Track artifact directory for cleanup pass
+        artifact_dirs_to_cleanup.append(artifact_dir)
 
         if reconcile_only:
             continue
@@ -163,6 +171,22 @@ def gc(
             deleted_blobs += 1
             deleted_bytes += blob_size
 
+    # Cleanup pass: remove empty directories after blob deletion
+    if not reconcile_only:
+        for artifact_dir in artifact_dirs_to_cleanup:
+            stats = cleanup_artifact_directories(artifact_dir, storage_path, dry_run)
+            cleanup_stats.empty_blobs_dirs += stats.empty_blobs_dirs
+            cleanup_stats.empty_metadata_dirs += stats.empty_metadata_dirs
+            cleanup_stats.empty_manifests += stats.empty_manifests
+            cleanup_stats.empty_artifact_dirs += stats.empty_artifact_dirs
+            cleanup_stats.empty_parent_dirs += stats.empty_parent_dirs
+            cleanup_stats.removed_paths.extend(stats.removed_paths)
+
+        # Report directories that would be / were removed
+        if dry_run and cleanup_stats.removed_paths:
+            for path in cleanup_stats.removed_paths:
+                click.echo(f"Would remove: {path}")
+
     # Print summary
     click.echo("")
     click.echo("GC Summary:")
@@ -174,6 +198,26 @@ def gc(
     if not reconcile_only:
         action = "Would delete" if dry_run else "Deleted"
         click.echo(f"  {action}: {deleted_blobs} blob(s), {_format_size(deleted_bytes)}")
+
+        # Report directory cleanup
+        if cleanup_stats.total_removed > 0:
+            action = "Would remove" if dry_run else "Removed"
+            click.echo(f"  {action} empty directories: {cleanup_stats.total_removed}")
+            if ctx.debug:
+                if cleanup_stats.empty_blobs_dirs:
+                    click.echo(f"    - blobs/ dirs: {cleanup_stats.empty_blobs_dirs}", err=True)
+                if cleanup_stats.empty_metadata_dirs:
+                    click.echo(
+                        f"    - metadata/ dirs: {cleanup_stats.empty_metadata_dirs}", err=True
+                    )
+                if cleanup_stats.empty_manifests:
+                    click.echo(f"    - .magpie files: {cleanup_stats.empty_manifests}", err=True)
+                if cleanup_stats.empty_artifact_dirs:
+                    click.echo(
+                        f"    - artifact dirs: {cleanup_stats.empty_artifact_dirs}", err=True
+                    )
+                if cleanup_stats.empty_parent_dirs:
+                    click.echo(f"    - parent dirs: {cleanup_stats.empty_parent_dirs}", err=True)
 
 
 def _get_blob_age_days(artifact_dir: Path, blob_hash: str, now: datetime) -> int | None:

--- a/src/magpie/server/routes/gc.py
+++ b/src/magpie/server/routes/gc.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, Query
@@ -11,6 +12,7 @@ from pydantic import BaseModel
 from magpie.auth.service import TokenInfo
 from magpie.config import MagpieSettings, get_settings
 from magpie.server.deps import require_admin_scope
+from magpie.storage.cleanup import cleanup_artifact_directories
 from magpie.storage.manifest import read_manifest
 from magpie.storage.metadata import read_metadata
 from magpie.storage.symlinks import reconcile_symlinks
@@ -26,6 +28,7 @@ class GCResponse(BaseModel):
     blobs_found: int
     blobs_deleted: int
     space_reclaimed_bytes: int
+    directories_removed: int = 0
 
 
 @router.post("/api/v1/gc")
@@ -62,8 +65,12 @@ async def trigger_gc(
     total_blobs_found = 0
     deleted_blobs = 0
     deleted_bytes = 0
+    directories_removed = 0
 
     now = datetime.now(timezone.utc)
+
+    # Collect artifact directories for cleanup pass
+    artifact_dirs_to_cleanup: list[Path] = []
 
     # Find all artifact directories (containing .magpie manifest)
     if storage_path.exists():
@@ -77,6 +84,9 @@ async def trigger_gc(
 
             # Reconcile symlinks for this artifact
             reconcile_symlinks(artifact_dir, manifest)
+
+            # Track artifact directory for cleanup pass
+            artifact_dirs_to_cleanup.append(artifact_dir)
 
             # Find all blobs in blobs/ directory
             blobs_dir = artifact_dir / "blobs"
@@ -119,12 +129,18 @@ async def trigger_gc(
                 deleted_blobs += 1
                 deleted_bytes += blob_size
 
+        # Cleanup pass: remove empty directories after blob deletion
+        for artifact_dir in artifact_dirs_to_cleanup:
+            stats = cleanup_artifact_directories(artifact_dir, storage_path, dry_run)
+            directories_removed += stats.total_removed
+
     return GCResponse(
         dry_run=dry_run,
         artifacts_scanned=total_artifacts,
         blobs_found=total_blobs_found,
         blobs_deleted=deleted_blobs,
         space_reclaimed_bytes=deleted_bytes,
+        directories_removed=directories_removed,
     )
 
 

--- a/src/magpie/storage/__init__.py
+++ b/src/magpie/storage/__init__.py
@@ -6,6 +6,10 @@ from magpie.storage.blob import (
     read_blob,
     store_blob,
 )
+from magpie.storage.cleanup import (
+    CleanupStats,
+    cleanup_artifact_directories,
+)
 from magpie.storage.exceptions import (
     ArtifactNotFoundError,
     BlobExistsError,
@@ -73,6 +77,9 @@ __all__ = [
     "create_symlink",
     "remove_symlink",
     "reconcile_symlinks",
+    # Cleanup operations
+    "CleanupStats",
+    "cleanup_artifact_directories",
     # Exceptions
     "StorageError",
     "ArtifactNotFoundError",

--- a/src/magpie/storage/cleanup.py
+++ b/src/magpie/storage/cleanup.py
@@ -1,0 +1,157 @@
+"""Cleanup utilities for removing empty artifact directories after GC."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from magpie.storage.manifest import read_manifest
+from magpie.storage.paths import manifest_path
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class CleanupStats:
+    """Statistics from directory cleanup operation."""
+
+    empty_blobs_dirs: int = 0
+    empty_metadata_dirs: int = 0
+    empty_manifests: int = 0
+    empty_artifact_dirs: int = 0
+    empty_parent_dirs: int = 0
+    removed_paths: list[str] = field(default_factory=list)
+
+    @property
+    def total_removed(self) -> int:
+        """Total number of items removed."""
+        return (
+            self.empty_blobs_dirs
+            + self.empty_metadata_dirs
+            + self.empty_manifests
+            + self.empty_artifact_dirs
+            + self.empty_parent_dirs
+        )
+
+
+def is_empty_directory(path: Path) -> bool:
+    """Check if a directory is empty.
+
+    Args:
+        path: Path to check.
+
+    Returns:
+        True if path is an empty directory, False otherwise.
+    """
+    if not path.is_dir():
+        return False
+    return not any(path.iterdir())
+
+
+def cleanup_artifact_directories(
+    artifact_dir: Path,
+    storage_root: Path,
+    dry_run: bool = False,
+) -> CleanupStats:
+    """Clean up empty directories for a single artifact after GC.
+
+    Removes in order:
+    1. Empty blobs/ directory
+    2. Empty metadata/ directory
+    3. .magpie if no tags remain
+    4. Artifact directory if completely empty
+    5. Empty parent directories up to storage_root
+
+    Args:
+        artifact_dir: Path to the artifact directory.
+        storage_root: Base storage path (cleanup stops here).
+        dry_run: If True, report what would be removed without removing.
+
+    Returns:
+        CleanupStats with counts of removed items.
+    """
+    stats = CleanupStats()
+
+    # Check and remove empty blobs/ directory
+    blobs_dir = artifact_dir / "blobs"
+    if blobs_dir.exists() and is_empty_directory(blobs_dir):
+        rel_path = str(blobs_dir.relative_to(storage_root))
+        stats.empty_blobs_dirs += 1
+        stats.removed_paths.append(rel_path)
+        if not dry_run:
+            logger.debug("Removing empty blobs directory: %s", rel_path)
+            blobs_dir.rmdir()
+
+    # Check and remove empty metadata/ directory
+    metadata_dir = artifact_dir / "metadata"
+    if metadata_dir.exists() and is_empty_directory(metadata_dir):
+        rel_path = str(metadata_dir.relative_to(storage_root))
+        stats.empty_metadata_dirs += 1
+        stats.removed_paths.append(rel_path)
+        if not dry_run:
+            logger.debug("Removing empty metadata directory: %s", rel_path)
+            metadata_dir.rmdir()
+
+    # Check and remove .magpie if no tags remain
+    manifest_file = manifest_path(artifact_dir)
+    if manifest_file.exists():
+        manifest = read_manifest(artifact_dir)
+        if not manifest.tags:
+            rel_path = str(manifest_file.relative_to(storage_root))
+            stats.empty_manifests += 1
+            stats.removed_paths.append(rel_path)
+            if not dry_run:
+                logger.debug("Removing empty manifest: %s", rel_path)
+                manifest_file.unlink()
+
+    # Check and remove artifact directory if completely empty
+    if artifact_dir.exists() and is_empty_directory(artifact_dir):
+        rel_path = str(artifact_dir.relative_to(storage_root))
+        stats.empty_artifact_dirs += 1
+        stats.removed_paths.append(rel_path)
+        if not dry_run:
+            logger.debug("Removing empty artifact directory: %s", rel_path)
+            artifact_dir.rmdir()
+
+        # Clean up empty parent directories up to storage_root
+        _cleanup_empty_parents(artifact_dir.parent, storage_root, dry_run, stats)
+
+    return stats
+
+
+def _cleanup_empty_parents(
+    start_dir: Path,
+    storage_root: Path,
+    dry_run: bool,
+    stats: CleanupStats,
+) -> None:
+    """Recursively remove empty parent directories up to storage_root.
+
+    Args:
+        start_dir: Directory to start checking from.
+        storage_root: Stop when reaching this directory (never removed).
+        dry_run: If True, report without removing.
+        stats: CleanupStats to update with removed paths.
+    """
+    current = start_dir
+
+    while current != storage_root and current.is_relative_to(storage_root):
+        if not current.exists():
+            # Parent was already removed in a previous iteration
+            current = current.parent
+            continue
+
+        if not is_empty_directory(current):
+            # Directory is not empty, stop climbing
+            break
+
+        rel_path = str(current.relative_to(storage_root))
+        stats.empty_parent_dirs += 1
+        stats.removed_paths.append(rel_path)
+
+        if not dry_run:
+            logger.debug("Removing empty parent directory: %s", rel_path)
+            current.rmdir()
+
+        current = current.parent

--- a/tests/integration/test_gc_endpoint.py
+++ b/tests/integration/test_gc_endpoint.py
@@ -216,6 +216,7 @@ class TestGCEndpointFunctionality:
             "blobs_found",
             "blobs_deleted",
             "space_reclaimed_bytes",
+            "directories_removed",
         }
         assert required_fields == set(data.keys())
 
@@ -326,3 +327,133 @@ class TestGCDeletesUntaggedBlobs:
         # Verify blob still exists (blob files use short hash as filename)
         blob_file = artifact_dir / "blobs" / hash_value[:8]
         assert blob_file.exists(), "Blob should not be deleted in dry run mode"
+
+
+class TestGCDirectoryCleanup:
+    """Tests for GC endpoint directory cleanup after blob deletion."""
+
+    def test_gc_response_includes_directories_removed(
+        self, client: TestClient, admin_token: str
+    ) -> None:
+        """GC response includes directories_removed field."""
+        response = client.post(
+            "/api/v1/gc",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "directories_removed" in data
+
+    def test_gc_removes_empty_artifact_directories(
+        self, client: TestClient, admin_token: str, test_config: MagpieSettings
+    ) -> None:
+        """GC removes empty artifact directories after deleting all blobs."""
+        # Upload artifact
+        upload_data = _upload_artifact(client, "gc-cleanup-test/artifact", b"cleanup content")
+        hash_value = upload_data["hash"]
+
+        # Remove the "latest" tag to make blob untagged
+        client.delete(
+            "/api/v1/artifacts/gc-cleanup-test/artifact/tags/latest",
+            headers={"X-Magpie-Scope": "write"},
+        )
+
+        # Age the blob
+        artifact_dir = test_config.storage_path / "gc-cleanup-test" / "artifact"
+        metadata_file = artifact_dir / "metadata" / f"{hash_value[:8]}.json"
+
+        if metadata_file.exists():
+            import json
+
+            with open(metadata_file) as f:
+                metadata = json.load(f)
+
+            old_time = datetime.now(timezone.utc) - timedelta(days=100)
+            metadata["uploaded_at"] = old_time.isoformat()
+
+            with open(metadata_file, "w") as f:
+                json.dump(metadata, f)
+
+        # Run GC
+        response = client.post(
+            "/api/v1/gc",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["blobs_deleted"] >= 1
+        assert data["directories_removed"] >= 1
+
+        # Artifact directory should be cleaned up
+        assert not artifact_dir.exists()
+
+    def test_gc_dry_run_reports_directories_to_remove(
+        self, client: TestClient, admin_token: str, test_config: MagpieSettings
+    ) -> None:
+        """GC dry run reports directories that would be removed."""
+        # Upload artifact
+        upload_data = _upload_artifact(client, "gc-dryrun-cleanup/artifact", b"dryrun cleanup")
+        hash_value = upload_data["hash"]
+
+        # Remove tag
+        client.delete(
+            "/api/v1/artifacts/gc-dryrun-cleanup/artifact/tags/latest",
+            headers={"X-Magpie-Scope": "write"},
+        )
+
+        # Age the blob
+        artifact_dir = test_config.storage_path / "gc-dryrun-cleanup" / "artifact"
+        metadata_file = artifact_dir / "metadata" / f"{hash_value[:8]}.json"
+
+        if metadata_file.exists():
+            import json
+
+            with open(metadata_file) as f:
+                metadata = json.load(f)
+
+            old_time = datetime.now(timezone.utc) - timedelta(days=100)
+            metadata["uploaded_at"] = old_time.isoformat()
+
+            with open(metadata_file, "w") as f:
+                json.dump(metadata, f)
+
+        # Run GC in dry run mode
+        response = client.post(
+            "/api/v1/gc",
+            headers={"Authorization": f"Bearer {admin_token}"},
+            params={"dry_run": "true"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["dry_run"] is True
+        assert data["directories_removed"] >= 1
+
+        # Artifact directory should still exist (dry run)
+        assert artifact_dir.exists()
+
+    def test_gc_preserves_artifact_with_tags(
+        self, client: TestClient, admin_token: str, test_config: MagpieSettings
+    ) -> None:
+        """GC preserves artifact directories when tags still exist."""
+        # Upload artifact (has "latest" tag)
+        _upload_artifact(client, "gc-preserve-test/artifact", b"preserve content")
+
+        artifact_dir = test_config.storage_path / "gc-preserve-test" / "artifact"
+        assert artifact_dir.exists()
+
+        # Run GC
+        response = client.post(
+            "/api/v1/gc",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["blobs_deleted"] == 0
+
+        # Artifact directory should still exist
+        assert artifact_dir.exists()
+        assert (artifact_dir / ".magpie").exists()

--- a/tests/unit/test_cleanup.py
+++ b/tests/unit/test_cleanup.py
@@ -1,0 +1,343 @@
+"""Unit tests for cleanup utilities."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from magpie.storage.cleanup import (
+    CleanupStats,
+    cleanup_artifact_directories,
+    is_empty_directory,
+)
+
+
+@pytest.fixture
+def storage_root(tmp_path: Path) -> Path:
+    """Create a temporary storage root directory."""
+    root = tmp_path / "storage"
+    root.mkdir()
+    return root
+
+
+def create_artifact_structure(
+    storage_root: Path,
+    artifact_path: str,
+    blobs: list[str] | None = None,
+    metadata: list[str] | None = None,
+    tags: dict[str, str] | None = None,
+) -> Path:
+    """Create an artifact directory structure for testing.
+
+    Args:
+        storage_root: Base storage directory.
+        artifact_path: Relative path to artifact.
+        blobs: List of blob hashes to create (creates actual files).
+        metadata: List of metadata file names to create.
+        tags: Dict of tag_name -> hash for manifest.
+
+    Returns:
+        Path to the artifact directory.
+    """
+    artifact_dir = storage_root / artifact_path
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+
+    if blobs:
+        blobs_dir = artifact_dir / "blobs"
+        blobs_dir.mkdir(exist_ok=True)
+        for blob_hash in blobs:
+            (blobs_dir / blob_hash[:8]).write_bytes(b"blob content")
+
+    if metadata:
+        metadata_dir = artifact_dir / "metadata"
+        metadata_dir.mkdir(exist_ok=True)
+        for meta_hash in metadata:
+            meta_file = metadata_dir / f"{meta_hash[:8]}.json"
+            meta_content = {
+                "hash": meta_hash,
+                "uploaded_by": "test",
+                "uploaded_at": datetime.now(timezone.utc).isoformat(),
+                "source_uri": None,
+            }
+            meta_file.write_text(json.dumps(meta_content), encoding="utf-8")
+
+    if tags is not None:
+        manifest = {"version": 1, "tags": tags}
+        (artifact_dir / ".magpie").write_text(json.dumps(manifest), encoding="utf-8")
+
+    return artifact_dir
+
+
+class TestIsEmptyDirectory:
+    """Tests for is_empty_directory function."""
+
+    def test_empty_directory_returns_true(self, tmp_path: Path) -> None:
+        """Empty directory returns True."""
+        empty_dir = tmp_path / "empty"
+        empty_dir.mkdir()
+        assert is_empty_directory(empty_dir) is True
+
+    def test_directory_with_file_returns_false(self, tmp_path: Path) -> None:
+        """Directory with a file returns False."""
+        dir_with_file = tmp_path / "has_file"
+        dir_with_file.mkdir()
+        (dir_with_file / "file.txt").write_text("content")
+        assert is_empty_directory(dir_with_file) is False
+
+    def test_directory_with_subdir_returns_false(self, tmp_path: Path) -> None:
+        """Directory with a subdirectory returns False."""
+        dir_with_subdir = tmp_path / "has_subdir"
+        dir_with_subdir.mkdir()
+        (dir_with_subdir / "subdir").mkdir()
+        assert is_empty_directory(dir_with_subdir) is False
+
+    def test_file_returns_false(self, tmp_path: Path) -> None:
+        """Regular file returns False."""
+        file_path = tmp_path / "file.txt"
+        file_path.write_text("content")
+        assert is_empty_directory(file_path) is False
+
+    def test_nonexistent_path_returns_false(self, tmp_path: Path) -> None:
+        """Non-existent path returns False."""
+        nonexistent = tmp_path / "does_not_exist"
+        assert is_empty_directory(nonexistent) is False
+
+
+class TestCleanupStats:
+    """Tests for CleanupStats dataclass."""
+
+    def test_default_values(self) -> None:
+        """Default values are all zero."""
+        stats = CleanupStats()
+        assert stats.empty_blobs_dirs == 0
+        assert stats.empty_metadata_dirs == 0
+        assert stats.empty_manifests == 0
+        assert stats.empty_artifact_dirs == 0
+        assert stats.empty_parent_dirs == 0
+        assert stats.removed_paths == []
+
+    def test_total_removed_calculation(self) -> None:
+        """total_removed sums all counts correctly."""
+        stats = CleanupStats(
+            empty_blobs_dirs=1,
+            empty_metadata_dirs=2,
+            empty_manifests=3,
+            empty_artifact_dirs=4,
+            empty_parent_dirs=5,
+        )
+        assert stats.total_removed == 15
+
+
+class TestCleanupArtifactDirectories:
+    """Tests for cleanup_artifact_directories function."""
+
+    def test_removes_empty_blobs_dir(self, storage_root: Path) -> None:
+        """Removes empty blobs/ directory."""
+        artifact_dir = create_artifact_structure(
+            storage_root, "test/artifact", blobs=["abc12345"], tags={"latest": "abc12345"}
+        )
+
+        # Manually empty the blobs directory
+        blobs_dir = artifact_dir / "blobs"
+        for f in blobs_dir.iterdir():
+            f.unlink()
+
+        stats = cleanup_artifact_directories(artifact_dir, storage_root, dry_run=False)
+
+        assert stats.empty_blobs_dirs == 1
+        assert not blobs_dir.exists()
+
+    def test_removes_empty_metadata_dir(self, storage_root: Path) -> None:
+        """Removes empty metadata/ directory."""
+        artifact_dir = create_artifact_structure(
+            storage_root, "test/artifact", metadata=["abc12345"], tags={"latest": "abc12345"}
+        )
+
+        # Manually empty the metadata directory
+        metadata_dir = artifact_dir / "metadata"
+        for f in metadata_dir.iterdir():
+            f.unlink()
+
+        stats = cleanup_artifact_directories(artifact_dir, storage_root, dry_run=False)
+
+        assert stats.empty_metadata_dirs == 1
+        assert not metadata_dir.exists()
+
+    def test_removes_manifest_with_no_tags(self, storage_root: Path) -> None:
+        """Removes .magpie file when no tags remain."""
+        artifact_dir = create_artifact_structure(
+            storage_root, "test/artifact", tags={}  # Empty tags
+        )
+
+        manifest_file = artifact_dir / ".magpie"
+        assert manifest_file.exists()
+
+        stats = cleanup_artifact_directories(artifact_dir, storage_root, dry_run=False)
+
+        assert stats.empty_manifests == 1
+        assert not manifest_file.exists()
+
+    def test_preserves_manifest_with_tags(self, storage_root: Path) -> None:
+        """Does not remove .magpie file when tags exist."""
+        artifact_dir = create_artifact_structure(
+            storage_root, "test/artifact", tags={"latest": "abc12345"}
+        )
+
+        manifest_file = artifact_dir / ".magpie"
+        assert manifest_file.exists()
+
+        stats = cleanup_artifact_directories(artifact_dir, storage_root, dry_run=False)
+
+        assert stats.empty_manifests == 0
+        assert manifest_file.exists()
+
+    def test_removes_empty_artifact_dir(self, storage_root: Path) -> None:
+        """Removes artifact directory when completely empty."""
+        artifact_dir = create_artifact_structure(storage_root, "test/artifact", tags={})
+
+        # Remove manifest to make it truly empty
+        (artifact_dir / ".magpie").unlink()
+
+        stats = cleanup_artifact_directories(artifact_dir, storage_root, dry_run=False)
+
+        assert stats.empty_artifact_dirs == 1
+        assert not artifact_dir.exists()
+
+    def test_removes_empty_parent_dirs(self, storage_root: Path) -> None:
+        """Removes empty parent directories up to storage root."""
+        artifact_dir = create_artifact_structure(
+            storage_root, "deep/nested/path/artifact", tags={}
+        )
+
+        # Remove manifest to make artifact dir empty
+        (artifact_dir / ".magpie").unlink()
+
+        stats = cleanup_artifact_directories(artifact_dir, storage_root, dry_run=False)
+
+        assert stats.empty_artifact_dirs == 1
+        assert stats.empty_parent_dirs == 3  # path, nested, deep
+        assert not (storage_root / "deep").exists()
+
+    def test_stops_at_storage_root(self, storage_root: Path) -> None:
+        """Does not remove storage root directory."""
+        artifact_dir = create_artifact_structure(storage_root, "single", tags={})
+
+        # Remove manifest
+        (artifact_dir / ".magpie").unlink()
+
+        stats = cleanup_artifact_directories(artifact_dir, storage_root, dry_run=False)
+
+        assert stats.empty_artifact_dirs == 1
+        assert storage_root.exists()
+
+    def test_preserves_non_empty_parent(self, storage_root: Path) -> None:
+        """Stops parent cleanup when reaching non-empty directory."""
+        # Create two artifacts under same parent
+        artifact_dir1 = create_artifact_structure(
+            storage_root, "parent/artifact1", tags={}
+        )
+        artifact_dir2 = create_artifact_structure(
+            storage_root, "parent/artifact2", tags={"latest": "abc12345"}
+        )
+
+        # Remove manifest from first artifact
+        (artifact_dir1 / ".magpie").unlink()
+
+        stats = cleanup_artifact_directories(artifact_dir1, storage_root, dry_run=False)
+
+        assert stats.empty_artifact_dirs == 1
+        assert stats.empty_parent_dirs == 0  # Parent not empty (has artifact2)
+        assert not artifact_dir1.exists()
+        assert artifact_dir2.exists()
+        assert (storage_root / "parent").exists()
+
+    def test_dry_run_does_not_remove(self, storage_root: Path) -> None:
+        """Dry run reports but does not remove directories."""
+        artifact_dir = create_artifact_structure(
+            storage_root, "test/artifact", blobs=["abc12345"], tags={}
+        )
+
+        # Empty the blobs dir
+        blobs_dir = artifact_dir / "blobs"
+        for f in blobs_dir.iterdir():
+            f.unlink()
+
+        stats = cleanup_artifact_directories(artifact_dir, storage_root, dry_run=True)
+
+        # Should report what would be removed
+        # Note: In dry run, blobs_dir and manifest are reported as removable,
+        # but artifact_dir is not empty (still has .magpie until we "remove" it)
+        # because we don't actually remove anything in dry run mode
+        assert stats.empty_blobs_dirs == 1
+        assert stats.empty_manifests == 1
+        # artifact_dir still contains .magpie (not actually removed), so not empty
+        assert stats.empty_artifact_dirs == 0
+        assert len(stats.removed_paths) >= 2
+
+        # But nothing should actually be removed
+        assert blobs_dir.exists()
+        assert (artifact_dir / ".magpie").exists()
+        assert artifact_dir.exists()
+
+    def test_removed_paths_contains_relative_paths(self, storage_root: Path) -> None:
+        """removed_paths contains paths relative to storage root."""
+        artifact_dir = create_artifact_structure(storage_root, "test/artifact", tags={})
+
+        # Remove manifest - now artifact_dir is truly empty
+        (artifact_dir / ".magpie").unlink()
+
+        # In dry run mode, we report artifact_dir as empty but don't remove it
+        # Since we don't remove it, the parent "test" still has content
+        stats = cleanup_artifact_directories(artifact_dir, storage_root, dry_run=True)
+
+        assert "test/artifact" in stats.removed_paths
+        # Parent "test" is not empty in dry-run because artifact_dir still exists
+        assert stats.empty_parent_dirs == 0
+
+    def test_handles_missing_directories(self, storage_root: Path) -> None:
+        """Handles case where subdirectories don't exist."""
+        artifact_dir = create_artifact_structure(storage_root, "test/artifact", tags={})
+
+        # No blobs/ or metadata/ directories created
+        stats = cleanup_artifact_directories(artifact_dir, storage_root, dry_run=False)
+
+        # Should still process the empty manifest
+        assert stats.empty_blobs_dirs == 0  # Didn't exist
+        assert stats.empty_metadata_dirs == 0  # Didn't exist
+        assert stats.empty_manifests == 1
+        assert stats.empty_artifact_dirs == 1
+
+    def test_full_cleanup_scenario(self, storage_root: Path) -> None:
+        """Tests a complete cleanup scenario after all blobs deleted."""
+        # Create artifact with blobs and metadata
+        artifact_dir = create_artifact_structure(
+            storage_root,
+            "project/component/artifact",
+            blobs=["hash1234", "hash5678"],
+            metadata=["hash1234", "hash5678"],
+            tags={},  # No tags (simulates after untag)
+        )
+
+        # Simulate GC having deleted all blobs and metadata
+        blobs_dir = artifact_dir / "blobs"
+        for f in blobs_dir.iterdir():
+            f.unlink()
+
+        metadata_dir = artifact_dir / "metadata"
+        for f in metadata_dir.iterdir():
+            f.unlink()
+
+        stats = cleanup_artifact_directories(artifact_dir, storage_root, dry_run=False)
+
+        assert stats.empty_blobs_dirs == 1
+        assert stats.empty_metadata_dirs == 1
+        assert stats.empty_manifests == 1
+        assert stats.empty_artifact_dirs == 1
+        assert stats.empty_parent_dirs == 2  # component, project
+        assert stats.total_removed == 6
+
+        # Everything should be cleaned up
+        assert not (storage_root / "project").exists()

--- a/tests/unit/test_cleanup.py
+++ b/tests/unit/test_cleanup.py
@@ -169,7 +169,9 @@ class TestCleanupArtifactDirectories:
     def test_removes_manifest_with_no_tags(self, storage_root: Path) -> None:
         """Removes .magpie file when no tags remain."""
         artifact_dir = create_artifact_structure(
-            storage_root, "test/artifact", tags={}  # Empty tags
+            storage_root,
+            "test/artifact",
+            tags={},  # Empty tags
         )
 
         manifest_file = artifact_dir / ".magpie"
@@ -208,9 +210,7 @@ class TestCleanupArtifactDirectories:
 
     def test_removes_empty_parent_dirs(self, storage_root: Path) -> None:
         """Removes empty parent directories up to storage root."""
-        artifact_dir = create_artifact_structure(
-            storage_root, "deep/nested/path/artifact", tags={}
-        )
+        artifact_dir = create_artifact_structure(storage_root, "deep/nested/path/artifact", tags={})
 
         # Remove manifest to make artifact dir empty
         (artifact_dir / ".magpie").unlink()
@@ -236,9 +236,7 @@ class TestCleanupArtifactDirectories:
     def test_preserves_non_empty_parent(self, storage_root: Path) -> None:
         """Stops parent cleanup when reaching non-empty directory."""
         # Create two artifacts under same parent
-        artifact_dir1 = create_artifact_structure(
-            storage_root, "parent/artifact1", tags={}
-        )
+        artifact_dir1 = create_artifact_structure(storage_root, "parent/artifact1", tags={})
         artifact_dir2 = create_artifact_structure(
             storage_root, "parent/artifact2", tags={"latest": "abc12345"}
         )

--- a/tests/unit/test_ctl_init_gc.py
+++ b/tests/unit/test_ctl_init_gc.py
@@ -495,3 +495,245 @@ class TestGCCommand:
 
         assert result.exit_code != 0
         assert "Invalid value" in result.output or "is not in the range" in result.output
+
+
+class TestGCDirectoryCleanup:
+    """Tests for GC directory cleanup after blob deletion."""
+
+    def test_gc_removes_empty_blobs_dir(
+        self, cli_runner: CliRunner, test_settings: MagpieSettings
+    ) -> None:
+        """GC removes empty blobs/ directory after deleting last blob."""
+        test_settings.storage_path.mkdir(parents=True, exist_ok=True)
+        # Create artifact with only untagged blob that will be deleted
+        create_artifact_with_blobs(
+            test_settings.storage_path,
+            "test/cleanup",
+            tagged_hashes={},  # No tags
+            untagged_hashes=["old_hash_xyz"],
+            blob_ages_days={"old_hash_xyz": 100},
+        )
+
+        blobs_dir = test_settings.storage_path / "test/cleanup/blobs"
+        assert blobs_dir.exists()
+
+        with patch("magpie.ctl.get_settings", return_value=test_settings):
+            result = cli_runner.invoke(cli, ["gc"])
+
+        assert result.exit_code == 0, f"Output: {result.output}"
+        assert "Deleted: 1 blob(s)" in result.output
+        # blobs/ directory should be removed
+        assert not blobs_dir.exists()
+
+    def test_gc_removes_empty_metadata_dir(
+        self, cli_runner: CliRunner, test_settings: MagpieSettings
+    ) -> None:
+        """GC removes empty metadata/ directory after deleting last blob."""
+        test_settings.storage_path.mkdir(parents=True, exist_ok=True)
+        create_artifact_with_blobs(
+            test_settings.storage_path,
+            "test/cleanup",
+            tagged_hashes={},
+            untagged_hashes=["old_hash_xyz"],
+            blob_ages_days={"old_hash_xyz": 100},
+        )
+
+        metadata_dir = test_settings.storage_path / "test/cleanup/metadata"
+        assert metadata_dir.exists()
+
+        with patch("magpie.ctl.get_settings", return_value=test_settings):
+            result = cli_runner.invoke(cli, ["gc"])
+
+        assert result.exit_code == 0
+        # metadata/ directory should be removed
+        assert not metadata_dir.exists()
+
+    def test_gc_removes_manifest_with_no_tags(
+        self, cli_runner: CliRunner, test_settings: MagpieSettings
+    ) -> None:
+        """GC removes .magpie file when no tags remain."""
+        test_settings.storage_path.mkdir(parents=True, exist_ok=True)
+        create_artifact_with_blobs(
+            test_settings.storage_path,
+            "test/cleanup",
+            tagged_hashes={},  # No tags
+            untagged_hashes=["old_hash_xyz"],
+            blob_ages_days={"old_hash_xyz": 100},
+        )
+
+        manifest_file = test_settings.storage_path / "test/cleanup/.magpie"
+        assert manifest_file.exists()
+
+        with patch("magpie.ctl.get_settings", return_value=test_settings):
+            result = cli_runner.invoke(cli, ["gc"])
+
+        assert result.exit_code == 0
+        # .magpie should be removed when no tags remain
+        assert not manifest_file.exists()
+
+    def test_gc_preserves_manifest_with_tags(
+        self, cli_runner: CliRunner, test_settings: MagpieSettings
+    ) -> None:
+        """GC preserves .magpie file when tags still exist."""
+        test_settings.storage_path.mkdir(parents=True, exist_ok=True)
+        create_artifact_with_blobs(
+            test_settings.storage_path,
+            "test/cleanup",
+            tagged_hashes={"latest": "tagged_hash_abc"},  # Has tags
+            untagged_hashes=["old_hash_xyz"],
+            blob_ages_days={"tagged_hash_abc": 0, "old_hash_xyz": 100},
+        )
+
+        manifest_file = test_settings.storage_path / "test/cleanup/.magpie"
+        assert manifest_file.exists()
+
+        with patch("magpie.ctl.get_settings", return_value=test_settings):
+            result = cli_runner.invoke(cli, ["gc"])
+
+        assert result.exit_code == 0
+        # .magpie should be preserved because "latest" tag exists
+        assert manifest_file.exists()
+
+    def test_gc_removes_empty_artifact_dir(
+        self, cli_runner: CliRunner, test_settings: MagpieSettings
+    ) -> None:
+        """GC removes artifact directory when completely empty."""
+        test_settings.storage_path.mkdir(parents=True, exist_ok=True)
+        create_artifact_with_blobs(
+            test_settings.storage_path,
+            "test/cleanup",
+            tagged_hashes={},
+            untagged_hashes=["old_hash_xyz"],
+            blob_ages_days={"old_hash_xyz": 100},
+        )
+
+        artifact_dir = test_settings.storage_path / "test/cleanup"
+        assert artifact_dir.exists()
+
+        with patch("magpie.ctl.get_settings", return_value=test_settings):
+            result = cli_runner.invoke(cli, ["gc"])
+
+        assert result.exit_code == 0
+        # Artifact directory should be removed when empty
+        assert not artifact_dir.exists()
+
+    def test_gc_removes_empty_parent_dirs(
+        self, cli_runner: CliRunner, test_settings: MagpieSettings
+    ) -> None:
+        """GC removes empty parent directories up to storage root."""
+        test_settings.storage_path.mkdir(parents=True, exist_ok=True)
+        create_artifact_with_blobs(
+            test_settings.storage_path,
+            "deep/nested/path/artifact",
+            tagged_hashes={},
+            untagged_hashes=["old_hash_xyz"],
+            blob_ages_days={"old_hash_xyz": 100},
+        )
+
+        parent_dir = test_settings.storage_path / "deep"
+        assert parent_dir.exists()
+
+        with patch("magpie.ctl.get_settings", return_value=test_settings):
+            result = cli_runner.invoke(cli, ["gc"])
+
+        assert result.exit_code == 0
+        # All empty parent directories should be removed
+        assert not parent_dir.exists()
+
+    def test_gc_preserves_non_empty_parent(
+        self, cli_runner: CliRunner, test_settings: MagpieSettings
+    ) -> None:
+        """GC preserves parent directories that have other content."""
+        test_settings.storage_path.mkdir(parents=True, exist_ok=True)
+        # Create two artifacts under same parent
+        create_artifact_with_blobs(
+            test_settings.storage_path,
+            "parent/artifact1",
+            tagged_hashes={},
+            untagged_hashes=["old_hash_xyz"],
+            blob_ages_days={"old_hash_xyz": 100},
+        )
+        create_artifact_with_blobs(
+            test_settings.storage_path,
+            "parent/artifact2",
+            tagged_hashes={"latest": "tagged_hash_abc"},
+            untagged_hashes=[],
+            blob_ages_days={"tagged_hash_abc": 0},
+        )
+
+        parent_dir = test_settings.storage_path / "parent"
+        artifact2_dir = test_settings.storage_path / "parent/artifact2"
+
+        with patch("magpie.ctl.get_settings", return_value=test_settings):
+            result = cli_runner.invoke(cli, ["gc"])
+
+        assert result.exit_code == 0
+        # artifact1 removed but parent preserved for artifact2
+        assert not (test_settings.storage_path / "parent/artifact1").exists()
+        assert artifact2_dir.exists()
+        assert parent_dir.exists()
+
+    def test_gc_dry_run_shows_directories_to_remove(
+        self, cli_runner: CliRunner, test_settings: MagpieSettings
+    ) -> None:
+        """GC --dry-run shows directories that would be removed."""
+        test_settings.storage_path.mkdir(parents=True, exist_ok=True)
+        create_artifact_with_blobs(
+            test_settings.storage_path,
+            "test/cleanup",
+            tagged_hashes={},
+            untagged_hashes=["old_hash_xyz"],
+            blob_ages_days={"old_hash_xyz": 100},
+        )
+
+        with patch("magpie.ctl.get_settings", return_value=test_settings):
+            result = cli_runner.invoke(cli, ["gc", "--dry-run"])
+
+        assert result.exit_code == 0
+        assert "Would remove" in result.output
+
+    def test_gc_dry_run_does_not_remove_directories(
+        self, cli_runner: CliRunner, test_settings: MagpieSettings
+    ) -> None:
+        """GC --dry-run does not actually remove directories."""
+        test_settings.storage_path.mkdir(parents=True, exist_ok=True)
+        create_artifact_with_blobs(
+            test_settings.storage_path,
+            "test/cleanup",
+            tagged_hashes={},
+            untagged_hashes=["old_hash_xyz"],
+            blob_ages_days={"old_hash_xyz": 100},
+        )
+
+        artifact_dir = test_settings.storage_path / "test/cleanup"
+        blobs_dir = artifact_dir / "blobs"
+        manifest_file = artifact_dir / ".magpie"
+
+        with patch("magpie.ctl.get_settings", return_value=test_settings):
+            result = cli_runner.invoke(cli, ["gc", "--dry-run"])
+
+        assert result.exit_code == 0
+        # Nothing should be removed in dry run
+        assert blobs_dir.exists()
+        assert manifest_file.exists()
+        assert artifact_dir.exists()
+
+    def test_gc_reports_directory_cleanup_count(
+        self, cli_runner: CliRunner, test_settings: MagpieSettings
+    ) -> None:
+        """GC reports number of directories removed in summary."""
+        test_settings.storage_path.mkdir(parents=True, exist_ok=True)
+        create_artifact_with_blobs(
+            test_settings.storage_path,
+            "test/cleanup",
+            tagged_hashes={},
+            untagged_hashes=["old_hash_xyz"],
+            blob_ages_days={"old_hash_xyz": 100},
+        )
+
+        with patch("magpie.ctl.get_settings", return_value=test_settings):
+            result = cli_runner.invoke(cli, ["gc"])
+
+        assert result.exit_code == 0
+        # Should report removed directories
+        assert "Removed empty directories:" in result.output


### PR DESCRIPTION
## Summary

- Adds directory cleanup phase to garbage collection after blob deletion
- Removes empty `blobs/` and `metadata/` directories
- Removes `.magpie` manifest files when no tags remain
- Removes empty artifact directories and parent directories up to storage root
- Respects dry-run mode (reports what would be removed without modifying)
- Reports directories removed in both CLI output and API response

Fixes #35

## Test plan

- [x] Unit tests for `cleanup_artifact_directories()` function
- [x] Integration tests for CLI GC directory cleanup
- [x] Integration tests for GC endpoint directory cleanup
- [x] Verify dry-run mode does not delete directories
- [x] Verify cleanup stops at storage root
- [x] Verify non-empty parent directories are preserved
- [x] All existing GC tests continue to pass


Generated with Claude Code (Claude Opus 4.5)