### PR TITLE
Add 'magpie config' command for managing CLI configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "opentelemetry-instrumentation-fastapi",
     "opentelemetry-exporter-otlp",
     "rich",
+    "tomli_w",
 ]
 
 [project.scripts]

--- a/src/magpie/cli/__init__.py
+++ b/src/magpie/cli/__init__.py
@@ -128,7 +128,19 @@ def version() -> None:
 
 
 # Register subcommands
-from magpie.cli.commands import amend, flush_tag, gc, get, info, ls, push, tag, untag, url  # noqa: E402, I001
+from magpie.cli.commands import (  # noqa: E402
+    amend,
+    config_cmd,
+    flush_tag,
+    gc,
+    get,
+    info,
+    ls,
+    push,
+    tag,
+    untag,
+    url,
+)
 
 cli.add_command(push)
 cli.add_command(get)
@@ -140,6 +152,7 @@ cli.add_command(untag)
 cli.add_command(flush_tag)
 cli.add_command(amend)
 cli.add_command(gc)
+cli.add_command(config_cmd, name="config")
 
 
 # Keep the old 'main' as an alias for backwards compatibility with entry point

--- a/src/magpie/cli/commands/__init__.py
+++ b/src/magpie/cli/commands/__init__.py
@@ -1,6 +1,7 @@
 """CLI commands for magpie client."""
 
 from magpie.cli.commands.amend import amend
+from magpie.cli.commands.config_cmd import config_cmd
 from magpie.cli.commands.flush_tag import flush_tag
 from magpie.cli.commands.gc import gc
 from magpie.cli.commands.get import get
@@ -14,6 +15,7 @@ from magpie.cli.commands.url import url
 
 __all__ = [
     "amend",
+    "config_cmd",
     "flush_tag",
     "gc",
     "get",

--- a/src/magpie/cli/commands/config_cmd.py
+++ b/src/magpie/cli/commands/config_cmd.py
@@ -5,8 +5,27 @@ from __future__ import annotations
 from pathlib import Path
 
 import click
+import tomli_w
 
 from magpie.cli import config as cli_config
+
+# Standard mask for hiding sensitive token values
+TOKEN_MASK = "********"
+
+
+def _mask_token(token: str) -> str:
+    """Mask a token for display, showing only last 4 characters.
+
+    Args:
+        token: The token to mask.
+
+    Returns:
+        Masked token string with last 4 chars visible, or just the mask
+        if token is 4 chars or shorter.
+    """
+    if len(token) > 4:
+        return TOKEN_MASK + token[-4:]
+    return TOKEN_MASK
 
 
 def _write_config(config_path: Path, server: str | None, token: str | None) -> None:
@@ -16,6 +35,10 @@ def _write_config(config_path: Path, server: str | None, token: str | None) -> N
         config_path: Path to the config file.
         server: Server URL to write (or None to keep existing).
         token: Token to write (or None to keep existing).
+
+    Note:
+        Empty string values are treated the same as the existing value, not as
+        a way to clear individual settings. Use --clear to remove all config.
     """
     # Load existing config to preserve values not being set
     existing = cli_config.load_config(config_path)
@@ -25,17 +48,15 @@ def _write_config(config_path: Path, server: str | None, token: str | None) -> N
     # Ensure parent directory exists
     config_path.parent.mkdir(parents=True, exist_ok=True)
 
-    # Write TOML manually (tomllib is read-only)
-    lines = ["[client]"]
+    # Build config dict for tomli_w
+    client_config: dict[str, str] = {}
     if final_server:
-        # Escape backslashes and quotes in TOML strings
-        escaped_server = final_server.replace("\\", "\\\\").replace('"', '\\"')
-        lines.append(f'server = "{escaped_server}"')
+        client_config["server"] = final_server
     if final_token:
-        escaped_token = final_token.replace("\\", "\\\\").replace('"', '\\"')
-        lines.append(f'token = "{escaped_token}"')
+        client_config["token"] = final_token
 
-    config_path.write_text("\n".join(lines) + "\n")
+    config_data = {"client": client_config}
+    config_path.write_bytes(tomli_w.dumps(config_data).encode())
 
 
 @click.command("config")
@@ -107,7 +128,7 @@ def config_cmd(
     if server:
         click.echo(f"Server set to: {server}")
     if token:
-        click.echo(f"Token set to: {'*' * 8}{token[-4:] if len(token) > 4 else '****'}")
+        click.echo(f"Token set to: {_mask_token(token)}")
 
     click.echo(f"Configuration saved to {config_path}")
 
@@ -129,9 +150,7 @@ def _show_config(config_path: Path) -> None:
         click.echo("  server = (not set)")
 
     if config.client.token:
-        # Mask token for security, show only last 4 chars
-        masked = "*" * 8 + config.client.token[-4:] if len(config.client.token) > 4 else "****"
-        click.echo(f"  token  = {masked}")
+        click.echo(f"  token  = {_mask_token(config.client.token)}")
     else:
         click.echo("  token  = (not set)")
 

--- a/src/magpie/cli/commands/config_cmd.py
+++ b/src/magpie/cli/commands/config_cmd.py
@@ -10,7 +10,7 @@ import tomli_w
 from magpie.cli import config as cli_config
 
 # Standard mask for hiding sensitive token values
-TOKEN_MASK = "********"
+TOKEN_MASK = "********"  # nosec B105 - display placeholder, not a real password
 
 
 def _mask_token(token: str) -> str:

--- a/src/magpie/cli/commands/config_cmd.py
+++ b/src/magpie/cli/commands/config_cmd.py
@@ -1,0 +1,153 @@
+"""Config command for managing ~/.magpie/config.toml."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+
+from magpie.cli import config as cli_config
+
+
+def _write_config(config_path: Path, server: str | None, token: str | None) -> None:
+    """Write configuration to TOML file.
+
+    Args:
+        config_path: Path to the config file.
+        server: Server URL to write (or None to keep existing).
+        token: Token to write (or None to keep existing).
+    """
+    # Load existing config to preserve values not being set
+    existing = cli_config.load_config(config_path)
+    final_server = server if server is not None else existing.client.server
+    final_token = token if token is not None else existing.client.token
+
+    # Ensure parent directory exists
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Write TOML manually (tomllib is read-only)
+    lines = ["[client]"]
+    if final_server:
+        # Escape backslashes and quotes in TOML strings
+        escaped_server = final_server.replace("\\", "\\\\").replace('"', '\\"')
+        lines.append(f'server = "{escaped_server}"')
+    if final_token:
+        escaped_token = final_token.replace("\\", "\\\\").replace('"', '\\"')
+        lines.append(f'token = "{escaped_token}"')
+
+    config_path.write_text("\n".join(lines) + "\n")
+
+
+@click.command("config")
+@click.option(
+    "--server",
+    metavar="URL",
+    help="Set the Magpie server URL.",
+)
+@click.option(
+    "--token",
+    metavar="TOKEN",
+    help="Set the authentication token.",
+)
+@click.option(
+    "--show",
+    is_flag=True,
+    help="Show current configuration.",
+)
+@click.option(
+    "--clear",
+    is_flag=True,
+    help="Clear all configuration.",
+)
+def config_cmd(
+    server: str | None,
+    token: str | None,
+    show: bool,
+    clear: bool,
+) -> None:
+    """Manage client configuration stored in ~/.magpie/config.toml.
+
+    Configuration values are used when --server or --token are not provided
+    on the command line, and MAGPIE_SERVER/MAGPIE_TOKEN environment variables
+    are not set.
+
+    Examples:
+
+        magpie config --server http://localhost:8080 --token mgp_abc123
+
+        magpie config --show
+
+        magpie config --clear
+    """
+    config_path = cli_config.DEFAULT_CONFIG_PATH
+
+    # Validate mutually exclusive options
+    if clear and (server or token):
+        raise click.ClickException("Cannot use --clear with --server or --token.")
+    if show and (server or token or clear):
+        raise click.ClickException("Cannot use --show with other options.")
+
+    if show:
+        _show_config(config_path)
+        return
+
+    if clear:
+        _clear_config(config_path)
+        return
+
+    # If no options provided, show current config
+    if server is None and token is None:
+        _show_config(config_path)
+        return
+
+    # Set values
+    _write_config(config_path, server, token)
+
+    # Show what was set
+    if server:
+        click.echo(f"Server set to: {server}")
+    if token:
+        click.echo(f"Token set to: {'*' * 8}{token[-4:] if len(token) > 4 else '****'}")
+
+    click.echo(f"Configuration saved to {config_path}")
+
+
+def _show_config(config_path: Path) -> None:
+    """Display current configuration."""
+    if not config_path.exists():
+        click.echo(f"No configuration file found at {config_path}")
+        click.echo("Run 'magpie config --server URL --token TOKEN' to create one.")
+        return
+
+    config = cli_config.load_config(config_path)
+    click.echo(f"Configuration file: {config_path}")
+    click.echo()
+
+    if config.client.server:
+        click.echo(f"  server = {config.client.server}")
+    else:
+        click.echo("  server = (not set)")
+
+    if config.client.token:
+        # Mask token for security, show only last 4 chars
+        masked = "*" * 8 + config.client.token[-4:] if len(config.client.token) > 4 else "****"
+        click.echo(f"  token  = {masked}")
+    else:
+        click.echo("  token  = (not set)")
+
+
+def _clear_config(config_path: Path) -> None:
+    """Remove configuration file."""
+    if not config_path.exists():
+        click.echo(f"No configuration file found at {config_path}")
+        return
+
+    config_path.unlink()
+    click.echo(f"Configuration cleared: {config_path}")
+
+    # Remove parent directory if empty
+    try:
+        config_path.parent.rmdir()
+    except OSError:
+        # Directory not empty or other error, ignore
+        pass

--- a/tests/unit/test_cli_config_cmd.py
+++ b/tests/unit/test_cli_config_cmd.py
@@ -17,20 +17,20 @@ def runner() -> CliRunner:
 
 
 @pytest.fixture
-def config_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
-    """Create a temporary config directory and patch the default path."""
-    config_path = tmp_path / ".magpie" / "config.toml"
+def config_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Create a temporary config path and patch the default path."""
+    path = tmp_path / ".magpie" / "config.toml"
     monkeypatch.setattr(
         "magpie.cli.config.DEFAULT_CONFIG_PATH",
-        config_path,
+        path,
     )
-    return config_path
+    return path
 
 
 class TestConfigShow:
     """Tests for 'magpie config --show' command."""
 
-    def test_show_no_config_file(self, runner: CliRunner, config_dir: Path) -> None:
+    def test_show_no_config_file(self, runner: CliRunner, config_path: Path) -> None:
         """Test --show with no config file."""
         result = runner.invoke(cli, ["config", "--show"])
 
@@ -38,10 +38,10 @@ class TestConfigShow:
         assert "No configuration file found" in result.output
         assert "magpie config --server" in result.output
 
-    def test_show_with_config(self, runner: CliRunner, config_dir: Path) -> None:
+    def test_show_with_config(self, runner: CliRunner, config_path: Path) -> None:
         """Test --show with existing config."""
-        config_dir.parent.mkdir(parents=True, exist_ok=True)
-        config_dir.write_text(
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(
             '[client]\nserver = "https://example.com"\ntoken = "mgp_testtoken123"\n'
         )
 
@@ -54,10 +54,10 @@ class TestConfigShow:
         assert "n123" in result.output  # Last 4 chars visible
         assert "********" in result.output or "****" in result.output
 
-    def test_show_partial_config(self, runner: CliRunner, config_dir: Path) -> None:
+    def test_show_partial_config(self, runner: CliRunner, config_path: Path) -> None:
         """Test --show with only server configured."""
-        config_dir.parent.mkdir(parents=True, exist_ok=True)
-        config_dir.write_text('[client]\nserver = "https://partial.example.com"\n')
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text('[client]\nserver = "https://partial.example.com"\n')
 
         result = runner.invoke(cli, ["config", "--show"])
 
@@ -65,7 +65,7 @@ class TestConfigShow:
         assert "https://partial.example.com" in result.output
         assert "(not set)" in result.output
 
-    def test_default_behavior_shows_config(self, runner: CliRunner, config_dir: Path) -> None:
+    def test_default_behavior_shows_config(self, runner: CliRunner, config_path: Path) -> None:
         """Test that running 'config' without options shows config."""
         result = runner.invoke(cli, ["config"])
 
@@ -76,18 +76,18 @@ class TestConfigShow:
 class TestConfigSet:
     """Tests for setting config values."""
 
-    def test_set_server(self, runner: CliRunner, config_dir: Path) -> None:
+    def test_set_server(self, runner: CliRunner, config_path: Path) -> None:
         """Test setting server URL."""
         result = runner.invoke(cli, ["config", "--server", "https://myserver.com"])
 
         assert result.exit_code == 0
         assert "Server set to: https://myserver.com" in result.output
-        assert config_dir.exists()
+        assert config_path.exists()
 
-        content = config_dir.read_text()
+        content = config_path.read_text()
         assert 'server = "https://myserver.com"' in content
 
-    def test_set_token(self, runner: CliRunner, config_dir: Path) -> None:
+    def test_set_token(self, runner: CliRunner, config_path: Path) -> None:
         """Test setting token."""
         result = runner.invoke(cli, ["config", "--token", "mgp_secrettoken"])
 
@@ -95,12 +95,12 @@ class TestConfigSet:
         assert "Token set to:" in result.output
         # Token should be masked in output
         assert "mgp_secrettoken" not in result.output
-        assert config_dir.exists()
+        assert config_path.exists()
 
-        content = config_dir.read_text()
+        content = config_path.read_text()
         assert 'token = "mgp_secrettoken"' in content
 
-    def test_set_both(self, runner: CliRunner, config_dir: Path) -> None:
+    def test_set_both(self, runner: CliRunner, config_path: Path) -> None:
         """Test setting both server and token."""
         result = runner.invoke(
             cli, ["config", "--server", "https://both.example.com", "--token", "mgp_both"]
@@ -109,50 +109,50 @@ class TestConfigSet:
         assert result.exit_code == 0
         assert "Server set to: https://both.example.com" in result.output
         assert "Token set to:" in result.output
-        assert config_dir.exists()
+        assert config_path.exists()
 
-        content = config_dir.read_text()
+        content = config_path.read_text()
         assert 'server = "https://both.example.com"' in content
         assert 'token = "mgp_both"' in content
 
-    def test_update_preserves_existing(self, runner: CliRunner, config_dir: Path) -> None:
+    def test_update_preserves_existing(self, runner: CliRunner, config_path: Path) -> None:
         """Test that updating one value preserves other values."""
-        config_dir.parent.mkdir(parents=True, exist_ok=True)
-        config_dir.write_text('[client]\nserver = "https://old.com"\ntoken = "mgp_oldtoken"\n')
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text('[client]\nserver = "https://old.com"\ntoken = "mgp_oldtoken"\n')
 
         result = runner.invoke(cli, ["config", "--server", "https://new.com"])
 
         assert result.exit_code == 0
-        content = config_dir.read_text()
+        content = config_path.read_text()
         assert 'server = "https://new.com"' in content
         assert 'token = "mgp_oldtoken"' in content
 
-    def test_creates_parent_directory(self, runner: CliRunner, config_dir: Path) -> None:
+    def test_creates_parent_directory(self, runner: CliRunner, config_path: Path) -> None:
         """Test that config command creates parent directory if needed."""
-        assert not config_dir.parent.exists()
+        assert not config_path.parent.exists()
 
         result = runner.invoke(cli, ["config", "--server", "https://new.com"])
 
         assert result.exit_code == 0
-        assert config_dir.parent.exists()
-        assert config_dir.exists()
+        assert config_path.parent.exists()
+        assert config_path.exists()
 
 
 class TestConfigClear:
     """Tests for 'magpie config --clear' command."""
 
-    def test_clear_existing_config(self, runner: CliRunner, config_dir: Path) -> None:
+    def test_clear_existing_config(self, runner: CliRunner, config_path: Path) -> None:
         """Test clearing existing config."""
-        config_dir.parent.mkdir(parents=True, exist_ok=True)
-        config_dir.write_text('[client]\nserver = "https://example.com"\n')
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text('[client]\nserver = "https://example.com"\n')
 
         result = runner.invoke(cli, ["config", "--clear"])
 
         assert result.exit_code == 0
         assert "Configuration cleared" in result.output
-        assert not config_dir.exists()
+        assert not config_path.exists()
 
-    def test_clear_no_config(self, runner: CliRunner, config_dir: Path) -> None:
+    def test_clear_no_config(self, runner: CliRunner, config_path: Path) -> None:
         """Test clearing when no config exists."""
         result = runner.invoke(cli, ["config", "--clear"])
 
@@ -163,28 +163,28 @@ class TestConfigClear:
 class TestConfigValidation:
     """Tests for config command option validation."""
 
-    def test_clear_with_server_fails(self, runner: CliRunner, config_dir: Path) -> None:
+    def test_clear_with_server_fails(self, runner: CliRunner, config_path: Path) -> None:
         """Test that --clear with --server fails."""
         result = runner.invoke(cli, ["config", "--clear", "--server", "https://example.com"])
 
         assert result.exit_code != 0
         assert "Cannot use --clear with --server or --token" in result.output
 
-    def test_clear_with_token_fails(self, runner: CliRunner, config_dir: Path) -> None:
+    def test_clear_with_token_fails(self, runner: CliRunner, config_path: Path) -> None:
         """Test that --clear with --token fails."""
         result = runner.invoke(cli, ["config", "--clear", "--token", "mgp_test"])
 
         assert result.exit_code != 0
         assert "Cannot use --clear with --server or --token" in result.output
 
-    def test_show_with_server_fails(self, runner: CliRunner, config_dir: Path) -> None:
+    def test_show_with_server_fails(self, runner: CliRunner, config_path: Path) -> None:
         """Test that --show with --server fails."""
         result = runner.invoke(cli, ["config", "--show", "--server", "https://example.com"])
 
         assert result.exit_code != 0
         assert "Cannot use --show with other options" in result.output
 
-    def test_show_with_clear_fails(self, runner: CliRunner, config_dir: Path) -> None:
+    def test_show_with_clear_fails(self, runner: CliRunner, config_path: Path) -> None:
         """Test that --show with --clear fails."""
         result = runner.invoke(cli, ["config", "--show", "--clear"])
 
@@ -195,7 +195,7 @@ class TestConfigValidation:
 class TestConfigTomlOutput:
     """Tests for TOML output format."""
 
-    def test_toml_format_valid(self, runner: CliRunner, config_dir: Path) -> None:
+    def test_toml_format_valid(self, runner: CliRunner, config_path: Path) -> None:
         """Test that output is valid TOML."""
         runner.invoke(cli, ["config", "--server", "https://test.com", "--token", "mgp_test123"])
 
@@ -205,13 +205,13 @@ class TestConfigTomlOutput:
         except ImportError:
             import tomli as tomllib  # type: ignore[import-not-found,no-redef]
 
-        content = config_dir.read_bytes()
+        content = config_path.read_bytes()
         data = tomllib.loads(content.decode())
 
         assert data["client"]["server"] == "https://test.com"
         assert data["client"]["token"] == "mgp_test123"
 
-    def test_special_chars_escaped(self, runner: CliRunner, config_dir: Path) -> None:
+    def test_special_chars_escaped(self, runner: CliRunner, config_path: Path) -> None:
         """Test that special characters are properly escaped."""
         # Test with a token containing quotes
         runner.invoke(cli, ["config", "--token", 'mgp_test"quote'])
@@ -221,12 +221,12 @@ class TestConfigTomlOutput:
         except ImportError:
             import tomli as tomllib  # type: ignore[import-not-found,no-redef]
 
-        content = config_dir.read_bytes()
+        content = config_path.read_bytes()
         data = tomllib.loads(content.decode())
 
         assert data["client"]["token"] == 'mgp_test"quote'
 
-    def test_backslash_escaped(self, runner: CliRunner, config_dir: Path) -> None:
+    def test_backslash_escaped(self, runner: CliRunner, config_path: Path) -> None:
         """Test that backslashes are properly escaped."""
         runner.invoke(cli, ["config", "--server", "https://test.com\\path"])
 
@@ -235,7 +235,7 @@ class TestConfigTomlOutput:
         except ImportError:
             import tomli as tomllib  # type: ignore[import-not-found,no-redef]
 
-        content = config_dir.read_bytes()
+        content = config_path.read_bytes()
         data = tomllib.loads(content.decode())
 
         assert data["client"]["server"] == "https://test.com\\path"

--- a/tests/unit/test_cli_config_cmd.py
+++ b/tests/unit/test_cli_config_cmd.py
@@ -1,0 +1,255 @@
+"""Tests for CLI config command."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from magpie.cli import cli
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    """Create a CLI test runner."""
+    return CliRunner()
+
+
+@pytest.fixture
+def config_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Create a temporary config directory and patch the default path."""
+    config_path = tmp_path / ".magpie" / "config.toml"
+    monkeypatch.setattr(
+        "magpie.cli.config.DEFAULT_CONFIG_PATH",
+        config_path,
+    )
+    return config_path
+
+
+class TestConfigShow:
+    """Tests for 'magpie config --show' command."""
+
+    def test_show_no_config_file(self, runner: CliRunner, config_dir: Path) -> None:
+        """Test --show with no config file."""
+        result = runner.invoke(cli, ["config", "--show"])
+
+        assert result.exit_code == 0
+        assert "No configuration file found" in result.output
+        assert "magpie config --server" in result.output
+
+    def test_show_with_config(self, runner: CliRunner, config_dir: Path) -> None:
+        """Test --show with existing config."""
+        config_dir.parent.mkdir(parents=True, exist_ok=True)
+        config_dir.write_text(
+            '[client]\nserver = "https://example.com"\ntoken = "mgp_testtoken123"\n'
+        )
+
+        result = runner.invoke(cli, ["config", "--show"])
+
+        assert result.exit_code == 0
+        assert "https://example.com" in result.output
+        # Token should be masked
+        assert "mgp_testtoken123" not in result.output
+        assert "n123" in result.output  # Last 4 chars visible
+        assert "********" in result.output or "****" in result.output
+
+    def test_show_partial_config(self, runner: CliRunner, config_dir: Path) -> None:
+        """Test --show with only server configured."""
+        config_dir.parent.mkdir(parents=True, exist_ok=True)
+        config_dir.write_text('[client]\nserver = "https://partial.example.com"\n')
+
+        result = runner.invoke(cli, ["config", "--show"])
+
+        assert result.exit_code == 0
+        assert "https://partial.example.com" in result.output
+        assert "(not set)" in result.output
+
+    def test_default_behavior_shows_config(self, runner: CliRunner, config_dir: Path) -> None:
+        """Test that running 'config' without options shows config."""
+        result = runner.invoke(cli, ["config"])
+
+        assert result.exit_code == 0
+        assert "No configuration file found" in result.output
+
+
+class TestConfigSet:
+    """Tests for setting config values."""
+
+    def test_set_server(self, runner: CliRunner, config_dir: Path) -> None:
+        """Test setting server URL."""
+        result = runner.invoke(cli, ["config", "--server", "https://myserver.com"])
+
+        assert result.exit_code == 0
+        assert "Server set to: https://myserver.com" in result.output
+        assert config_dir.exists()
+
+        content = config_dir.read_text()
+        assert 'server = "https://myserver.com"' in content
+
+    def test_set_token(self, runner: CliRunner, config_dir: Path) -> None:
+        """Test setting token."""
+        result = runner.invoke(cli, ["config", "--token", "mgp_secrettoken"])
+
+        assert result.exit_code == 0
+        assert "Token set to:" in result.output
+        # Token should be masked in output
+        assert "mgp_secrettoken" not in result.output
+        assert config_dir.exists()
+
+        content = config_dir.read_text()
+        assert 'token = "mgp_secrettoken"' in content
+
+    def test_set_both(self, runner: CliRunner, config_dir: Path) -> None:
+        """Test setting both server and token."""
+        result = runner.invoke(
+            cli, ["config", "--server", "https://both.example.com", "--token", "mgp_both"]
+        )
+
+        assert result.exit_code == 0
+        assert "Server set to: https://both.example.com" in result.output
+        assert "Token set to:" in result.output
+        assert config_dir.exists()
+
+        content = config_dir.read_text()
+        assert 'server = "https://both.example.com"' in content
+        assert 'token = "mgp_both"' in content
+
+    def test_update_preserves_existing(self, runner: CliRunner, config_dir: Path) -> None:
+        """Test that updating one value preserves other values."""
+        config_dir.parent.mkdir(parents=True, exist_ok=True)
+        config_dir.write_text('[client]\nserver = "https://old.com"\ntoken = "mgp_oldtoken"\n')
+
+        result = runner.invoke(cli, ["config", "--server", "https://new.com"])
+
+        assert result.exit_code == 0
+        content = config_dir.read_text()
+        assert 'server = "https://new.com"' in content
+        assert 'token = "mgp_oldtoken"' in content
+
+    def test_creates_parent_directory(self, runner: CliRunner, config_dir: Path) -> None:
+        """Test that config command creates parent directory if needed."""
+        assert not config_dir.parent.exists()
+
+        result = runner.invoke(cli, ["config", "--server", "https://new.com"])
+
+        assert result.exit_code == 0
+        assert config_dir.parent.exists()
+        assert config_dir.exists()
+
+
+class TestConfigClear:
+    """Tests for 'magpie config --clear' command."""
+
+    def test_clear_existing_config(self, runner: CliRunner, config_dir: Path) -> None:
+        """Test clearing existing config."""
+        config_dir.parent.mkdir(parents=True, exist_ok=True)
+        config_dir.write_text('[client]\nserver = "https://example.com"\n')
+
+        result = runner.invoke(cli, ["config", "--clear"])
+
+        assert result.exit_code == 0
+        assert "Configuration cleared" in result.output
+        assert not config_dir.exists()
+
+    def test_clear_no_config(self, runner: CliRunner, config_dir: Path) -> None:
+        """Test clearing when no config exists."""
+        result = runner.invoke(cli, ["config", "--clear"])
+
+        assert result.exit_code == 0
+        assert "No configuration file found" in result.output
+
+
+class TestConfigValidation:
+    """Tests for config command option validation."""
+
+    def test_clear_with_server_fails(self, runner: CliRunner, config_dir: Path) -> None:
+        """Test that --clear with --server fails."""
+        result = runner.invoke(cli, ["config", "--clear", "--server", "https://example.com"])
+
+        assert result.exit_code != 0
+        assert "Cannot use --clear with --server or --token" in result.output
+
+    def test_clear_with_token_fails(self, runner: CliRunner, config_dir: Path) -> None:
+        """Test that --clear with --token fails."""
+        result = runner.invoke(cli, ["config", "--clear", "--token", "mgp_test"])
+
+        assert result.exit_code != 0
+        assert "Cannot use --clear with --server or --token" in result.output
+
+    def test_show_with_server_fails(self, runner: CliRunner, config_dir: Path) -> None:
+        """Test that --show with --server fails."""
+        result = runner.invoke(cli, ["config", "--show", "--server", "https://example.com"])
+
+        assert result.exit_code != 0
+        assert "Cannot use --show with other options" in result.output
+
+    def test_show_with_clear_fails(self, runner: CliRunner, config_dir: Path) -> None:
+        """Test that --show with --clear fails."""
+        result = runner.invoke(cli, ["config", "--show", "--clear"])
+
+        assert result.exit_code != 0
+        assert "Cannot use --show with other options" in result.output
+
+
+class TestConfigTomlOutput:
+    """Tests for TOML output format."""
+
+    def test_toml_format_valid(self, runner: CliRunner, config_dir: Path) -> None:
+        """Test that output is valid TOML."""
+        runner.invoke(cli, ["config", "--server", "https://test.com", "--token", "mgp_test123"])
+
+        # Try to parse the output with tomllib
+        try:
+            import tomllib
+        except ImportError:
+            import tomli as tomllib  # type: ignore[import-not-found,no-redef]
+
+        content = config_dir.read_bytes()
+        data = tomllib.loads(content.decode())
+
+        assert data["client"]["server"] == "https://test.com"
+        assert data["client"]["token"] == "mgp_test123"
+
+    def test_special_chars_escaped(self, runner: CliRunner, config_dir: Path) -> None:
+        """Test that special characters are properly escaped."""
+        # Test with a token containing quotes
+        runner.invoke(cli, ["config", "--token", 'mgp_test"quote'])
+
+        try:
+            import tomllib
+        except ImportError:
+            import tomli as tomllib  # type: ignore[import-not-found,no-redef]
+
+        content = config_dir.read_bytes()
+        data = tomllib.loads(content.decode())
+
+        assert data["client"]["token"] == 'mgp_test"quote'
+
+    def test_backslash_escaped(self, runner: CliRunner, config_dir: Path) -> None:
+        """Test that backslashes are properly escaped."""
+        runner.invoke(cli, ["config", "--server", "https://test.com\\path"])
+
+        try:
+            import tomllib
+        except ImportError:
+            import tomli as tomllib  # type: ignore[import-not-found,no-redef]
+
+        content = config_dir.read_bytes()
+        data = tomllib.loads(content.decode())
+
+        assert data["client"]["server"] == "https://test.com\\path"
+
+
+class TestConfigHelpText:
+    """Tests for config command help text."""
+
+    def test_help_shows_examples(self, runner: CliRunner) -> None:
+        """Test that help text includes examples."""
+        result = runner.invoke(cli, ["config", "--help"])
+
+        assert result.exit_code == 0
+        assert "--server" in result.output
+        assert "--token" in result.output
+        assert "--show" in result.output
+        assert "--clear" in result.output

--- a/uv.lock
+++ b/uv.lock
@@ -395,6 +395,7 @@ dependencies = [
     { name = "python-multipart" },
     { name = "rich" },
     { name = "sentry-sdk", extra = ["fastapi"] },
+    { name = "tomli-w" },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
@@ -420,6 +421,7 @@ requires-dist = [
     { name = "python-multipart" },
     { name = "rich" },
     { name = "sentry-sdk", extras = ["fastapi"] },
+    { name = "tomli-w" },
     { name = "uvicorn", extras = ["standard"] },
 ]
 
@@ -968,6 +970,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/96/5b/496f8abebd10c3301129abba7ddafd46c71d799a70c44ab080323987c4c9/stevedore-5.6.0.tar.gz", hash = "sha256:f22d15c6ead40c5bbfa9ca54aa7e7b4a07d59b36ae03ed12ced1a54cf0b51945", size = 516074, upload-time = "2025-11-20T10:06:07.264Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/40/8561ce06dc46fd17242c7724ab25b257a2ac1b35f4ebf551b40ce6105cfa/stevedore-5.6.0-py3-none-any.whl", hash = "sha256:4a36dccefd7aeea0c70135526cecb7766c4c84c473b1af68db23d541b6dc1820", size = 54428, upload-time = "2025-11-20T10:06:05.946Z" },
+]
+
+[[package]]
+name = "tomli-w"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184, upload-time = "2025-01-15T12:07:24.262Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675, upload-time = "2025-01-15T12:07:22.074Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds the `magpie config` command that was documented in the user guide but not implemented
- Supports `--server URL` and `--token TOKEN` to set persistent configuration values in `~/.magpie/config.toml`
- Supports `--show` to display current configuration (with masked tokens for security)
- Supports `--clear` to remove the configuration file

## Test plan

- [x] All 420 unit tests pass
- [x] New command tests cover all options (set, show, clear, validation)
- [x] Tests verify TOML output is valid and handles special characters
- [x] Linting passes with ruff check and format

Closes #14

Generated with Claude Code (claude-opus-4-5-20251101)