### PR TITLE
Make get --force skip hash-match optimization

### DIFF
--- a/src/magpie/cli/commands/get.py
+++ b/src/magpie/cli/commands/get.py
@@ -23,7 +23,10 @@ from magpie.storage.hash import compute_hash
 @click.option("--no-verify", is_flag=True, help="Skip SHA-256 verification.")
 @click.option("--quiet", "-q", is_flag=True, help="Suppress progress output.")
 @click.option(
-    "--force", "-f", is_flag=True, help="Overwrite existing output file without prompting."
+    "--force",
+    "-f",
+    is_flag=True,
+    help="Overwrite existing output file without prompting, and re-download even if local hash matches.",
 )
 @click.pass_obj
 def get(
@@ -85,9 +88,10 @@ def get(
         # Check if output file exists before downloading to avoid wasting bandwidth
         if output.exists():
             # If local file has same hash as remote, skip download entirely
+            # (unless --force is set, in which case we re-download anyway)
             # Use compute_hash for streaming hash computation (handles large files)
             local_hash = compute_hash(output)
-            if local_hash == expected_hash:
+            if local_hash == expected_hash and not force:
                 click.echo(f"File already exists with matching hash: {output}")
                 return
 

--- a/tests/integration/test_cli_push_get.py
+++ b/tests/integration/test_cli_push_get.py
@@ -862,6 +862,58 @@ class TestGetCommand:
         assert len(stream_called) == 0, "Download should have been skipped for identical file"
         assert "already exists with matching hash" in result.output
 
+    def test_get_force_redownloads_even_when_hash_matches(
+        self,
+        cli_runner: CliRunner,
+        api_client: TestClient,
+        tmp_path: Path,
+        test_storage_service: StorageService,
+    ) -> None:
+        """Get with --force re-downloads even when local file has matching hash."""
+        # Upload a file
+        test_content = b"content for force hash match test"
+        files = {"file": ("artifact.bin", io.BytesIO(test_content), "application/octet-stream")}
+        api_client.post("/api/v1/upload/forcehashmatch/test", files=files)
+
+        # Create existing output file with SAME content (same hash)
+        output_file = tmp_path / "force_hash_match.bin"
+        output_file.write_bytes(test_content)
+
+        mock_client = MockClientWithDownload(api_client, test_storage_service)
+
+        # Track if stream was called (SHOULD be called when --force is used)
+        original_stream = mock_client.stream
+        stream_called = []
+
+        def tracking_stream(method: str, url: str):
+            stream_called.append((method, url))
+            return original_stream(method, url)
+
+        mock_client.stream = tracking_stream
+
+        with patch(PATCH_GET_CLIENT) as mock_get_client:
+            mock_get_client.return_value = mock_client
+
+            result = cli_runner.invoke(
+                cli,
+                [
+                    "--server",
+                    "http://test",
+                    "get",
+                    "forcehashmatch/test",
+                    "-o",
+                    str(output_file),
+                    "--force",
+                ],
+            )
+
+        assert result.exit_code == 0
+        # Download should have happened despite matching hash
+        assert len(stream_called) == 1, "Download should have occurred with --force"
+        assert "Downloaded:" in result.output
+        # File should still have correct content
+        assert output_file.read_bytes() == test_content
+
 
 class TestPushQuietFlag:
     """Tests for push command --quiet flag and TTY detection."""


### PR DESCRIPTION
## Summary
- Modified `get` command to skip the hash-match optimization when `--force` is set
- Updated the `--force` help text to clarify this behavior: "Overwrite existing output file without prompting, and re-download even if local hash matches"
- Added test `test_get_force_redownloads_even_when_hash_matches` to verify the new behavior

Fixes #77

## Expected behavior:
| Flag | File exists | Hash matches | Action |
|------|-------------|--------------|--------|
| (none) | Yes | - | Prompt/error |
| (none) | Yes | Yes | Skip download |
| `--force` | Yes | No | Overwrite |
| `--force` | Yes | Yes | Re-download anyway |

## Test plan
- [x] `test_get_skips_download_when_local_hash_matches` - Verifies optimization still works without --force
- [x] `test_get_force_redownloads_even_when_hash_matches` - Verifies --force bypasses the optimization
- [x] All existing `--force` tests continue to pass

Generated with Claude Code (Claude Opus 4.5)