### PR TITLE
Add --force flag to prevent accidental file overwrites in get command

### DIFF
--- a/src/magpie/cli/commands/get.py
+++ b/src/magpie/cli/commands/get.py
@@ -21,6 +21,9 @@ from magpie.cli.progress import transfer_progress
 @click.option("-o", "--output", type=click.Path(path_type=Path), help="Output file path.")
 @click.option("--no-verify", is_flag=True, help="Skip SHA-256 verification.")
 @click.option("--quiet", "-q", is_flag=True, help="Suppress progress output.")
+@click.option(
+    "--force", "-f", is_flag=True, help="Overwrite existing output file without prompting."
+)
 @click.pass_obj
 def get(
     ctx: CLIContext,
@@ -28,6 +31,7 @@ def get(
     output: Path | None,
     no_verify: bool,
     quiet: bool,
+    force: bool,
 ) -> None:
     """Download an artifact from the server.
 
@@ -120,6 +124,12 @@ def get(
     if output is None:
         # Derive from artifact path (use last component)
         output = Path(parsed.path.split("/")[-1])
+
+    # Check if output file exists and --force not specified
+    if output.exists() and not force:
+        raise click.ClickException(
+            f"Output file already exists: {output}\nUse --force to overwrite existing files."
+        )
 
     # Write file
     output.write_bytes(content)

--- a/src/magpie/cli/commands/get.py
+++ b/src/magpie/cli/commands/get.py
@@ -76,6 +76,26 @@ def get(
             click.echo(f"Hash ref: {hash_ref}", err=True)
             click.echo(f"Size: {file_size} bytes", err=True)
 
+        # Determine output path early so we can check for existing file before download
+        if output is None:
+            # Derive from artifact path (use last component)
+            output = Path(parsed.path.split("/")[-1])
+
+        # Check if output file exists before downloading to avoid wasting bandwidth
+        if output.exists():
+            # If local file has same hash as remote, skip download entirely
+            local_hash = hashlib.sha256(output.read_bytes()).hexdigest()
+            if local_hash == expected_hash:
+                click.echo(f"File already exists with matching hash: {output}")
+                return
+
+            # File exists but has different hash - require --force
+            if not force:
+                raise click.ClickException(
+                    f"Output file already exists: {output}\n"
+                    "Use --force to overwrite existing files."
+                )
+
         # Download the artifact
         # Hash refs use blobs/ subdirectory, tags are symlinks at root
         if hash_ref.startswith("@"):
@@ -119,17 +139,6 @@ def get(
             )
         if ctx.debug:
             click.echo("Hash verified.", err=True)
-
-    # Determine output path
-    if output is None:
-        # Derive from artifact path (use last component)
-        output = Path(parsed.path.split("/")[-1])
-
-    # Check if output file exists and --force not specified
-    if output.exists() and not force:
-        raise click.ClickException(
-            f"Output file already exists: {output}\nUse --force to overwrite existing files."
-        )
 
     # Write file
     output.write_bytes(content)

--- a/src/magpie/cli/commands/get.py
+++ b/src/magpie/cli/commands/get.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
 from magpie.cli import CLIContext
 from magpie.cli.commands.parse import ParseError, parse_artifact_ref
 from magpie.cli.progress import transfer_progress
+from magpie.storage.hash import compute_hash
 
 
 @click.command()
@@ -84,7 +85,8 @@ def get(
         # Check if output file exists before downloading to avoid wasting bandwidth
         if output.exists():
             # If local file has same hash as remote, skip download entirely
-            local_hash = hashlib.sha256(output.read_bytes()).hexdigest()
+            # Use compute_hash for streaming hash computation (handles large files)
+            local_hash = compute_hash(output)
             if local_hash == expected_hash:
                 click.echo(f"File already exists with matching hash: {output}")
                 return

--- a/tests/integration/test_cli_push_get.py
+++ b/tests/integration/test_cli_push_get.py
@@ -774,6 +774,94 @@ class TestGetCommand:
         assert output_file.exists()
         assert output_file.read_bytes() == test_content
 
+    def test_get_skips_download_when_local_hash_matches(
+        self,
+        cli_runner: CliRunner,
+        api_client: TestClient,
+        tmp_path: Path,
+        test_storage_service: StorageService,
+    ) -> None:
+        """Get skips download when local file has matching hash (no --force needed)."""
+        # Upload a file
+        test_content = b"content for hash match test"
+        files = {"file": ("artifact.bin", io.BytesIO(test_content), "application/octet-stream")}
+        api_client.post("/api/v1/upload/hashmatch/test", files=files)
+
+        # Create existing output file with SAME content (same hash)
+        output_file = tmp_path / "hash_match.bin"
+        output_file.write_bytes(test_content)
+
+        mock_client = MockClientWithDownload(api_client, test_storage_service)
+
+        with patch(PATCH_GET_CLIENT) as mock_get_client:
+            mock_get_client.return_value = mock_client
+
+            result = cli_runner.invoke(
+                cli,
+                [
+                    "--server",
+                    "http://test",
+                    "get",
+                    "hashmatch/test",
+                    "-o",
+                    str(output_file),
+                ],
+            )
+
+        assert result.exit_code == 0
+        assert "already exists with matching hash" in result.output
+        # File should not have been modified (same content anyway)
+        assert output_file.read_bytes() == test_content
+
+    def test_get_skips_download_no_force_needed_for_identical_file(
+        self,
+        cli_runner: CliRunner,
+        api_client: TestClient,
+        tmp_path: Path,
+        test_storage_service: StorageService,
+    ) -> None:
+        """Get does not require --force when existing file is identical to remote."""
+        # Upload a file
+        test_content = b"identical content test"
+        files = {"file": ("artifact.bin", io.BytesIO(test_content), "application/octet-stream")}
+        api_client.post("/api/v1/upload/identical/test", files=files)
+
+        # Create existing output file with SAME content
+        output_file = tmp_path / "identical.bin"
+        output_file.write_bytes(test_content)
+
+        mock_client = MockClientWithDownload(api_client, test_storage_service)
+
+        # Track if stream was called (should NOT be called for identical files)
+        original_stream = mock_client.stream
+        stream_called = []
+
+        def tracking_stream(method: str, url: str):
+            stream_called.append((method, url))
+            return original_stream(method, url)
+
+        mock_client.stream = tracking_stream
+
+        with patch(PATCH_GET_CLIENT) as mock_get_client:
+            mock_get_client.return_value = mock_client
+
+            result = cli_runner.invoke(
+                cli,
+                [
+                    "--server",
+                    "http://test",
+                    "get",
+                    "identical/test",
+                    "-o",
+                    str(output_file),
+                ],
+            )
+
+        assert result.exit_code == 0
+        # Download should have been skipped
+        assert len(stream_called) == 0, "Download should have been skipped for identical file"
+        assert "already exists with matching hash" in result.output
+
 
 class TestPushQuietFlag:
     """Tests for push command --quiet flag and TTY detection."""

--- a/tests/integration/test_cli_push_get.py
+++ b/tests/integration/test_cli_push_get.py
@@ -618,6 +618,162 @@ class TestGetCommand:
         # Should still get the Downloaded message
         assert "Downloaded:" in result.output
 
+    def test_get_refuses_to_overwrite_existing_file(
+        self,
+        cli_runner: CliRunner,
+        api_client: TestClient,
+        tmp_path: Path,
+        test_storage_service: StorageService,
+    ) -> None:
+        """Get refuses to overwrite existing file without --force."""
+        # Upload a file
+        test_content = b"content for overwrite test"
+        files = {"file": ("artifact.bin", io.BytesIO(test_content), "application/octet-stream")}
+        api_client.post("/api/v1/upload/overwrite/test", files=files)
+
+        # Create existing output file
+        output_file = tmp_path / "existing.bin"
+        output_file.write_bytes(b"original content")
+
+        mock_client = MockClientWithDownload(api_client, test_storage_service)
+
+        with patch(PATCH_GET_CLIENT) as mock_get_client:
+            mock_get_client.return_value = mock_client
+
+            result = cli_runner.invoke(
+                cli,
+                [
+                    "--server",
+                    "http://test",
+                    "get",
+                    "overwrite/test",
+                    "-o",
+                    str(output_file),
+                ],
+            )
+
+        assert result.exit_code != 0
+        assert "already exists" in result.output
+        assert "--force" in result.output
+        # Original file should not be modified
+        assert output_file.read_bytes() == b"original content"
+
+    def test_get_overwrites_existing_file_with_force(
+        self,
+        cli_runner: CliRunner,
+        api_client: TestClient,
+        tmp_path: Path,
+        test_storage_service: StorageService,
+    ) -> None:
+        """Get overwrites existing file when --force is specified."""
+        # Upload a file
+        test_content = b"new content for force test"
+        files = {"file": ("artifact.bin", io.BytesIO(test_content), "application/octet-stream")}
+        api_client.post("/api/v1/upload/force/test", files=files)
+
+        # Create existing output file
+        output_file = tmp_path / "force_overwrite.bin"
+        output_file.write_bytes(b"original content")
+
+        mock_client = MockClientWithDownload(api_client, test_storage_service)
+
+        with patch(PATCH_GET_CLIENT) as mock_get_client:
+            mock_get_client.return_value = mock_client
+
+            result = cli_runner.invoke(
+                cli,
+                [
+                    "--server",
+                    "http://test",
+                    "get",
+                    "force/test",
+                    "-o",
+                    str(output_file),
+                    "--force",
+                ],
+            )
+
+        assert result.exit_code == 0
+        assert "Downloaded:" in result.output
+        # File should be overwritten with new content
+        assert output_file.read_bytes() == test_content
+
+    def test_get_force_short_flag(
+        self,
+        cli_runner: CliRunner,
+        api_client: TestClient,
+        tmp_path: Path,
+        test_storage_service: StorageService,
+    ) -> None:
+        """Get -f short flag works same as --force."""
+        # Upload a file
+        test_content = b"content for short flag test"
+        files = {"file": ("artifact.bin", io.BytesIO(test_content), "application/octet-stream")}
+        api_client.post("/api/v1/upload/shortflag/test", files=files)
+
+        # Create existing output file
+        output_file = tmp_path / "short_flag.bin"
+        output_file.write_bytes(b"original content")
+
+        mock_client = MockClientWithDownload(api_client, test_storage_service)
+
+        with patch(PATCH_GET_CLIENT) as mock_get_client:
+            mock_get_client.return_value = mock_client
+
+            result = cli_runner.invoke(
+                cli,
+                [
+                    "--server",
+                    "http://test",
+                    "get",
+                    "shortflag/test",
+                    "-o",
+                    str(output_file),
+                    "-f",
+                ],
+            )
+
+        assert result.exit_code == 0
+        assert output_file.read_bytes() == test_content
+
+    def test_get_no_force_needed_for_new_file(
+        self,
+        cli_runner: CliRunner,
+        api_client: TestClient,
+        tmp_path: Path,
+        test_storage_service: StorageService,
+    ) -> None:
+        """Get does not require --force when output file does not exist."""
+        # Upload a file
+        test_content = b"content for new file test"
+        files = {"file": ("artifact.bin", io.BytesIO(test_content), "application/octet-stream")}
+        api_client.post("/api/v1/upload/newfile/test", files=files)
+
+        output_file = tmp_path / "new_file.bin"
+        # Ensure file does not exist
+        assert not output_file.exists()
+
+        mock_client = MockClientWithDownload(api_client, test_storage_service)
+
+        with patch(PATCH_GET_CLIENT) as mock_get_client:
+            mock_get_client.return_value = mock_client
+
+            result = cli_runner.invoke(
+                cli,
+                [
+                    "--server",
+                    "http://test",
+                    "get",
+                    "newfile/test",
+                    "-o",
+                    str(output_file),
+                ],
+            )
+
+        assert result.exit_code == 0
+        assert output_file.exists()
+        assert output_file.read_bytes() == test_content
+
 
 class TestPushQuietFlag:
     """Tests for push command --quiet flag and TTY detection."""


### PR DESCRIPTION
## Summary

- Add `--force` / `-f` flag to the `get` command
- Error with clear message when output file exists and `--force` not specified
- Original file is preserved when overwrite is blocked (safer default behavior)

Fixes #29

## Test plan

- [ ] Run `magpie get <artifact>` when output file exists - should error with message mentioning `--force`
- [ ] Run `magpie get <artifact> --force` when output file exists - should overwrite
- [ ] Run `magpie get <artifact> -f` (short flag) when output file exists - should overwrite
- [ ] Run `magpie get <artifact>` when output file does not exist - should work without `--force`
- [ ] Verify existing test suite passes: `pytest tests/integration/test_cli_push_get.py`

Generated with Claude Code (Claude Opus 4.5)