### PR TITLE
Add comprehensive path normalization for artifact paths

### DIFF
--- a/src/magpie/cli/commands/parse.py
+++ b/src/magpie/cli/commands/parse.py
@@ -23,6 +23,9 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 
+from magpie.storage.exceptions import InvalidArtifactPathError
+from magpie.storage.paths import normalize_artifact_path
+
 # Pattern for validating hash refs: @ followed by 8 hex characters
 HASH_REF_PATTERN = re.compile(r"^@[0-9a-f]{8}$")
 
@@ -67,11 +70,18 @@ def parse_artifact_ref(artifact_ref: str, default_ref: str = "latest") -> Artifa
     Uses colon (:) as the separator between path and ref. This is the
     canonical format that should be used consistently across all CLI commands.
 
+    Path normalization is applied to handle common input variations:
+    - Leading slashes are stripped
+    - Trailing slashes are stripped
+    - Multiple consecutive slashes are collapsed
+
     Examples:
         "images/ubuntu:latest" -> ArtifactRef(path="images/ubuntu", ref="latest")
         "images/ubuntu:@abc12345" -> ArtifactRef(path="images/ubuntu", ref="@abc12345")
         "images/ubuntu" -> ArtifactRef(path="images/ubuntu", ref="latest")
         "project/images/ubuntu:v1.0" -> ArtifactRef(path="project/images/ubuntu", ref="v1.0")
+        "/images/ubuntu:latest" -> ArtifactRef(path="images/ubuntu", ref="latest")
+        "//images//ubuntu//:latest" -> ArtifactRef(path="images/ubuntu", ref="latest")
 
     Args:
         artifact_ref: Artifact reference string in path:ref format.
@@ -103,7 +113,13 @@ def parse_artifact_ref(artifact_ref: str, default_ref: str = "latest") -> Artifa
         path = artifact_ref
         ref = default_ref
 
-    # Validate path
+    # Normalize path (strip leading/trailing slashes, collapse multiple slashes)
+    try:
+        path = normalize_artifact_path(path)
+    except InvalidArtifactPathError as e:
+        raise ParseError(str(e))
+
+    # Validate path components
     _validate_path(path)
 
     # Validate ref
@@ -117,12 +133,20 @@ def parse_artifact_path(artifact_input: str) -> str:
 
     This is for commands that only accept a path (like `ls`). If the user
     provides a ref (path:ref format), the ref is stripped and only the
-    path is returned. Leading slashes are also normalized away.
+    path is returned. Path normalization is applied to handle common
+    input variations.
+
+    Path normalization handles:
+    - Leading slashes are stripped
+    - Trailing slashes are stripped
+    - Multiple consecutive slashes are collapsed
 
     Examples:
         "images/ubuntu" -> "images/ubuntu"
         "images/ubuntu:latest" -> "images/ubuntu" (ref stripped)
         "/images/ubuntu" -> "images/ubuntu" (leading slash stripped)
+        "images/ubuntu/" -> "images/ubuntu" (trailing slash stripped)
+        "//images//ubuntu//" -> "images/ubuntu" (multiple slashes collapsed)
 
     Args:
         artifact_input: Artifact path or path:ref string.
@@ -139,19 +163,23 @@ def parse_artifact_path(artifact_input: str) -> str:
     # Check for common mistakes
     _validate_no_double_colon(artifact_input)
 
-    # Normalize: strip leading slashes
-    path = artifact_input.lstrip("/")
-
-    # If there's a colon, extract just the path
+    # If there's a colon, extract just the path portion first
+    path = artifact_input
     if ":" in path:
         idx = path.rfind(":")
         path = path[:idx]
         # Note: We silently accept and strip the ref for UX
 
-    if not path:
+    if not path or path.strip("/") == "":
         raise ParseError(f"Empty path in input: {artifact_input}")
 
-    # Validate path
+    # Normalize path (strip leading/trailing slashes, collapse multiple slashes)
+    try:
+        path = normalize_artifact_path(path)
+    except InvalidArtifactPathError as e:
+        raise ParseError(str(e))
+
+    # Validate path components
     _validate_path(path)
 
     return path

--- a/src/magpie/cli/commands/push.py
+++ b/src/magpie/cli/commands/push.py
@@ -13,6 +13,8 @@ if TYPE_CHECKING:
 from magpie.cli import CLIContext
 from magpie.cli.progress import transfer_progress
 from magpie.cli.utils import handle_http_error
+from magpie.storage.exceptions import InvalidArtifactPathError
+from magpie.storage.paths import normalize_artifact_path
 
 
 class ProgressFileWrapper:
@@ -116,6 +118,12 @@ def push(
     """
     if not ctx.server:
         raise click.ClickException("No server configured. Use --server or set MAGPIE_SERVER.")
+
+    # Normalize artifact path
+    try:
+        artifact_path = normalize_artifact_path(artifact_path)
+    except InvalidArtifactPathError as e:
+        raise click.ClickException(str(e))
 
     # Build query params
     params: dict[str, str] = {}

--- a/src/magpie/cli/commands/untag.py
+++ b/src/magpie/cli/commands/untag.py
@@ -6,6 +6,8 @@ import click
 
 from magpie.cli import CLIContext
 from magpie.cli.utils import handle_http_error
+from magpie.storage.exceptions import InvalidArtifactPathError
+from magpie.storage.paths import normalize_artifact_path
 
 
 @click.command()
@@ -27,6 +29,12 @@ def untag(ctx: CLIContext, artifact_path: str, tag_name: str) -> None:
     """
     if not ctx.server:
         raise click.ClickException("No server configured. Use --server or set MAGPIE_SERVER.")
+
+    # Normalize artifact path
+    try:
+        artifact_path = normalize_artifact_path(artifact_path)
+    except InvalidArtifactPathError as e:
+        raise click.ClickException(str(e))
 
     with ctx.get_client() as client:
         if ctx.debug:

--- a/src/magpie/server/routes/artifacts.py
+++ b/src/magpie/server/routes/artifacts.py
@@ -5,14 +5,35 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, Response, status
+from fastapi import APIRouter, Depends, HTTPException, Response, status
 from pydantic import BaseModel
 
 from magpie.server.deps import get_storage_service, require_write_scope
-from magpie.storage.exceptions import ArtifactNotFoundError
+from magpie.storage.exceptions import ArtifactNotFoundError, InvalidArtifactPathError
+from magpie.storage.paths import normalize_artifact_path
 from magpie.storage.service import StorageService
 
 router = APIRouter()
+
+
+def _normalize_path(path: str) -> str:
+    """Normalize artifact path for defense in depth.
+
+    CLI should also normalize, but server validates as well.
+
+    Args:
+        path: Raw artifact path from request.
+
+    Returns:
+        Normalized path.
+
+    Raises:
+        HTTPException 400: If path is invalid.
+    """
+    try:
+        return normalize_artifact_path(path)
+    except InvalidArtifactPathError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
 
 
 class VersionInfo(BaseModel):
@@ -95,6 +116,7 @@ async def get_artifact_info(
         ArtifactNotFoundError: If path doesn't exist or ref doesn't resolve.
             Automatically converted to HTTP 404 by error handlers.
     """
+    path = _normalize_path(path)
     info = storage_service.get_artifact_info(path, ref)
 
     return ArtifactInfoResponse(
@@ -138,6 +160,8 @@ async def create_tag(
         ArtifactNotFoundError: If path doesn't exist or ref doesn't resolve.
             Automatically converted to HTTP 404 by error handlers.
     """
+    path = _normalize_path(path)
+
     # Resolve ref (tag name or hash ref) to get the hash_ref
     # This handles both "latest" (tag) and "@abc123" (hash ref) formats
     existing_info = storage_service.get_artifact_info(path, ref)
@@ -182,6 +206,7 @@ async def remove_tag(
         ArtifactNotFoundError: If path doesn't exist or tag doesn't exist.
             Automatically converted to HTTP 404 by error handlers.
     """
+    path = _normalize_path(path)
     removed = storage_service.remove_tag(path, tag_name)
 
     if not removed:
@@ -221,6 +246,8 @@ async def amend_metadata(
         ArtifactNotFoundError: If path doesn't exist or ref doesn't resolve.
             Automatically converted to HTTP 404 by error handlers.
     """
+    path = _normalize_path(path)
+
     # Resolve ref (tag name or hash ref) to get the hash_ref
     existing_info = storage_service.get_artifact_info(path, ref)
 
@@ -258,6 +285,13 @@ async def list_artifact_paths(
     Returns:
         ArtifactPathsResponse with list of matching artifact paths.
     """
+    # Normalize prefix if provided (empty string is valid for listing all)
+    if prefix:
+        try:
+            prefix = normalize_artifact_path(prefix)
+        except InvalidArtifactPathError as e:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
     paths = storage_service.list_artifact_paths(prefix)
     return ArtifactPathsResponse(paths=paths)
 
@@ -279,6 +313,7 @@ async def list_artifacts(
         ArtifactListResponse with artifact path and list of versions.
         Empty versions list if path doesn't exist.
     """
+    path = _normalize_path(path)
     artifact_infos = storage_service.list_artifacts(path)
 
     versions = [

--- a/src/magpie/server/routes/upload.py
+++ b/src/magpie/server/routes/upload.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 import logging
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, Header, UploadFile
+from fastapi import APIRouter, Depends, Header, HTTPException, UploadFile, status
 from pydantic import BaseModel
 
 from magpie.server.deps import get_storage_service, require_write_scope
+from magpie.storage.exceptions import InvalidArtifactPathError
+from magpie.storage.paths import normalize_artifact_path
 from magpie.storage.service import StorageService
 
 logger = logging.getLogger(__name__)
@@ -64,6 +66,12 @@ async def upload_artifact(
         HTTPException 403: If token has read scope (insufficient permissions).
         StorageError: If storage operation fails.
     """
+    # Normalize path for defense in depth (CLI should also normalize)
+    try:
+        path = normalize_artifact_path(path)
+    except InvalidArtifactPathError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
     # Use X-Magpie-User header if present (authenticated via Caddy)
     # Fall back to query parameter for direct API access
     if x_magpie_user is not None:

--- a/src/magpie/storage/paths.py
+++ b/src/magpie/storage/paths.py
@@ -63,9 +63,16 @@ def verify_path_is_descendant(base: Path, artifact_path: str) -> Path:
     the resolved path rather than just token-based validation. After constructing
     the full path, this function verifies it remains within the base directory.
 
+    Note:
+        This function expects artifact_path to be pre-normalized via
+        normalize_artifact_path(). Paths containing ".." segments should be
+        rejected by normalize_artifact_path before reaching this function.
+        This function provides an additional safety layer to catch any
+        traversal attempts that might bypass token-based validation.
+
     Args:
         base: Base storage directory path (must be absolute).
-        artifact_path: Normalized artifact path string.
+        artifact_path: Normalized artifact path string (no ".." segments).
 
     Returns:
         The resolved full path if it is a valid descendant.
@@ -77,8 +84,6 @@ def verify_path_is_descendant(base: Path, artifact_path: str) -> Path:
         >>> base = Path("/storage/artifacts")
         >>> verify_path_is_descendant(base, "project/artifact")
         PosixPath('/storage/artifacts/project/artifact')
-        >>> verify_path_is_descendant(base, "../escape")
-        Raises InvalidArtifactPathError
     """
     # Construct the full path
     full_path = (base / artifact_path).resolve()

--- a/src/magpie/storage/paths.py
+++ b/src/magpie/storage/paths.py
@@ -53,6 +53,7 @@ def normalize_artifact_path(path: str) -> str:
 
     return path
 
+
 # Reserved directory names that cannot appear in artifact paths
 RESERVED_SEGMENTS = {"blobs", "metadata", ".magpie"}
 

--- a/src/magpie/storage/paths.py
+++ b/src/magpie/storage/paths.py
@@ -43,8 +43,10 @@ def normalize_artifact_path(path: str) -> str:
     # Collapse multiple consecutive slashes to single slash
     path = re.sub(r"/+", "/", path)
 
-    # Check for path traversal attempts
-    if ".." in path:
+    # Check for path traversal attempts using segment-based validation
+    # This avoids false positives for legitimate paths like "v1..2" or "test..file"
+    segments = path.split("/") if path else []
+    if any(segment == ".." for segment in segments):
         raise InvalidArtifactPathError("Path traversal '..' is not allowed in artifact paths")
 
     # Check for empty path after normalization
@@ -52,6 +54,50 @@ def normalize_artifact_path(path: str) -> str:
         raise InvalidArtifactPathError("Artifact path cannot be empty")
 
     return path
+
+
+def verify_path_is_descendant(base: Path, artifact_path: str) -> Path:
+    """Verify that a constructed path is strictly a descendant of the base directory.
+
+    This provides defense-in-depth against path traversal attacks by checking
+    the resolved path rather than just token-based validation. After constructing
+    the full path, this function verifies it remains within the base directory.
+
+    Args:
+        base: Base storage directory path (must be absolute).
+        artifact_path: Normalized artifact path string.
+
+    Returns:
+        The resolved full path if it is a valid descendant.
+
+    Raises:
+        InvalidArtifactPathError: If the resolved path escapes the base directory.
+
+    Example:
+        >>> base = Path("/storage/artifacts")
+        >>> verify_path_is_descendant(base, "project/artifact")
+        PosixPath('/storage/artifacts/project/artifact')
+        >>> verify_path_is_descendant(base, "../escape")
+        Raises InvalidArtifactPathError
+    """
+    # Construct the full path
+    full_path = (base / artifact_path).resolve()
+    base_resolved = base.resolve()
+
+    # Check if the resolved path is under the base directory
+    # Using is_relative_to() which returns True if path is relative to base
+    try:
+        full_path.relative_to(base_resolved)
+    except ValueError:
+        raise InvalidArtifactPathError(
+            f"Path '{artifact_path}' resolves outside the storage directory"
+        )
+
+    # Additional check: ensure it's not the base directory itself
+    if full_path == base_resolved:
+        raise InvalidArtifactPathError("Artifact path cannot resolve to storage root")
+
+    return full_path
 
 
 # Reserved directory names that cannot appear in artifact paths

--- a/src/magpie/storage/paths.py
+++ b/src/magpie/storage/paths.py
@@ -2,9 +2,56 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 from magpie.storage.exceptions import InvalidArtifactPathError
+
+
+def normalize_artifact_path(path: str) -> str:
+    """Normalize artifact path, stripping leading/trailing slashes.
+
+    This function provides consistent path normalization for artifact paths
+    across CLI commands and server routes. It handles common input variations
+    like leading slashes, trailing slashes, and multiple consecutive slashes.
+
+    Args:
+        path: Raw artifact path string from user input.
+
+    Returns:
+        Normalized path with leading/trailing slashes removed and
+        multiple slashes collapsed to single slashes.
+
+    Raises:
+        InvalidArtifactPathError: If path contains traversal (..) or is empty.
+
+    Examples:
+        >>> normalize_artifact_path("/test/artifact")
+        'test/artifact'
+        >>> normalize_artifact_path("test/artifact/")
+        'test/artifact'
+        >>> normalize_artifact_path("//test//artifact//")
+        'test/artifact'
+        >>> normalize_artifact_path("test/../other")
+        Raises InvalidArtifactPathError
+        >>> normalize_artifact_path("")
+        Raises InvalidArtifactPathError
+    """
+    # Strip leading and trailing slashes
+    path = path.strip("/")
+
+    # Collapse multiple consecutive slashes to single slash
+    path = re.sub(r"/+", "/", path)
+
+    # Check for path traversal attempts
+    if ".." in path:
+        raise InvalidArtifactPathError("Path traversal '..' is not allowed in artifact paths")
+
+    # Check for empty path after normalization
+    if not path:
+        raise InvalidArtifactPathError("Artifact path cannot be empty")
+
+    return path
 
 # Reserved directory names that cannot appear in artifact paths
 RESERVED_SEGMENTS = {"blobs", "metadata", ".magpie"}

--- a/src/magpie/storage/service.py
+++ b/src/magpie/storage/service.py
@@ -22,6 +22,7 @@ from magpie.storage.paths import (
     artifact_dir_path,
     check_artifact_nesting,
     validate_artifact_path,
+    verify_path_is_descendant,
 )
 from magpie.storage.symlinks import reconcile_symlinks
 
@@ -93,6 +94,9 @@ class StorageService:
         """
         # Validate artifact path for reserved names
         validate_artifact_path(artifact_path)
+
+        # Defense-in-depth: verify resolved path stays within storage directory
+        verify_path_is_descendant(self.config.storage_path, artifact_path)
 
         # Check for nesting conflicts with existing artifacts
         check_artifact_nesting(self.config.storage_path, artifact_path)

--- a/tests/unit/test_parse.py
+++ b/tests/unit/test_parse.py
@@ -93,10 +93,12 @@ class TestParseArtifactRefErrors:
         with pytest.raises(ParseError, match="Empty ref after colon"):
             parse_artifact_ref("images/ubuntu:")
 
-    def test_double_slash_in_path_raises_error(self) -> None:
-        """Double slash in path raises ParseError."""
-        with pytest.raises(ParseError, match="Empty component"):
-            parse_artifact_ref("images//ubuntu:latest")
+    def test_double_slash_in_path_is_normalized(self) -> None:
+        """Double slash in path is normalized (collapsed to single slash)."""
+        # With path normalization, double slashes are collapsed rather than rejected
+        result = parse_artifact_ref("images//ubuntu:latest")
+        assert result.path == "images/ubuntu"
+        assert result.ref == "latest"
 
     def test_invalid_path_component_starting_char(self) -> None:
         """Path component starting with non-alphanumeric raises error."""
@@ -278,3 +280,78 @@ class TestParseEdgeCases:
         result = parse_artifact_ref("app/release:v1.2.3-rc1")
         assert result.path == "app/release"
         assert result.ref == "v1.2.3-rc1"
+
+
+class TestParsePathNormalization:
+    """Tests for path normalization in parse functions."""
+
+    def test_parse_ref_strips_leading_slash(self) -> None:
+        """parse_artifact_ref strips leading slash from path."""
+        result = parse_artifact_ref("/images/ubuntu:latest")
+        assert result.path == "images/ubuntu"
+        assert result.ref == "latest"
+
+    def test_parse_ref_strips_trailing_slash(self) -> None:
+        """parse_artifact_ref strips trailing slash from path."""
+        result = parse_artifact_ref("images/ubuntu/:latest")
+        assert result.path == "images/ubuntu"
+        assert result.ref == "latest"
+
+    def test_parse_ref_strips_both_slashes(self) -> None:
+        """parse_artifact_ref strips both leading and trailing slashes."""
+        result = parse_artifact_ref("/images/ubuntu/:latest")
+        assert result.path == "images/ubuntu"
+        assert result.ref == "latest"
+
+    def test_parse_ref_collapses_multiple_slashes(self) -> None:
+        """parse_artifact_ref collapses multiple consecutive slashes."""
+        result = parse_artifact_ref("images//ubuntu:latest")
+        assert result.path == "images/ubuntu"
+        assert result.ref == "latest"
+
+    def test_parse_ref_full_normalization(self) -> None:
+        """parse_artifact_ref applies all normalizations."""
+        result = parse_artifact_ref("//images//ubuntu//:latest")
+        assert result.path == "images/ubuntu"
+        assert result.ref == "latest"
+
+    def test_parse_ref_rejects_path_traversal(self) -> None:
+        """parse_artifact_ref rejects path traversal."""
+        with pytest.raises(ParseError, match="Path traversal"):
+            parse_artifact_ref("images/../etc:latest")
+
+    def test_parse_path_strips_leading_slash(self) -> None:
+        """parse_artifact_path strips leading slash."""
+        result = parse_artifact_path("/images/ubuntu")
+        assert result == "images/ubuntu"
+
+    def test_parse_path_strips_trailing_slash(self) -> None:
+        """parse_artifact_path strips trailing slash."""
+        result = parse_artifact_path("images/ubuntu/")
+        assert result == "images/ubuntu"
+
+    def test_parse_path_collapses_multiple_slashes(self) -> None:
+        """parse_artifact_path collapses multiple consecutive slashes."""
+        result = parse_artifact_path("images//ubuntu")
+        assert result == "images/ubuntu"
+
+    def test_parse_path_full_normalization(self) -> None:
+        """parse_artifact_path applies all normalizations."""
+        result = parse_artifact_path("//images//ubuntu//")
+        assert result == "images/ubuntu"
+
+    def test_parse_path_rejects_path_traversal(self) -> None:
+        """parse_artifact_path rejects path traversal."""
+        with pytest.raises(ParseError, match="Path traversal"):
+            parse_artifact_path("images/../etc")
+
+    def test_parse_path_strips_ref_with_normalization(self) -> None:
+        """parse_artifact_path strips ref and normalizes path."""
+        result = parse_artifact_path("/images//ubuntu/:latest")
+        assert result == "images/ubuntu"
+
+    def test_parse_ref_without_ref_normalizes(self) -> None:
+        """parse_artifact_ref without explicit ref still normalizes path."""
+        result = parse_artifact_ref("/images//ubuntu/")
+        assert result.path == "images/ubuntu"
+        assert result.ref == "latest"

--- a/tests/unit/test_path_validation.py
+++ b/tests/unit/test_path_validation.py
@@ -7,7 +7,11 @@ from pathlib import Path
 import pytest
 
 from magpie.storage.exceptions import InvalidArtifactPathError
-from magpie.storage.paths import check_artifact_nesting, validate_artifact_path
+from magpie.storage.paths import (
+    check_artifact_nesting,
+    normalize_artifact_path,
+    validate_artifact_path,
+)
 
 
 class TestValidateArtifactPath:
@@ -181,3 +185,90 @@ class TestCheckArtifactNesting:
 
         # Should allow sibling
         check_artifact_nesting(tmp_path, "org/team1/project2")
+
+
+class TestNormalizeArtifactPath:
+    """Tests for normalize_artifact_path function."""
+
+    def test_simple_path_unchanged(self) -> None:
+        """Simple path without special characters is unchanged."""
+        assert normalize_artifact_path("test/artifact") == "test/artifact"
+
+    def test_single_component_path(self) -> None:
+        """Single component path is unchanged."""
+        assert normalize_artifact_path("artifact") == "artifact"
+
+    def test_strip_leading_slash(self) -> None:
+        """Leading slash is stripped."""
+        assert normalize_artifact_path("/test/artifact") == "test/artifact"
+
+    def test_strip_trailing_slash(self) -> None:
+        """Trailing slash is stripped."""
+        assert normalize_artifact_path("test/artifact/") == "test/artifact"
+
+    def test_strip_both_slashes(self) -> None:
+        """Both leading and trailing slashes are stripped."""
+        assert normalize_artifact_path("/test/artifact/") == "test/artifact"
+
+    def test_collapse_multiple_slashes(self) -> None:
+        """Multiple consecutive slashes are collapsed to single slash."""
+        assert normalize_artifact_path("test//artifact") == "test/artifact"
+
+    def test_collapse_many_slashes(self) -> None:
+        """Many consecutive slashes are collapsed."""
+        assert normalize_artifact_path("test////artifact") == "test/artifact"
+
+    def test_combined_normalization(self) -> None:
+        """All normalizations applied together."""
+        assert normalize_artifact_path("//test//artifact//") == "test/artifact"
+
+    def test_complex_path_normalization(self) -> None:
+        """Complex path with multiple issues is normalized."""
+        assert normalize_artifact_path("///foo///bar///baz///") == "foo/bar/baz"
+
+    def test_reject_path_traversal_double_dot(self) -> None:
+        """Path traversal with .. is rejected."""
+        with pytest.raises(InvalidArtifactPathError, match="Path traversal.*not allowed"):
+            normalize_artifact_path("test/../other")
+
+    def test_reject_path_traversal_at_start(self) -> None:
+        """Path traversal at start is rejected."""
+        with pytest.raises(InvalidArtifactPathError, match="Path traversal.*not allowed"):
+            normalize_artifact_path("../test")
+
+    def test_reject_path_traversal_at_end(self) -> None:
+        """Path traversal at end is rejected."""
+        with pytest.raises(InvalidArtifactPathError, match="Path traversal.*not allowed"):
+            normalize_artifact_path("test/..")
+
+    def test_reject_only_double_dot(self) -> None:
+        """Just .. is rejected."""
+        with pytest.raises(InvalidArtifactPathError, match="Path traversal.*not allowed"):
+            normalize_artifact_path("..")
+
+    def test_reject_empty_path(self) -> None:
+        """Empty path is rejected."""
+        with pytest.raises(InvalidArtifactPathError, match="cannot be empty"):
+            normalize_artifact_path("")
+
+    def test_reject_only_slashes(self) -> None:
+        """Path with only slashes is rejected (becomes empty after strip)."""
+        with pytest.raises(InvalidArtifactPathError, match="cannot be empty"):
+            normalize_artifact_path("///")
+
+    def test_reject_only_leading_slash(self) -> None:
+        """Path with only leading slash is rejected."""
+        with pytest.raises(InvalidArtifactPathError, match="cannot be empty"):
+            normalize_artifact_path("/")
+
+    def test_deeply_nested_path(self) -> None:
+        """Deeply nested path is normalized correctly."""
+        assert normalize_artifact_path("/a/b/c/d/e/") == "a/b/c/d/e"
+
+    def test_path_with_dots_allowed(self) -> None:
+        """Single dots in path components are allowed (not traversal)."""
+        # This tests that single dots within names are ok (e.g., version numbers)
+        # The ".." traversal is blocked, but "v1.0" or "file.tar" should work
+        # However, note that validate_artifact_path blocks segments starting with "."
+        # The normalize function only checks for ".." traversal
+        assert normalize_artifact_path("v1.0/artifact") == "v1.0/artifact"

--- a/tests/unit/test_path_validation.py
+++ b/tests/unit/test_path_validation.py
@@ -327,11 +327,3 @@ class TestVerifyPathIsDescendant:
         """Double dots within filenames are allowed (not traversal)."""
         result = verify_path_is_descendant(tmp_path, "v1..2/artifact")
         assert result == tmp_path / "v1..2" / "artifact"
-
-    def test_path_stays_within_base(self, tmp_path: Path) -> None:
-        """Path that goes up then down but stays in base is valid."""
-        # Note: This tests that "project/../other" resolves to "other" which is valid
-        # The segment-based check in normalize_artifact_path would catch ".."
-        # but this test verifies the resolution behavior
-        result = verify_path_is_descendant(tmp_path, "project/../other")
-        assert result == tmp_path / "other"

--- a/tests/unit/test_path_validation.py
+++ b/tests/unit/test_path_validation.py
@@ -11,6 +11,7 @@ from magpie.storage.paths import (
     check_artifact_nesting,
     normalize_artifact_path,
     validate_artifact_path,
+    verify_path_is_descendant,
 )
 
 
@@ -272,3 +273,65 @@ class TestNormalizeArtifactPath:
         # However, note that validate_artifact_path blocks segments starting with "."
         # The normalize function only checks for ".." traversal
         assert normalize_artifact_path("v1.0/artifact") == "v1.0/artifact"
+
+    def test_double_dot_in_filename_allowed(self) -> None:
+        """Double dots within filenames are allowed (not path traversal).
+
+        This tests that segment-based validation correctly allows paths like
+        "v1..2" or "test..file" which contain ".." as part of a filename
+        but are not path traversal attempts.
+        """
+        assert normalize_artifact_path("v1..2/artifact") == "v1..2/artifact"
+        assert normalize_artifact_path("test..file") == "test..file"
+        assert normalize_artifact_path("project/name..ext") == "project/name..ext"
+
+    def test_double_dot_as_segment_rejected(self) -> None:
+        """Double dots as a complete path segment are rejected."""
+        with pytest.raises(InvalidArtifactPathError, match="Path traversal.*not allowed"):
+            normalize_artifact_path("test/../other")
+        with pytest.raises(InvalidArtifactPathError, match="Path traversal.*not allowed"):
+            normalize_artifact_path("../test")
+        with pytest.raises(InvalidArtifactPathError, match="Path traversal.*not allowed"):
+            normalize_artifact_path("test/..")
+
+
+class TestVerifyPathIsDescendant:
+    """Tests for verify_path_is_descendant function."""
+
+    def test_valid_simple_descendant(self, tmp_path: Path) -> None:
+        """Valid simple path is a descendant of base."""
+        result = verify_path_is_descendant(tmp_path, "artifact")
+        assert result == tmp_path / "artifact"
+
+    def test_valid_nested_descendant(self, tmp_path: Path) -> None:
+        """Valid nested path is a descendant of base."""
+        result = verify_path_is_descendant(tmp_path, "project/component/artifact")
+        assert result == tmp_path / "project" / "component" / "artifact"
+
+    def test_reject_traversal_escape(self, tmp_path: Path) -> None:
+        """Path traversal that escapes base is rejected."""
+        with pytest.raises(InvalidArtifactPathError, match="resolves outside"):
+            verify_path_is_descendant(tmp_path, "../escape")
+
+    def test_reject_complex_traversal(self, tmp_path: Path) -> None:
+        """Complex path traversal that escapes base is rejected."""
+        with pytest.raises(InvalidArtifactPathError, match="resolves outside"):
+            verify_path_is_descendant(tmp_path, "project/../../escape")
+
+    def test_reject_root_path(self, tmp_path: Path) -> None:
+        """Path that resolves to base directory itself is rejected."""
+        with pytest.raises(InvalidArtifactPathError, match="resolve to storage root"):
+            verify_path_is_descendant(tmp_path, ".")
+
+    def test_double_dot_in_filename_allowed(self, tmp_path: Path) -> None:
+        """Double dots within filenames are allowed (not traversal)."""
+        result = verify_path_is_descendant(tmp_path, "v1..2/artifact")
+        assert result == tmp_path / "v1..2" / "artifact"
+
+    def test_path_stays_within_base(self, tmp_path: Path) -> None:
+        """Path that goes up then down but stays in base is valid."""
+        # Note: This tests that "project/../other" resolves to "other" which is valid
+        # The segment-based check in normalize_artifact_path would catch ".."
+        # but this test verifies the resolution behavior
+        result = verify_path_is_descendant(tmp_path, "project/../other")
+        assert result == tmp_path / "other"


### PR DESCRIPTION
## Summary

- Add `normalize_artifact_path()` function in storage/paths.py for consistent path handling
- Apply normalization in all CLI commands via the parse module
- Apply normalization in server routes as defense in depth
- Add comprehensive unit tests for the normalization function

Fixes #79

## Test plan

- [x] Run `uv run pytest tests/unit tests/integration -x`
- [x] Verify `/test/artifact` normalizes to `test/artifact`
- [x] Verify `test/artifact/` normalizes to `test/artifact`
- [x] Verify `//test//artifact//` normalizes to `test/artifact`
- [x] Verify `test/../other` is rejected with path traversal error
- [x] Verify empty path is rejected

Note: Some pre-existing test failures unrelated to this PR (test_*_requires_server tests) are excluded from the test run.

---
Generated with [Claude Code](https://claude.ai/code) (Claude Opus 4.5)