### PR TITLE
Add processing indicator after upload completes

### DIFF
--- a/src/magpie/cli/commands/push.py
+++ b/src/magpie/cli/commands/push.py
@@ -54,8 +54,15 @@ class ProgressFileWrapper:
         return data
 
     def seek(self, offset: int, whence: int = 0) -> int:
-        """Seek in file (needed for multipart encoding)."""
-        return self._file.seek(offset, whence)
+        """Seek in file (needed for multipart encoding).
+
+        Resets the bytes read counter to match the new file position,
+        ensuring accurate tracking even if httpx seeks back to re-read.
+        """
+        result = self._file.seek(offset, whence)
+        # Update _bytes_read to match the new file position
+        self._bytes_read = self._file.tell()
+        return result
 
     def tell(self) -> int:
         """Return current position."""

--- a/src/magpie/cli/commands/push.py
+++ b/src/magpie/cli/commands/push.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, BinaryIO
+from typing import TYPE_CHECKING, BinaryIO, Callable
 
 import click
 
@@ -21,18 +21,36 @@ class ProgressFileWrapper:
     def __init__(
         self,
         file: BinaryIO,
+        total_size: int,
         progress: "Progress | None",
         task_id: "TaskID | None",
+        on_upload_complete: Callable[[], None] | None = None,
     ) -> None:
         self._file = file
+        self._total_size = total_size
         self._progress = progress
         self._task_id = task_id
+        self._on_upload_complete = on_upload_complete
+        self._bytes_read = 0
+        self._upload_complete_fired = False
 
     def read(self, size: int = -1) -> bytes:
         """Read bytes and update progress."""
         data = self._file.read(size)
         if self._progress is not None and self._task_id is not None:
             self._progress.update(self._task_id, advance=len(data))
+
+        self._bytes_read += len(data)
+
+        # Fire callback when all bytes have been read (upload complete)
+        if (
+            not self._upload_complete_fired
+            and self._bytes_read >= self._total_size
+            and self._on_upload_complete is not None
+        ):
+            self._upload_complete_fired = True
+            self._on_upload_complete()
+
         return data
 
     def seek(self, offset: int, whence: int = 0) -> int:
@@ -42,6 +60,26 @@ class ProgressFileWrapper:
     def tell(self) -> int:
         """Return current position."""
         return self._file.tell()
+
+
+def _show_processing_status(
+    progress: "Progress | None", upload_task_id: "TaskID | None"
+) -> "TaskID | None":
+    """Update progress display to show processing status.
+
+    Marks the upload task as finished and adds a new indeterminate task
+    to show a spinner while waiting for server response.
+
+    Returns:
+        The processing task ID if created, None otherwise.
+    """
+    if progress is not None and upload_task_id is not None:
+        # Mark the upload task as finished (hides the progress bar)
+        progress.update(upload_task_id, visible=False)
+        # Add a new indeterminate task for processing phase
+        processing_task_id = progress.add_task("Processing", total=None)
+        return processing_task_id
+    return None
 
 
 @click.command()
@@ -88,7 +126,16 @@ def push(
     with transfer_progress("Uploading", file_size, quiet=quiet) as (progress, task_id):
         with ctx.get_client() as client:
             with file.open("rb") as f:
-                wrapped_file = ProgressFileWrapper(f, progress, task_id)
+                # Container for processing task ID (mutable to allow callback to store it)
+                processing_task: list["TaskID | None"] = [None]
+
+                # Create callback to update display when upload completes
+                def on_complete() -> None:
+                    processing_task[0] = _show_processing_status(progress, task_id)
+
+                wrapped_file = ProgressFileWrapper(
+                    f, file_size, progress, task_id, on_upload_complete=on_complete
+                )
                 files = {"file": (file.name, wrapped_file, "application/octet-stream")}
 
                 response = client.post(
@@ -96,6 +143,10 @@ def push(
                     files=files,
                     params=params if params else None,
                 )
+
+                # Hide processing indicator now that we have a response
+                if progress is not None and processing_task[0] is not None:
+                    progress.update(processing_task[0], visible=False)
 
             if response.status_code != 200:
                 _handle_error(response)

--- a/src/magpie/cli/progress.py
+++ b/src/magpie/cli/progress.py
@@ -134,8 +134,8 @@ def processing_spinner(
         return
 
     from rich.console import Console
-    from rich.spinner import Spinner
     from rich.live import Live
+    from rich.spinner import Spinner
 
     console = Console()
     spinner = Spinner("dots", text=f"[bold blue]{message}")

--- a/src/magpie/cli/progress.py
+++ b/src/magpie/cli/progress.py
@@ -110,3 +110,35 @@ def count_progress(
     with progress:
         task_id = progress.add_task(description, total=total)
         yield progress, task_id
+
+
+@contextmanager
+def processing_spinner(
+    message: str = "Processing...",
+    quiet: bool = False,
+) -> Generator[None, None, None]:
+    """Context manager for displaying a processing spinner.
+
+    Shows a spinner with a message while waiting for an operation to complete.
+    Only shows in TTY environments and when not quiet.
+
+    Args:
+        message: Message to display (e.g., "Processing...", "Finalizing...").
+        quiet: If True, suppress spinner output entirely.
+
+    Yields:
+        Nothing. The spinner displays until the context exits.
+    """
+    if quiet or not is_tty():
+        yield
+        return
+
+    from rich.console import Console
+    from rich.spinner import Spinner
+    from rich.live import Live
+
+    console = Console()
+    spinner = Spinner("dots", text=f"[bold blue]{message}")
+
+    with Live(spinner, console=console, refresh_per_second=10):
+        yield

--- a/tests/unit/test_cli_progress.py
+++ b/tests/unit/test_cli_progress.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import io
 import sys
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
-from magpie.cli.progress import count_progress, is_tty, transfer_progress
+from magpie.cli.commands.push import ProgressFileWrapper
+from magpie.cli.progress import count_progress, is_tty, processing_spinner, transfer_progress
 
 
 class TestIsTty:
@@ -119,3 +121,152 @@ class TestCountProgress:
                 assert task_id is not None
                 task = progress.tasks[task_id]
                 assert task.total is None
+
+
+class TestProcessingSpinner:
+    """Tests for processing_spinner context manager."""
+
+    def test_spinner_suppressed_with_quiet_flag(self) -> None:
+        """Test that spinner is suppressed when quiet=True."""
+        with patch("magpie.cli.progress.is_tty", return_value=True):
+            # Should not raise and should do nothing
+            with processing_spinner("Processing...", quiet=True):
+                pass
+
+    def test_spinner_suppressed_when_not_tty(self) -> None:
+        """Test that spinner is suppressed when stdout is not a TTY."""
+        with patch("magpie.cli.progress.is_tty", return_value=False):
+            # Should not raise and should do nothing
+            with processing_spinner("Processing...", quiet=False):
+                pass
+
+    def test_spinner_displayed_in_tty_mode(self) -> None:
+        """Test that spinner is displayed in normal TTY conditions."""
+        with patch("magpie.cli.progress.is_tty", return_value=True):
+            # Should not raise - the spinner context manager runs
+            with processing_spinner("Processing...", quiet=False):
+                pass
+
+    def test_spinner_with_custom_message(self) -> None:
+        """Test that spinner accepts custom message."""
+        with patch("magpie.cli.progress.is_tty", return_value=True):
+            # Should not raise with custom message
+            with processing_spinner("Finalizing upload...", quiet=False):
+                pass
+
+
+class TestProgressFileWrapper:
+    """Tests for ProgressFileWrapper class."""
+
+    def test_read_updates_progress(self) -> None:
+        """Test that reading updates the progress bar."""
+        data = b"Hello, World!"
+        file = io.BytesIO(data)
+        progress = MagicMock()
+        task_id = MagicMock()
+
+        wrapper = ProgressFileWrapper(file, len(data), progress, task_id)
+        result = wrapper.read(5)
+
+        assert result == b"Hello"
+        progress.update.assert_called_once_with(task_id, advance=5)
+
+    def test_read_without_progress(self) -> None:
+        """Test that reading works when progress is None."""
+        data = b"Hello, World!"
+        file = io.BytesIO(data)
+
+        wrapper = ProgressFileWrapper(file, len(data), None, None)
+        result = wrapper.read(5)
+
+        assert result == b"Hello"
+
+    def test_callback_fired_when_upload_complete(self) -> None:
+        """Test that on_upload_complete callback is fired when all bytes read."""
+        data = b"Hello"
+        file = io.BytesIO(data)
+        callback = MagicMock()
+
+        wrapper = ProgressFileWrapper(file, len(data), None, None, on_upload_complete=callback)
+
+        # Read all bytes
+        wrapper.read(-1)
+
+        callback.assert_called_once()
+
+    def test_callback_fired_only_once(self) -> None:
+        """Test that callback is only fired once even if read multiple times."""
+        data = b"Hello, World!"
+        file = io.BytesIO(data)
+        callback = MagicMock()
+
+        wrapper = ProgressFileWrapper(file, len(data), None, None, on_upload_complete=callback)
+
+        # Read all bytes in multiple calls
+        wrapper.read(5)  # "Hello"
+        wrapper.read(8)  # ", World!"
+        wrapper.read()  # Empty read after EOF
+
+        # Callback should only be fired once
+        callback.assert_called_once()
+
+    def test_callback_not_fired_before_complete(self) -> None:
+        """Test that callback is not fired until all bytes are read."""
+        data = b"Hello, World!"
+        file = io.BytesIO(data)
+        callback = MagicMock()
+
+        wrapper = ProgressFileWrapper(file, len(data), None, None, on_upload_complete=callback)
+
+        # Read partial data
+        wrapper.read(5)
+
+        callback.assert_not_called()
+
+    def test_seek_resets_bytes_read(self) -> None:
+        """Test that seek() resets _bytes_read to match file position."""
+        data = b"Hello, World!"
+        file = io.BytesIO(data)
+        callback = MagicMock()
+
+        wrapper = ProgressFileWrapper(file, len(data), None, None, on_upload_complete=callback)
+
+        # Read all bytes
+        wrapper.read(-1)
+        callback.assert_called_once()
+
+        # Seek back to beginning
+        wrapper.seek(0)
+
+        # _bytes_read should now be 0, matching file position
+        assert wrapper._bytes_read == 0
+
+    def test_seek_allows_reread_without_duplicate_callback(self) -> None:
+        """Test that seeking back and re-reading doesn't fire callback again."""
+        data = b"Hello"
+        file = io.BytesIO(data)
+        callback = MagicMock()
+
+        wrapper = ProgressFileWrapper(file, len(data), None, None, on_upload_complete=callback)
+
+        # Read all bytes - callback fires
+        wrapper.read(-1)
+        assert callback.call_count == 1
+
+        # Seek back to beginning
+        wrapper.seek(0)
+
+        # Read all bytes again - callback should NOT fire again
+        wrapper.read(-1)
+        assert callback.call_count == 1  # Still only 1 call
+
+    def test_tell_returns_current_position(self) -> None:
+        """Test that tell() returns current file position."""
+        data = b"Hello, World!"
+        file = io.BytesIO(data)
+
+        wrapper = ProgressFileWrapper(file, len(data), None, None)
+
+        assert wrapper.tell() == 0
+        wrapper.read(5)
+        assert wrapper.tell() == 5


### PR DESCRIPTION
## Summary

- Adds a visible "Processing..." spinner after file upload reaches 100%
- Spinner appears while waiting for server to process (hash, store, etc.)
- Indicator disappears when HTTP response is received

Closes #76

## Changes

- Enhanced `ProgressFileWrapper` to track total bytes and fire callback on upload completion
- Added `_show_processing_status()` function to transition from upload bar to processing spinner
- Added `processing_spinner` context manager in progress.py for standalone spinner use

## Example output

```
  Uploading ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 2.1GB/2.1GB 0:01:23
  ⠋ Processing
Uploaded: abc12345...
```

## Test plan

- [x] Existing push tests pass (29/31 - 2 pre-existing failures unrelated to this change)
- [ ] Manual test with large file upload to verify spinner visibility

---

🤖 Generated with [Claude Code](https://claude.ai/code) using Claude Opus 4.5