### PR TITLE
Fix artifact URL generation to match storage layout

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -103,7 +103,7 @@ Output:
 ```
 Uploaded: a1b2c3d4e5f6...
 Hash ref: @a1b2c3d4
-Download: https://magpie.example.com/artifacts/images/ubuntu/@a1b2c3d4
+Download: https://magpie.example.com/artifacts/images/ubuntu/latest
 ```
 
 ### List Artifact Versions
@@ -466,8 +466,11 @@ curl https://magpie.example.com/api/v1/artifacts/images/ubuntu
 # Get metadata
 curl https://magpie.example.com/api/v1/artifacts/images/ubuntu/latest/info
 
-# Download file
-curl -O https://magpie.example.com/artifacts/images/ubuntu/@a1b2c3d4
+# Download file by tag
+curl -O https://magpie.example.com/artifacts/images/ubuntu/latest
+
+# Download file by hash
+curl -O https://magpie.example.com/artifacts/images/ubuntu/blobs/a1b2c3d4
 
 # Upload (requires token)
 curl -X POST \

--- a/src/magpie/cli/commands/get.py
+++ b/src/magpie/cli/commands/get.py
@@ -100,10 +100,13 @@ def get(
 
         # Download the artifact
         # Hash refs use blobs/ subdirectory, tags are symlinks at root
-        if hash_ref.startswith("@"):
-            download_url = f"/artifacts/{parsed.path}/blobs/{hash_ref.lstrip('@')}"
+        if parsed.ref.startswith("@"):
+            # User requested hash directly - use blobs path
+            blob_name = hash_ref.lstrip("@")
+            download_url = f"/artifacts/{parsed.path}/blobs/{blob_name}"
         else:
-            download_url = f"/artifacts/{parsed.path}/{hash_ref}"
+            # User requested tag - use tag symlink path
+            download_url = f"/artifacts/{parsed.path}/{parsed.ref}"
 
         if ctx.debug:
             click.echo(f"Downloading from {download_url}...", err=True)

--- a/src/magpie/cli/commands/url.py
+++ b/src/magpie/cli/commands/url.py
@@ -56,7 +56,14 @@ def url(ctx: CLIContext, artifact_ref: str) -> None:
         hash_ref = data["hash_ref"]
 
     # Output bare URL (no newline issues - click.echo adds one)
-    download_url = f"{ctx.server}/artifacts/{parsed.path}/{hash_ref}"
+    # Hash refs use blobs/ subdirectory, tags are symlinks at root
+    if parsed.ref.startswith("@"):
+        # User requested hash directly - use blobs path
+        blob_name = hash_ref.lstrip("@")
+        download_url = f"{ctx.server}/artifacts/{parsed.path}/blobs/{blob_name}"
+    else:
+        # User requested tag - use tag symlink path
+        download_url = f"{ctx.server}/artifacts/{parsed.path}/{parsed.ref}"
     click.echo(download_url)
 
 

--- a/src/magpie/server/routes/upload.py
+++ b/src/magpie/server/routes/upload.py
@@ -83,7 +83,9 @@ async def upload_artifact(
         source_uri=source_uri,
     )
 
-    download_url = f"/artifacts/{path}/{info.hash_ref}"
+    # Use blobs/ path for hash-based downloads (info.hash_ref has @ prefix)
+    blob_name = info.hash_ref.lstrip("@")
+    download_url = f"/artifacts/{path}/blobs/{blob_name}"
 
     return UploadResponse(
         hash=info.hash,

--- a/tests/integration/test_cli_push_get.py
+++ b/tests/integration/test_cli_push_get.py
@@ -494,6 +494,113 @@ class TestGetCommand:
         assert result.exit_code != 0
         assert "not found" in result.output.lower()
 
+    def test_get_by_hash_ref_uses_blobs_path(
+        self,
+        cli_runner: CliRunner,
+        api_client: TestClient,
+        tmp_path: Path,
+        test_storage_service: StorageService,
+    ) -> None:
+        """Get by hash ref uses blobs/ path instead of tag symlink."""
+        # Upload a file
+        test_content = b"content for hash ref get test"
+        files = {"file": ("artifact.bin", io.BytesIO(test_content), "application/octet-stream")}
+        upload_response = api_client.post("/api/v1/upload/hashref/gettest", files=files)
+        assert upload_response.status_code == 200
+        upload_data = upload_response.json()
+        hash_ref = upload_data["hash_ref"]  # e.g., "@abc12345"
+
+        output_file = tmp_path / "hashref_downloaded.bin"
+
+        # Track what URL is used for download
+        urls_requested: list[str] = []
+
+        mock_client = MockClientWithDownload(api_client, test_storage_service)
+        original_stream = mock_client.stream
+
+        def tracking_stream(method: str, url: str) -> MockStreamResponse:
+            urls_requested.append(url)
+            return original_stream(method, url)
+
+        mock_client.stream = tracking_stream
+
+        with patch(PATCH_GET_CLIENT) as mock_get_client:
+            mock_get_client.return_value = mock_client
+
+            result = cli_runner.invoke(
+                cli,
+                [
+                    "--server",
+                    "http://test",
+                    "get",
+                    f"hashref/gettest:{hash_ref}",  # Request by hash ref
+                    "-o",
+                    str(output_file),
+                ],
+            )
+
+        assert result.exit_code == 0, f"Exit code: {result.exit_code}, Output: {result.output}"
+        assert output_file.exists()
+        assert output_file.read_bytes() == test_content
+
+        # Verify download URL used blobs/ path
+        assert len(urls_requested) == 1
+        blob_name = hash_ref.lstrip("@")
+        expected_url = f"/artifacts/hashref/gettest/blobs/{blob_name}"
+        assert urls_requested[0] == expected_url
+
+    def test_get_by_tag_uses_tag_symlink_path(
+        self,
+        cli_runner: CliRunner,
+        api_client: TestClient,
+        tmp_path: Path,
+        test_storage_service: StorageService,
+    ) -> None:
+        """Get by tag name uses tag symlink path (not blobs/)."""
+        # Upload a file
+        test_content = b"content for tag get test"
+        files = {"file": ("artifact.bin", io.BytesIO(test_content), "application/octet-stream")}
+        upload_response = api_client.post("/api/v1/upload/tagref/gettest", files=files)
+        assert upload_response.status_code == 200
+
+        output_file = tmp_path / "tagref_downloaded.bin"
+
+        # Track what URL is used for download
+        urls_requested: list[str] = []
+
+        mock_client = MockClientWithDownload(api_client, test_storage_service)
+        original_stream = mock_client.stream
+
+        def tracking_stream(method: str, url: str) -> MockStreamResponse:
+            urls_requested.append(url)
+            return original_stream(method, url)
+
+        mock_client.stream = tracking_stream
+
+        with patch(PATCH_GET_CLIENT) as mock_get_client:
+            mock_get_client.return_value = mock_client
+
+            result = cli_runner.invoke(
+                cli,
+                [
+                    "--server",
+                    "http://test",
+                    "get",
+                    "tagref/gettest:latest",  # Request by tag name
+                    "-o",
+                    str(output_file),
+                ],
+            )
+
+        assert result.exit_code == 0, f"Exit code: {result.exit_code}, Output: {result.output}"
+        assert output_file.exists()
+        assert output_file.read_bytes() == test_content
+
+        # Verify download URL used tag symlink path (not blobs/)
+        assert len(urls_requested) == 1
+        expected_url = "/artifacts/tagref/gettest/latest"
+        assert urls_requested[0] == expected_url
+
     def test_get_requires_server(self, cli_runner: CliRunner, tmp_path: Path) -> None:
         """Get without server configured fails with error."""
         output_file = tmp_path / "noserver.bin"
@@ -1034,10 +1141,10 @@ class TestPushOutputFeatures:
             )
 
         assert result.exit_code == 0, f"Exit code: {result.exit_code}, Output: {result.output}"
-        # Download URL should contain the hash ref (short hash prefixed with @)
-        assert "Download: http://test/artifacts/download/hash-test/@" in result.output
-        # Verify the hash ref is derived from the full hash
-        assert expected_hash[:8] in result.output
+        # Download URL should use blobs/ path with short hash (no @ prefix)
+        short_hash = expected_hash[:8]
+        expected_url = f"Download: http://test/artifacts/download/hash-test/blobs/{short_hash}"
+        assert expected_url in result.output
 
     def test_push_shows_source_uri_info_when_not_provided(
         self, cli_runner: CliRunner, api_client: TestClient, tmp_path: Path

--- a/tests/integration/test_cli_query.py
+++ b/tests/integration/test_cli_query.py
@@ -341,8 +341,7 @@ class TestUrlCommand:
 
     def test_url_outputs_bare_url(self, cli_runner: CliRunner, api_client: TestClient) -> None:
         """Url command outputs bare URL for scripting."""
-        upload_data = upload_test_artifact(api_client, "test/url", b"url test content")
-        hash_ref = upload_data["hash_ref"]
+        upload_test_artifact(api_client, "test/url", b"url test content")
 
         with patch(PATCH_GET_CLIENT) as mock_get_client:
             mock_get_client.return_value = api_client
@@ -353,11 +352,9 @@ class TestUrlCommand:
             )
 
         assert result.exit_code == 0, f"Output: {result.output}"
-        # Check output is a bare URL
+        # Check output is a bare URL with tag symlink path
         output = result.output.strip()
-        assert output.startswith("http://test/artifacts/")
-        assert hash_ref in output
-        assert "test/url" in output
+        assert output == "http://test/artifacts/test/url/latest"
 
     def test_url_suitable_for_curl(self, cli_runner: CliRunner, api_client: TestClient) -> None:
         """Url output is suitable for curl/wget (single line, no extra text)."""
@@ -380,10 +377,11 @@ class TestUrlCommand:
         # Should not have any extra text
         assert output.count("http") == 1
 
-    def test_url_resolves_tag_to_hash(self, cli_runner: CliRunner, api_client: TestClient) -> None:
-        """Url resolves tag to hash ref in output."""
-        upload_data = upload_test_artifact(api_client, "test/resolve", b"resolve test")
-        hash_ref = upload_data["hash_ref"]
+    def test_url_uses_tag_symlink_when_tag_requested(
+        self, cli_runner: CliRunner, api_client: TestClient
+    ) -> None:
+        """Url uses tag symlink path when user requests by tag name."""
+        upload_test_artifact(api_client, "test/resolve", b"resolve test")
 
         with patch(PATCH_GET_CLIENT) as mock_get_client:
             mock_get_client.return_value = api_client
@@ -394,9 +392,30 @@ class TestUrlCommand:
             )
 
         assert result.exit_code == 0
-        # URL should contain hash_ref, not "latest"
-        assert hash_ref in result.output
-        assert ":latest" not in result.output
+        # URL should use tag symlink path (not blobs/ path)
+        output = result.output.strip()
+        assert output == "http://test/artifacts/test/resolve/latest"
+
+    def test_url_uses_blobs_path_when_hash_requested(
+        self, cli_runner: CliRunner, api_client: TestClient
+    ) -> None:
+        """Url uses blobs/ path when user requests by hash ref."""
+        upload_data = upload_test_artifact(api_client, "test/hash-url", b"hash url test")
+        hash_ref = upload_data["hash_ref"]
+
+        with patch(PATCH_GET_CLIENT) as mock_get_client:
+            mock_get_client.return_value = api_client
+
+            result = cli_runner.invoke(
+                cli,
+                ["--server", "http://test", "url", f"test/hash-url:{hash_ref}"],
+            )
+
+        assert result.exit_code == 0
+        # URL should use blobs/ path (hash without @ prefix)
+        output = result.output.strip()
+        blob_name = hash_ref.lstrip("@")
+        assert output == f"http://test/artifacts/test/hash-url/blobs/{blob_name}"
 
     def test_url_not_found(self, cli_runner: CliRunner, api_client: TestClient) -> None:
         """Url for non-existent artifact returns error."""

--- a/tests/integration/test_upload_endpoint.py
+++ b/tests/integration/test_upload_endpoint.py
@@ -63,7 +63,9 @@ class TestUploadEndpoint:
         assert data["hash_ref"].startswith("@")
         assert data["artifact_path"] == "project/component"
         assert data["is_duplicate"] is False
-        assert data["download_url"] == f"/artifacts/project/component/{data['hash_ref']}"
+        # download_url uses blobs/ path with hash (without @ prefix)
+        blob_name = data["hash_ref"].lstrip("@")
+        assert data["download_url"] == f"/artifacts/project/component/blobs/{blob_name}"
 
     def test_upload_default_uploaded_by(self, client: TestClient) -> None:
         """Upload without uploaded_by defaults to 'anonymous'."""
@@ -217,15 +219,17 @@ class TestResponseFormat:
         assert required_fields == set(data.keys())
 
     def test_download_url_format(self, client: TestClient) -> None:
-        """Download URL should follow expected format."""
+        """Download URL should follow expected format with blobs/ path."""
         content = b"download url test"
         files = {"file": ("artifact.bin", io.BytesIO(content), "application/octet-stream")}
 
         response = client.post("/api/v1/upload/download/url", files=files)
 
         data = response.json()
-        expected_prefix = f"/artifacts/download/url/{data['hash_ref']}"
-        assert data["download_url"] == expected_prefix
+        # download_url uses blobs/ path with hash (without @ prefix)
+        blob_name = data["hash_ref"].lstrip("@")
+        expected_url = f"/artifacts/download/url/blobs/{blob_name}"
+        assert data["download_url"] == expected_url
 
 
 class TestAuthHeaderHandling:


### PR DESCRIPTION
## Summary
- Fix `magpie url` command to generate working URLs (tag symlinks or blobs/ paths)
- Fix `magpie get` command to use correct download URLs based on user request type
- Update upload endpoint to return blobs/ path URLs for consistency
- Update user-guide.md documentation to show correct URL formats

## Test plan
- [x] Run `uv run pytest tests/integration/test_cli_push_get.py tests/integration/test_cli_query.py -k "not requires_server"` - all tests pass
- [x] Run `uv run pytest tests/integration/test_upload_endpoint.py` - all tests pass
- [ ] Manual testing with curl to verify URLs work

## Follow-up tasks
- Design docs in `/home/george/swccdc/deployment/docs/docs/projects/active/magpie/` are outside this repo and should be updated to match

Fixes #27

Generated with Claude Code (Claude Opus 4.5)