### PR TITLE
Improve token rejection UX for CLI commands

### DIFF
--- a/src/magpie/cli/commands/amend.py
+++ b/src/magpie/cli/commands/amend.py
@@ -2,12 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import click
-
-if TYPE_CHECKING:
-    import httpx
 
 from magpie.cli import CLIContext
 from magpie.cli.commands.parse import ParseError, parse_artifact_ref

--- a/src/magpie/cli/commands/amend.py
+++ b/src/magpie/cli/commands/amend.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
 
 from magpie.cli import CLIContext
 from magpie.cli.commands.parse import ParseError, parse_artifact_ref
+from magpie.cli.utils import handle_http_error
 
 
 @click.command()
@@ -62,7 +63,7 @@ def amend(ctx: CLIContext, artifact_ref: str, source_uri: str | None) -> None:
         if response.status_code == 404:
             raise click.ClickException(f"Artifact not found: {parsed.path}:{parsed.ref}")
         if response.status_code != 200:
-            _handle_error(response)
+            handle_http_error(response, "Amend", ctx.token)
 
         data = response.json()
 
@@ -70,13 +71,3 @@ def amend(ctx: CLIContext, artifact_ref: str, source_uri: str | None) -> None:
     click.echo(f"Updated: {parsed.path}:{data['hash_ref']}")
     click.echo(f"  Source URI: {data.get('source_uri') or '(none)'}")
     click.echo(f"  Tags: {', '.join(data.get('tags', []))}")
-
-
-def _handle_error(response: "httpx.Response") -> None:
-    """Handle HTTP error responses."""
-    try:
-        detail = response.json().get("detail", response.text)
-    except Exception:
-        detail = response.text
-
-    raise click.ClickException(f"Amend failed ({response.status_code}): {detail}")

--- a/src/magpie/cli/commands/config_cmd.py
+++ b/src/magpie/cli/commands/config_cmd.py
@@ -8,24 +8,7 @@ import click
 import tomli_w
 
 from magpie.cli import config as cli_config
-
-# Standard mask for hiding sensitive token values
-TOKEN_MASK = "********"  # nosec B105 - display placeholder, not a real password
-
-
-def _mask_token(token: str) -> str:
-    """Mask a token for display, showing only last 4 characters.
-
-    Args:
-        token: The token to mask.
-
-    Returns:
-        Masked token string with last 4 chars visible, or just the mask
-        if token is 4 chars or shorter.
-    """
-    if len(token) > 4:
-        return TOKEN_MASK + token[-4:]
-    return TOKEN_MASK
+from magpie.cli.utils import mask_token
 
 
 def _write_config(config_path: Path, server: str | None, token: str | None) -> None:
@@ -128,7 +111,7 @@ def config_cmd(
     if server:
         click.echo(f"Server set to: {server}")
     if token:
-        click.echo(f"Token set to: {_mask_token(token)}")
+        click.echo(f"Token set to: {mask_token(token)}")
 
     click.echo(f"Configuration saved to {config_path}")
 
@@ -150,7 +133,7 @@ def _show_config(config_path: Path) -> None:
         click.echo("  server = (not set)")
 
     if config.client.token:
-        click.echo(f"  token  = {_mask_token(config.client.token)}")
+        click.echo(f"  token  = {mask_token(config.client.token)}")
     else:
         click.echo("  token  = (not set)")
 

--- a/src/magpie/cli/commands/flush_tag.py
+++ b/src/magpie/cli/commands/flush_tag.py
@@ -10,6 +10,7 @@ if TYPE_CHECKING:
     import httpx
 
 from magpie.cli import CLIContext
+from magpie.cli.utils import handle_http_error
 
 # Tags that require --force to flush due to their common importance
 PROTECTED_TAGS = frozenset({"latest", "stable", "production", "prod", "release"})
@@ -89,9 +90,9 @@ def flush_tag(ctx: CLIContext, tag_name: str, dry_run: bool, yes: bool, force: b
         )
 
         if response.status_code == 400:
-            _handle_error(response)
+            handle_http_error(response, "Flush", ctx.token)
         if response.status_code not in (200,):
-            _handle_error(response)
+            handle_http_error(response, "Flush", ctx.token)
 
         data = response.json()
         affected_count = data.get("count", 0)
@@ -106,13 +107,3 @@ def flush_tag(ctx: CLIContext, tag_name: str, dry_run: bool, yes: bool, force: b
         click.echo("Affected artifacts:")
         for artifact in affected_artifacts:
             click.echo(f"  - {artifact}")
-
-
-def _handle_error(response: "httpx.Response") -> None:
-    """Handle HTTP error responses."""
-    try:
-        detail = response.json().get("detail", response.text)
-    except Exception:
-        detail = response.text
-
-    raise click.ClickException(f"Flush failed ({response.status_code}): {detail}")

--- a/src/magpie/cli/commands/flush_tag.py
+++ b/src/magpie/cli/commands/flush_tag.py
@@ -2,12 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import click
-
-if TYPE_CHECKING:
-    import httpx
 
 from magpie.cli import CLIContext
 from magpie.cli.utils import handle_http_error

--- a/src/magpie/cli/commands/gc.py
+++ b/src/magpie/cli/commands/gc.py
@@ -2,12 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import click
-
-if TYPE_CHECKING:
-    import httpx
 
 from magpie.cli import CLIContext
 from magpie.cli.utils import handle_http_error, mask_token

--- a/src/magpie/cli/commands/gc.py
+++ b/src/magpie/cli/commands/gc.py
@@ -10,6 +10,7 @@ if TYPE_CHECKING:
     import httpx
 
 from magpie.cli import CLIContext
+from magpie.cli.utils import handle_http_error, mask_token
 
 
 @click.command()
@@ -56,11 +57,13 @@ def gc(ctx: CLIContext, dry_run: bool) -> None:
         response = client.post("/api/v1/gc", params=params)
 
         if response.status_code == 401:
-            _handle_error(response, "Authentication failed. Check your token.")
+            msg = f"Authentication failed. Check your token (token: {mask_token(ctx.token)})"
+            raise click.ClickException(msg)
         if response.status_code == 403:
-            _handle_error(response, "Admin token required for garbage collection.")
+            msg = f"Admin token required for garbage collection (token: {mask_token(ctx.token)})"
+            raise click.ClickException(msg)
         if response.status_code not in (200,):
-            _handle_error(response)
+            handle_http_error(response, "GC", ctx.token)
 
         data = response.json()
 
@@ -80,19 +83,6 @@ def gc(ctx: CLIContext, dry_run: bool) -> None:
     click.echo(
         f"  Space {'reclaimable' if dry_run else 'reclaimed'}: {_format_size(data['space_reclaimed_bytes'])}"
     )
-
-
-def _handle_error(response: "httpx.Response", message: str | None = None) -> None:
-    """Handle HTTP error responses."""
-    if message:
-        raise click.ClickException(message)
-
-    try:
-        detail = response.json().get("detail", response.text)
-    except Exception:
-        detail = response.text
-
-    raise click.ClickException(f"GC failed ({response.status_code}): {detail}")
 
 
 def _format_size(size_bytes: int) -> str:

--- a/src/magpie/cli/commands/get.py
+++ b/src/magpie/cli/commands/get.py
@@ -4,12 +4,8 @@ from __future__ import annotations
 
 import hashlib
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 import click
-
-if TYPE_CHECKING:
-    import httpx
 
 from magpie.cli import CLIContext
 from magpie.cli.commands.parse import ParseError, parse_artifact_ref

--- a/src/magpie/cli/commands/get.py
+++ b/src/magpie/cli/commands/get.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
 from magpie.cli import CLIContext
 from magpie.cli.commands.parse import ParseError, parse_artifact_ref
 from magpie.cli.progress import transfer_progress
+from magpie.cli.utils import handle_http_error
 from magpie.storage.hash import compute_hash
 
 
@@ -65,7 +66,7 @@ def get(
         if info_response.status_code == 404:
             raise click.ClickException(f"Artifact not found: {parsed.path}:{parsed.ref}")
         if info_response.status_code != 200:
-            _handle_error(info_response, "metadata fetch")
+            handle_http_error(info_response, "Metadata fetch", ctx.token)
 
         info = info_response.json()
         expected_hash = info["hash"]
@@ -116,7 +117,7 @@ def get(
             if response.status_code != 200:
                 # Read response body for error message
                 response.read()
-                _handle_error(response, "download")
+                handle_http_error(response, "Download", ctx.token)
 
             # Get content length from header if available (may be more accurate)
             content_length = response.headers.get("content-length")
@@ -145,13 +146,3 @@ def get(
     # Write file
     output.write_bytes(content)
     click.echo(f"Downloaded: {output}")
-
-
-def _handle_error(response: "httpx.Response", operation: str) -> None:
-    """Handle HTTP error responses."""
-    try:
-        detail = response.json().get("detail", response.text)
-    except Exception:
-        detail = response.text
-
-    raise click.ClickException(f"{operation} failed ({response.status_code}): {detail}")

--- a/src/magpie/cli/commands/get.py
+++ b/src/magpie/cli/commands/get.py
@@ -62,7 +62,7 @@ def get(
         if info_response.status_code == 404:
             raise click.ClickException(f"Artifact not found: {parsed.path}:{parsed.ref}")
         if info_response.status_code != 200:
-            handle_http_error(info_response, "Metadata fetch", ctx.token)
+            handle_http_error(info_response, "Metadata", ctx.token)
 
         info = info_response.json()
         expected_hash = info["hash"]

--- a/src/magpie/cli/commands/info.py
+++ b/src/magpie/cli/commands/info.py
@@ -2,12 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import click
-
-if TYPE_CHECKING:
-    import httpx
 
 from magpie.cli import CLIContext
 from magpie.cli.commands.parse import ParseError, parse_artifact_ref

--- a/src/magpie/cli/commands/info.py
+++ b/src/magpie/cli/commands/info.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
 
 from magpie.cli import CLIContext
 from magpie.cli.commands.parse import ParseError, parse_artifact_ref
+from magpie.cli.utils import handle_http_error
 
 
 @click.command()
@@ -47,7 +48,7 @@ def info(ctx: CLIContext, artifact_ref: str) -> None:
         if response.status_code == 404:
             raise click.ClickException(f"Artifact not found: {parsed.path}:{parsed.ref}")
         if response.status_code != 200:
-            _handle_error(response)
+            handle_http_error(response, "Info", ctx.token)
 
         data = response.json()
 
@@ -68,13 +69,3 @@ def info(ctx: CLIContext, artifact_ref: str) -> None:
         click.echo(f"Tags:        {', '.join(tags)}")
     else:
         click.echo("Tags:        (none)")
-
-
-def _handle_error(response: "httpx.Response") -> None:
-    """Handle HTTP error responses."""
-    try:
-        detail = response.json().get("detail", response.text)
-    except Exception:
-        detail = response.text
-
-    raise click.ClickException(f"Info failed ({response.status_code}): {detail}")

--- a/src/magpie/cli/commands/ls.py
+++ b/src/magpie/cli/commands/ls.py
@@ -11,9 +11,7 @@ if TYPE_CHECKING:
 
 from magpie.cli import CLIContext
 from magpie.cli.commands.parse import ParseError, parse_artifact_path
-
-if TYPE_CHECKING:
-    import httpx
+from magpie.cli.utils import handle_http_error
 
 
 @click.command(name="ls")
@@ -88,7 +86,7 @@ def _list_paths(ctx: CLIContext, client: "httpx.Client", prefix: str) -> None:
     response = client.get("/api/v1/artifacts", params={"prefix": prefix})
 
     if response.status_code != 200:
-        _handle_error(response)
+        handle_http_error(response, "List", ctx.token)
 
     data = response.json()
     paths = data.get("paths", [])
@@ -143,13 +141,3 @@ def _format_datetime(dt_str: str) -> str:
         return dt_str
     except Exception:
         return dt_str
-
-
-def _handle_error(response: "httpx.Response") -> None:
-    """Handle HTTP error responses."""
-    try:
-        detail = response.json().get("detail", response.text)
-    except Exception:
-        detail = response.text
-
-    raise click.ClickException(f"List failed ({response.status_code}): {detail}")

--- a/src/magpie/cli/commands/push.py
+++ b/src/magpie/cli/commands/push.py
@@ -84,14 +84,7 @@ def push(
     if ctx.debug:
         click.echo(f"Uploading {file} ({file_size} bytes) to {artifact_path}...", err=True)
 
-    # Pre-flight auth check before showing progress bar.
-    # This prevents the misleading UX where progress completes before auth error appears.
-    with ctx.get_client() as client:
-        preflight = client.head(f"/api/v1/upload/{artifact_path}")
-        if preflight.status_code in (401, 403):
-            handle_http_error(preflight, "Upload", ctx.token)
-
-    # Upload file with progress (auth already verified)
+    # Upload file with progress
     with transfer_progress("Uploading", file_size, quiet=quiet) as (progress, task_id):
         with ctx.get_client() as client:
             with file.open("rb") as f:

--- a/src/magpie/cli/commands/push.py
+++ b/src/magpie/cli/commands/push.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
 
 from magpie.cli import CLIContext
 from magpie.cli.progress import transfer_progress
+from magpie.cli.utils import handle_http_error
 
 
 class ProgressFileWrapper:
@@ -84,7 +85,14 @@ def push(
     if ctx.debug:
         click.echo(f"Uploading {file} ({file_size} bytes) to {artifact_path}...", err=True)
 
-    # Upload file with progress
+    # Pre-flight auth check before showing progress bar.
+    # This prevents the misleading UX where progress completes before auth error appears.
+    with ctx.get_client() as client:
+        preflight = client.head(f"/api/v1/upload/{artifact_path}")
+        if preflight.status_code in (401, 403):
+            handle_http_error(preflight, "Upload", ctx.token)
+
+    # Upload file with progress (auth already verified)
     with transfer_progress("Uploading", file_size, quiet=quiet) as (progress, task_id):
         with ctx.get_client() as client:
             with file.open("rb") as f:
@@ -98,7 +106,7 @@ def push(
                 )
 
             if response.status_code != 200:
-                _handle_error(response)
+                handle_http_error(response, "Upload", ctx.token)
 
             data = response.json()
 
@@ -120,13 +128,3 @@ def push(
     if not source_uri:
         click.echo()
         click.echo("Info: No --source-uri provided. Consider adding provenance metadata.")
-
-
-def _handle_error(response: "httpx.Response") -> None:
-    """Handle HTTP error responses."""
-    try:
-        detail = response.json().get("detail", response.text)
-    except Exception:
-        detail = response.text
-
-    raise click.ClickException(f"Upload failed ({response.status_code}): {detail}")

--- a/src/magpie/cli/commands/push.py
+++ b/src/magpie/cli/commands/push.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING, BinaryIO
 import click
 
 if TYPE_CHECKING:
-    import httpx
     from rich.progress import Progress, TaskID
 
 from magpie.cli import CLIContext

--- a/src/magpie/cli/commands/tag.py
+++ b/src/magpie/cli/commands/tag.py
@@ -47,7 +47,7 @@ def tag(ctx: CLIContext, artifact_ref: str, tag_name: str) -> None:
         if response.status_code == 404:
             raise click.ClickException(f"Artifact not found: {parsed.path}:{parsed.ref}")
         if response.status_code != 200:
-            handle_http_error(response, "Tag creation", ctx.token)
+            handle_http_error(response, "Tag", ctx.token)
 
         data = response.json()
 

--- a/src/magpie/cli/commands/tag.py
+++ b/src/magpie/cli/commands/tag.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
 
 from magpie.cli import CLIContext
 from magpie.cli.commands.parse import ParseError, parse_artifact_ref
+from magpie.cli.utils import handle_http_error
 
 
 @click.command()
@@ -51,19 +52,9 @@ def tag(ctx: CLIContext, artifact_ref: str, tag_name: str) -> None:
         if response.status_code == 404:
             raise click.ClickException(f"Artifact not found: {parsed.path}:{parsed.ref}")
         if response.status_code != 200:
-            _handle_error(response)
+            handle_http_error(response, "Tag creation", ctx.token)
 
         data = response.json()
 
     click.echo(f"Tagged {data['hash_ref']} as '{tag_name}'")
     click.echo(f"All tags: {', '.join(data.get('tags', []))}")
-
-
-def _handle_error(response: "httpx.Response") -> None:
-    """Handle HTTP error responses."""
-    try:
-        detail = response.json().get("detail", response.text)
-    except Exception:
-        detail = response.text
-
-    raise click.ClickException(f"Tag creation failed ({response.status_code}): {detail}")

--- a/src/magpie/cli/commands/tag.py
+++ b/src/magpie/cli/commands/tag.py
@@ -2,12 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import click
-
-if TYPE_CHECKING:
-    import httpx
 
 from magpie.cli import CLIContext
 from magpie.cli.commands.parse import ParseError, parse_artifact_ref

--- a/src/magpie/cli/commands/untag.py
+++ b/src/magpie/cli/commands/untag.py
@@ -2,12 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import click
-
-if TYPE_CHECKING:
-    import httpx
 
 from magpie.cli import CLIContext
 from magpie.cli.utils import handle_http_error

--- a/src/magpie/cli/commands/untag.py
+++ b/src/magpie/cli/commands/untag.py
@@ -39,6 +39,6 @@ def untag(ctx: CLIContext, artifact_path: str, tag_name: str) -> None:
         if response.status_code == 404:
             raise click.ClickException(f"Tag not found: {artifact_path}:{tag_name}")
         if response.status_code != 204:
-            handle_http_error(response, "Tag removal", ctx.token)
+            handle_http_error(response, "Untag", ctx.token)
 
     click.echo(f"Removed tag '{tag_name}' from {artifact_path}")

--- a/src/magpie/cli/commands/untag.py
+++ b/src/magpie/cli/commands/untag.py
@@ -10,6 +10,7 @@ if TYPE_CHECKING:
     import httpx
 
 from magpie.cli import CLIContext
+from magpie.cli.utils import handle_http_error
 
 
 @click.command()
@@ -43,16 +44,6 @@ def untag(ctx: CLIContext, artifact_path: str, tag_name: str) -> None:
         if response.status_code == 404:
             raise click.ClickException(f"Tag not found: {artifact_path}:{tag_name}")
         if response.status_code != 204:
-            _handle_error(response)
+            handle_http_error(response, "Tag removal", ctx.token)
 
     click.echo(f"Removed tag '{tag_name}' from {artifact_path}")
-
-
-def _handle_error(response: "httpx.Response") -> None:
-    """Handle HTTP error responses."""
-    try:
-        detail = response.json().get("detail", response.text)
-    except Exception:
-        detail = response.text
-
-    raise click.ClickException(f"Tag removal failed ({response.status_code}): {detail}")

--- a/src/magpie/cli/utils.py
+++ b/src/magpie/cli/utils.py
@@ -1,0 +1,84 @@
+"""CLI utility functions."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import click
+
+if TYPE_CHECKING:
+    import httpx
+
+# Standard mask for hiding sensitive token values
+TOKEN_MASK = "********"  # nosec B105 - display placeholder, not a real password
+
+
+def mask_token(token: str) -> str:
+    """Mask a token for display, showing only last 4 characters.
+
+    Args:
+        token: The token to mask.
+
+    Returns:
+        Masked token string with last 4 chars visible, or just the mask
+        if token is 4 chars or shorter.
+
+    Examples:
+        >>> mask_token("mgp_1234567890abcdef")
+        '********cdef'
+        >>> mask_token("abc")
+        '********'
+    """
+    if len(token) > 4:
+        return TOKEN_MASK + token[-4:]
+    return TOKEN_MASK
+
+
+def format_auth_error(
+    response: "httpx.Response",
+    operation: str,
+    token: str | None = None,
+) -> str:
+    """Format an authentication error message with optional masked token.
+
+    Args:
+        response: The HTTP response object.
+        operation: Description of the operation that failed (e.g., "Upload", "Download").
+        token: Optional token to include (masked) in the error message.
+
+    Returns:
+        Formatted error message string.
+    """
+    try:
+        detail = response.json().get("detail", response.text)
+    except Exception:
+        detail = response.text
+
+    base_msg = f"{operation} failed ({response.status_code}): {detail}"
+
+    # Add masked token for auth errors to help debug wrong-token issues
+    if response.status_code in (401, 403) and token:
+        base_msg += f" (token: {mask_token(token)})"
+
+    return base_msg
+
+
+def handle_http_error(
+    response: "httpx.Response",
+    operation: str,
+    token: str | None = None,
+) -> None:
+    """Handle HTTP error responses, raising ClickException.
+
+    For authentication errors (401/403), includes the masked token in the
+    error message to help users identify which token was used.
+
+    Args:
+        response: The HTTP response object.
+        operation: Description of the operation that failed.
+        token: Optional token to include (masked) for auth errors.
+
+    Raises:
+        click.ClickException: Always raised with formatted error message.
+    """
+    raise click.ClickException(format_auth_error(response, operation, token))

--- a/tests/unit/test_cli_utils.py
+++ b/tests/unit/test_cli_utils.py
@@ -1,0 +1,153 @@
+"""Tests for CLI utility functions."""
+
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import click
+import pytest
+
+from magpie.cli.utils import TOKEN_MASK, format_auth_error, handle_http_error, mask_token
+
+
+class TestMaskToken:
+    """Tests for mask_token function."""
+
+    def test_mask_long_token(self) -> None:
+        """Tokens longer than 4 chars show last 4 chars."""
+        result = mask_token("mgp_1234567890abcdef")
+        assert result == "********cdef"
+
+    def test_mask_exactly_5_chars(self) -> None:
+        """Token of exactly 5 chars shows last 4."""
+        result = mask_token("12345")
+        assert result == "********2345"
+
+    def test_mask_short_token_4_chars(self) -> None:
+        """Token of exactly 4 chars returns just the mask."""
+        result = mask_token("abcd")
+        assert result == TOKEN_MASK
+
+    def test_mask_short_token_3_chars(self) -> None:
+        """Token shorter than 4 chars returns just the mask."""
+        result = mask_token("abc")
+        assert result == TOKEN_MASK
+
+    def test_mask_empty_token(self) -> None:
+        """Empty token returns just the mask."""
+        result = mask_token("")
+        assert result == TOKEN_MASK
+
+    def test_mask_single_char(self) -> None:
+        """Single character token returns just the mask."""
+        result = mask_token("x")
+        assert result == TOKEN_MASK
+
+
+class TestFormatAuthError:
+    """Tests for format_auth_error function."""
+
+    def test_format_with_json_detail(self) -> None:
+        """Error message includes detail from JSON response."""
+        response = Mock()
+        response.status_code = 500
+        response.json.return_value = {"detail": "Internal server error"}
+        response.text = "raw text"
+
+        result = format_auth_error(response, "Upload")
+        assert result == "Upload failed (500): Internal server error"
+
+    def test_format_with_json_no_detail(self) -> None:
+        """Falls back to response.text when JSON has no detail key."""
+        response = Mock()
+        response.status_code = 400
+        response.json.return_value = {"error": "something"}
+        response.text = "Bad request"
+
+        result = format_auth_error(response, "Download")
+        assert result == "Download failed (400): Bad request"
+
+    def test_format_with_json_parse_error(self) -> None:
+        """Falls back to response.text when JSON parsing fails."""
+        response = Mock()
+        response.status_code = 502
+        response.json.side_effect = ValueError("Invalid JSON")
+        response.text = "Bad gateway"
+
+        result = format_auth_error(response, "Info")
+        assert result == "Info failed (502): Bad gateway"
+
+    def test_format_401_with_token(self) -> None:
+        """401 errors include masked token in message."""
+        response = Mock()
+        response.status_code = 401
+        response.json.return_value = {"detail": "Unauthorized"}
+
+        result = format_auth_error(response, "Upload", "mgp_secret123456")
+        assert result == "Upload failed (401): Unauthorized (token: ********3456)"
+
+    def test_format_403_with_token(self) -> None:
+        """403 errors include masked token in message."""
+        response = Mock()
+        response.status_code = 403
+        response.json.return_value = {"detail": "Forbidden"}
+
+        result = format_auth_error(response, "Download", "mgp_secret123456")
+        assert result == "Download failed (403): Forbidden (token: ********3456)"
+
+    def test_format_401_without_token(self) -> None:
+        """401 errors without token don't include token suffix."""
+        response = Mock()
+        response.status_code = 401
+        response.json.return_value = {"detail": "Unauthorized"}
+
+        result = format_auth_error(response, "Upload", None)
+        assert result == "Upload failed (401): Unauthorized"
+        assert "token:" not in result
+
+    def test_format_non_auth_error_with_token(self) -> None:
+        """Non-auth errors don't include token even if provided."""
+        response = Mock()
+        response.status_code = 500
+        response.json.return_value = {"detail": "Server error"}
+
+        result = format_auth_error(response, "Upload", "mgp_secret123456")
+        assert result == "Upload failed (500): Server error"
+        assert "token:" not in result
+
+
+class TestHandleHttpError:
+    """Tests for handle_http_error function."""
+
+    def test_raises_click_exception(self) -> None:
+        """Always raises ClickException."""
+        response = Mock()
+        response.status_code = 500
+        response.json.return_value = {"detail": "Error"}
+
+        with pytest.raises(click.ClickException) as exc_info:
+            handle_http_error(response, "Test")
+
+        assert "Test failed (500): Error" in str(exc_info.value)
+
+    def test_exception_includes_masked_token_for_401(self) -> None:
+        """ClickException message includes masked token for 401."""
+        response = Mock()
+        response.status_code = 401
+        response.json.return_value = {"detail": "Unauthorized"}
+
+        with pytest.raises(click.ClickException) as exc_info:
+            handle_http_error(response, "Upload", "mgp_testtoken1234")
+
+        assert "token: ********1234" in str(exc_info.value)
+
+    def test_exception_includes_masked_token_for_403(self) -> None:
+        """ClickException message includes masked token for 403."""
+        response = Mock()
+        response.status_code = 403
+        response.json.return_value = {"detail": "Forbidden"}
+
+        with pytest.raises(click.ClickException) as exc_info:
+            handle_http_error(response, "Download", "mgp_testtoken5678")
+
+        assert "token: ********5678" in str(exc_info.value)


### PR DESCRIPTION
## Summary

- Extract `mask_token` to shared `utils.py` module for consistent token masking across all CLI commands
- Update all CLI command error handlers to show the masked token on authentication failures (401/403)
- Add pre-flight auth check in `push` command to fail fast before showing progress bar

Closes #74

## Test plan

- [x] Run `uv run pytest tests/ --ignore=tests/e2e -k "not (requires_server or requires_token)"` (659 passed)
- [ ] Manual test: Use invalid token and verify error message shows `(token: ********XXXX)` suffix
- [ ] Manual test: Run `magpie push` with invalid token and verify error appears before progress bar

Generated with Claude Code (Claude Opus 4.5)