### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# CODEOWNERS - automatically request reviews from appropriate owners
+# Reference: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owners for everything in the repository
+* @SouthwestCCDC/blackteam


### PR DESCRIPTION
## Summary

- Adds `.github/CODEOWNERS` file to enable automatic review assignment
- Configures `@SouthwestCCDC/blackteam` as default owners for all files
- Pull requests will now automatically request reviews from the blackteam

Closes #1

## Test plan

- [x] Verify CODEOWNERS file syntax is valid (GitHub will parse it on merge)
- [x] Confirm file is in correct location (`.github/CODEOWNERS`)

---
Generated with Claude Code (Claude Opus 4.5)