### PR TITLE
Enable directory browsing for artifact paths

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -32,7 +32,7 @@
 #   - GET    /api/v1/artifacts/*           - List artifacts, get info
 #   - GET    /api/v1/auth/validate         - Auth validation endpoint
 #   - GET    /health                       - Health check
-#   - GET    /artifacts/*                  - Static file downloads
+#   - GET    /artifacts/*                  - Static file downloads + directory browsing
 #
 # =============================================================================
 # HEADER PROPAGATION
@@ -74,9 +74,10 @@
 
 	# Static artifact downloads - served directly by Caddy for performance
 	# Files accessed via /artifacts/{artifact_path}/{ref} symlinks
+	# Directory browsing enabled for discovery and debugging
 	handle /artifacts/* {
 		root * /data
-		file_server
+		file_server browse
 	}
 
 	# =========================================================================

--- a/tests/e2e/test_edge_cases.py
+++ b/tests/e2e/test_edge_cases.py
@@ -352,3 +352,76 @@ class TestLargeArtifact:
 
         assert response.status_code == 200
         assert response.json()["hash"] == expected_hash
+
+
+@pytest.mark.e2e
+@pytest.mark.slow
+class TestDirectoryBrowsing:
+    """Tests for directory browsing on artifact paths.
+
+    Verifies that Caddy serves directory listings for /artifacts/ paths,
+    enabling discovery and debugging of stored artifacts.
+    """
+
+    def test_browse_artifacts_root(
+        self,
+        http_client: httpx.Client,
+        authenticated_client: httpx.Client,
+        test_artifact_content: bytes,
+    ) -> None:
+        """Verify browsing /artifacts/ returns directory listing."""
+        # Upload an artifact first to ensure there's something to list
+        authenticated_client.post(
+            "/api/v1/upload/e2e-tests/browse-test",
+            files={"file": ("artifact", test_artifact_content, "application/octet-stream")},
+        )
+
+        # Browse the artifacts root directory
+        response = http_client.get("/artifacts/")
+
+        assert response.status_code == 200
+        # Caddy's browse directive returns HTML
+        assert "text/html" in response.headers.get("content-type", "")
+        # Should contain directory listing indicators
+        body = response.text
+        # Caddy's directory listing contains the path somewhere
+        assert "artifacts" in body.lower() or "Index of" in body
+
+    def test_browse_artifact_path_shows_contents(
+        self,
+        http_client: httpx.Client,
+        authenticated_client: httpx.Client,
+        test_artifact_content: bytes,
+    ) -> None:
+        """Verify browsing artifact directory shows blobs, metadata, etc."""
+        # Upload an artifact
+        upload_response = authenticated_client.post(
+            "/api/v1/upload/e2e-tests/browse-path-test",
+            files={"file": ("artifact", test_artifact_content, "application/octet-stream")},
+        )
+        assert upload_response.status_code == 200
+
+        # Browse the specific artifact directory
+        response = http_client.get("/artifacts/e2e-tests/browse-path-test/")
+
+        assert response.status_code == 200
+        assert "text/html" in response.headers.get("content-type", "")
+        body = response.text
+        # Directory should contain blobs, metadata dirs and .magpie manifest
+        # At least one of these should appear in the listing
+        assert (
+            "blobs" in body.lower()
+            or "metadata" in body.lower()
+            or "magpie" in body.lower()
+            or "latest" in body.lower()  # symlink to latest version
+        )
+
+    def test_browse_nonexistent_path_returns_404(
+        self,
+        http_client: httpx.Client,
+    ) -> None:
+        """Verify browsing nonexistent path returns 404."""
+        response = http_client.get("/artifacts/nonexistent/path/that/does/not/exist/")
+
+        # Should get 404 for nonexistent directory
+        assert response.status_code == 404


### PR DESCRIPTION
## Summary

- Enable Caddy's `browse` directive for `/artifacts/*` routes
- Add e2e tests to verify directory browsing functionality

Fixes #86 - Directory browsing: artifact paths should show directory listing

## Implementation

Added `file_server browse` instead of just `file_server` in the Caddyfile. This enables Caddy's built-in directory listing feature for artifact paths, allowing users to:

1. **Discovery** - Browse to see what tags/versions exist
2. **Debugging** - Verify what's actually stored
3. **Integration** - Tools can enumerate available artifacts

Browsing `/artifacts/test/myartifact/` now shows an HTML directory listing with:
- `blobs/` - stored artifact content
- `metadata/` - JSON metadata files
- `latest` - symlink to latest version
- `.magpie` - manifest file

## Test plan

- [x] Unit tests pass (`uv run pytest tests/unit/ -x`)
- [x] Linting passes (`uv run ruff check src/ tests/`)
- [ ] E2E tests verify directory browsing (new `TestDirectoryBrowsing` class)
- [ ] CI passes

Generated with [Claude Code](https://claude.ai/code) (Claude Opus 4.5)