### PR TITLE
Fix misleading GC output label for removed items

### DIFF
--- a/src/magpie/cli/commands/gc.py
+++ b/src/magpie/cli/commands/gc.py
@@ -81,6 +81,12 @@ def gc(ctx: CLIContext, dry_run: bool) -> None:
         f"  Space {'reclaimable' if dry_run else 'reclaimed'}: {_format_size(data['space_reclaimed_bytes'])}"
     )
 
+    # Display items removed (directories + manifest files)
+    items_removed = data.get("items_removed", 0)
+    if items_removed > 0:
+        action = "Would remove" if dry_run else "Removed"
+        click.echo(f"  {action} empty items: {items_removed}")
+
 
 def _handle_error(response: "httpx.Response", message: str | None = None) -> None:
     """Handle HTTP error responses."""

--- a/src/magpie/ctl/commands/gc.py
+++ b/src/magpie/ctl/commands/gc.py
@@ -292,7 +292,7 @@ def gc(
         # Report directory cleanup
         if cleanup_stats.total_removed > 0:
             action = "Would remove" if dry_run else "Removed"
-            click.echo(f"  {action} empty directories: {cleanup_stats.total_removed}")
+            click.echo(f"  {action} empty items: {cleanup_stats.total_removed}")
             if ctx.debug:
                 if cleanup_stats.empty_blobs_dirs:
                     click.echo(f"    - blobs/ dirs: {cleanup_stats.empty_blobs_dirs}", err=True)

--- a/src/magpie/server/routes/gc.py
+++ b/src/magpie/server/routes/gc.py
@@ -30,7 +30,7 @@ class GCResponse(BaseModel):
     space_reclaimed_bytes: int
     symlinks_checked: int
     symlinks_fixed: int
-    directories_removed: int = 0
+    items_removed: int = 0
 
 
 @router.post("/api/v1/gc")
@@ -69,7 +69,7 @@ async def trigger_gc(
     deleted_bytes = 0
     symlinks_checked = 0
     symlinks_fixed = 0
-    directories_removed = 0
+    items_removed = 0
 
     now = datetime.now(timezone.utc)
 
@@ -135,10 +135,10 @@ async def trigger_gc(
                 deleted_blobs += 1
                 deleted_bytes += blob_size
 
-        # Cleanup pass: remove empty directories after blob deletion
+        # Cleanup pass: remove empty directories and manifests after blob deletion
         for artifact_dir in artifact_dirs_to_cleanup:
             stats = cleanup_artifact_directories(artifact_dir, storage_path, dry_run)
-            directories_removed += stats.total_removed
+            items_removed += stats.total_removed
 
     return GCResponse(
         dry_run=dry_run,
@@ -148,7 +148,7 @@ async def trigger_gc(
         space_reclaimed_bytes=deleted_bytes,
         symlinks_checked=symlinks_checked,
         symlinks_fixed=symlinks_fixed,
-        directories_removed=directories_removed,
+        items_removed=items_removed,
     )
 
 

--- a/tests/integration/test_gc_endpoint.py
+++ b/tests/integration/test_gc_endpoint.py
@@ -336,9 +336,7 @@ class TestGCDeletesUntaggedBlobs:
 class TestGCDirectoryCleanup:
     """Tests for GC endpoint directory cleanup after blob deletion."""
 
-    def test_gc_response_includes_items_removed(
-        self, client: TestClient, admin_token: str
-    ) -> None:
+    def test_gc_response_includes_items_removed(self, client: TestClient, admin_token: str) -> None:
         """GC response includes items_removed field."""
         response = client.post(
             "/api/v1/gc",

--- a/tests/integration/test_gc_endpoint.py
+++ b/tests/integration/test_gc_endpoint.py
@@ -218,7 +218,7 @@ class TestGCEndpointFunctionality:
             "space_reclaimed_bytes",
             "symlinks_checked",
             "symlinks_fixed",
-            "directories_removed",
+            "items_removed",
         }
         assert required_fields == set(data.keys())
 
@@ -336,10 +336,10 @@ class TestGCDeletesUntaggedBlobs:
 class TestGCDirectoryCleanup:
     """Tests for GC endpoint directory cleanup after blob deletion."""
 
-    def test_gc_response_includes_directories_removed(
+    def test_gc_response_includes_items_removed(
         self, client: TestClient, admin_token: str
     ) -> None:
-        """GC response includes directories_removed field."""
+        """GC response includes items_removed field."""
         response = client.post(
             "/api/v1/gc",
             headers={"Authorization": f"Bearer {admin_token}"},
@@ -347,7 +347,7 @@ class TestGCDirectoryCleanup:
 
         assert response.status_code == 200
         data = response.json()
-        assert "directories_removed" in data
+        assert "items_removed" in data
 
     def test_gc_removes_empty_artifact_directories(
         self, client: TestClient, admin_token: str, test_config: MagpieSettings
@@ -388,7 +388,7 @@ class TestGCDirectoryCleanup:
         assert response.status_code == 200
         data = response.json()
         assert data["blobs_deleted"] >= 1
-        assert data["directories_removed"] >= 1
+        assert data["items_removed"] >= 1
 
         # Artifact directory should be cleaned up
         assert not artifact_dir.exists()
@@ -433,7 +433,7 @@ class TestGCDirectoryCleanup:
         assert response.status_code == 200
         data = response.json()
         assert data["dry_run"] is True
-        assert data["directories_removed"] >= 1
+        assert data["items_removed"] >= 1
 
         # Artifact directory should still exist (dry run)
         assert artifact_dir.exists()

--- a/tests/unit/test_ctl_init_gc.py
+++ b/tests/unit/test_ctl_init_gc.py
@@ -762,7 +762,7 @@ class TestGCDirectoryCleanup:
     def test_gc_reports_directory_cleanup_count(
         self, cli_runner: CliRunner, test_settings: MagpieSettings
     ) -> None:
-        """GC reports number of directories removed in summary."""
+        """GC reports number of items removed in summary."""
         test_settings.storage_path.mkdir(parents=True, exist_ok=True)
         create_artifact_with_blobs(
             test_settings.storage_path,
@@ -776,5 +776,5 @@ class TestGCDirectoryCleanup:
             result = cli_runner.invoke(cli, ["gc"])
 
         assert result.exit_code == 0
-        # Should report removed directories
-        assert "Removed empty directories:" in result.output
+        # Should report removed items (directories + manifest files)
+        assert "Removed empty items:" in result.output


### PR DESCRIPTION
## Summary

- Renamed API response field from `directories_removed` to `items_removed` to accurately reflect that the count includes both empty directories and empty manifest files
- Updated CLI output label from "Removed empty directories" to "Removed empty items"
- Added display of `items_removed` field to the remote CLI client when items are removed

Fixes #80

## Test plan

- [x] Run `uv run pytest tests/unit/test_ctl_init_gc.py tests/integration/test_gc_endpoint.py -v` to verify GC-related tests pass
- [ ] Manual testing: run `magpie-ctl gc` and verify output shows "Removed empty items: N" instead of "Removed empty directories: N"

---
Generated with Claude Code (claude-opus-4-5-20251101)