### PR TITLE
Consolidate CLI error handling into shared errors module

### DIFF
--- a/src/magpie/cli/commands/amend.py
+++ b/src/magpie/cli/commands/amend.py
@@ -6,7 +6,7 @@ import click
 
 from magpie.cli import CLIContext
 from magpie.cli.commands.parse import ParseError, parse_artifact_ref
-from magpie.cli.utils import handle_http_error
+from magpie.cli.errors import handle_http_error
 
 
 @click.command()

--- a/src/magpie/cli/commands/config_cmd.py
+++ b/src/magpie/cli/commands/config_cmd.py
@@ -8,7 +8,7 @@ import click
 import tomli_w
 
 from magpie.cli import config as cli_config
-from magpie.cli.utils import mask_token
+from magpie.cli.errors import mask_token
 
 
 def _write_config(config_path: Path, server: str | None, token: str | None) -> None:

--- a/src/magpie/cli/commands/flush_tag.py
+++ b/src/magpie/cli/commands/flush_tag.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import click
 
 from magpie.cli import CLIContext
-from magpie.cli.utils import handle_http_error
+from magpie.cli.errors import handle_http_error
 
 # Tags that require --force to flush due to their common importance
 PROTECTED_TAGS = frozenset({"latest", "stable", "production", "prod", "release"})

--- a/src/magpie/cli/commands/gc.py
+++ b/src/magpie/cli/commands/gc.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import click
 
 from magpie.cli import CLIContext
-from magpie.cli.utils import handle_http_error, mask_token
+from magpie.cli.errors import handle_http_error, mask_token
 
 
 @click.command()

--- a/src/magpie/cli/commands/get.py
+++ b/src/magpie/cli/commands/get.py
@@ -9,8 +9,8 @@ import click
 
 from magpie.cli import CLIContext
 from magpie.cli.commands.parse import ParseError, parse_artifact_ref
+from magpie.cli.errors import handle_http_error
 from magpie.cli.progress import transfer_progress
-from magpie.cli.utils import handle_http_error
 from magpie.storage.hash import compute_hash
 
 

--- a/src/magpie/cli/commands/info.py
+++ b/src/magpie/cli/commands/info.py
@@ -6,7 +6,7 @@ import click
 
 from magpie.cli import CLIContext
 from magpie.cli.commands.parse import ParseError, parse_artifact_ref
-from magpie.cli.utils import handle_http_error
+from magpie.cli.errors import handle_http_error
 
 
 @click.command()

--- a/src/magpie/cli/commands/ls.py
+++ b/src/magpie/cli/commands/ls.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 
 from magpie.cli import CLIContext
 from magpie.cli.commands.parse import ParseError, parse_artifact_path
-from magpie.cli.utils import handle_http_error
+from magpie.cli.errors import handle_http_error
 
 
 @click.command(name="ls")

--- a/src/magpie/cli/commands/push.py
+++ b/src/magpie/cli/commands/push.py
@@ -11,8 +11,8 @@ if TYPE_CHECKING:
     from rich.progress import Progress, TaskID
 
 from magpie.cli import CLIContext
+from magpie.cli.errors import handle_http_error
 from magpie.cli.progress import transfer_progress
-from magpie.cli.utils import handle_http_error
 from magpie.storage.exceptions import InvalidArtifactPathError
 from magpie.storage.paths import normalize_artifact_path
 

--- a/src/magpie/cli/commands/tag.py
+++ b/src/magpie/cli/commands/tag.py
@@ -6,7 +6,7 @@ import click
 
 from magpie.cli import CLIContext
 from magpie.cli.commands.parse import ParseError, parse_artifact_ref
-from magpie.cli.utils import handle_http_error
+from magpie.cli.errors import handle_http_error
 
 
 @click.command()

--- a/src/magpie/cli/commands/untag.py
+++ b/src/magpie/cli/commands/untag.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import click
 
 from magpie.cli import CLIContext
-from magpie.cli.utils import handle_http_error
+from magpie.cli.errors import handle_http_error
 from magpie.storage.exceptions import InvalidArtifactPathError
 from magpie.storage.paths import normalize_artifact_path
 

--- a/src/magpie/cli/commands/url.py
+++ b/src/magpie/cli/commands/url.py
@@ -2,15 +2,11 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import click
-
-if TYPE_CHECKING:
-    import httpx
 
 from magpie.cli import CLIContext
 from magpie.cli.commands.parse import ParseError, parse_artifact_ref
+from magpie.cli.errors import handle_http_error
 
 
 @click.command()
@@ -50,7 +46,7 @@ def url(ctx: CLIContext, artifact_ref: str) -> None:
         if response.status_code == 404:
             raise click.ClickException(f"Artifact not found: {parsed.path}:{parsed.ref}")
         if response.status_code != 200:
-            _handle_error(response)
+            handle_http_error(response, "URL resolution")
 
         data = response.json()
         hash_ref = data["hash_ref"]
@@ -65,13 +61,3 @@ def url(ctx: CLIContext, artifact_ref: str) -> None:
         # User requested tag - use tag symlink path
         download_url = f"{ctx.server}/artifacts/{parsed.path}/{parsed.ref}"
     click.echo(download_url)
-
-
-def _handle_error(response: "httpx.Response") -> None:
-    """Handle HTTP error responses."""
-    try:
-        detail = response.json().get("detail", response.text)
-    except Exception:
-        detail = response.text
-
-    raise click.ClickException(f"URL resolution failed ({response.status_code}): {detail}")

--- a/src/magpie/cli/errors.py
+++ b/src/magpie/cli/errors.py
@@ -1,0 +1,91 @@
+"""CLI error handling utilities.
+
+This module provides unified error handling for all CLI commands, ensuring
+consistent error messages and exit codes across the application.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import click
+
+if TYPE_CHECKING:
+    import httpx
+
+# Standard mask for hiding sensitive token values
+TOKEN_MASK = "********"  # nosec B105 - display placeholder, not a real password
+
+
+def mask_token(token: str) -> str:
+    """Mask a token for display, showing only last 4 characters.
+
+    Args:
+        token: The token to mask.
+
+    Returns:
+        Masked token string with last 4 chars visible, or just the mask
+        if token is 4 chars or shorter.
+
+    Examples:
+        >>> mask_token("mgp_1234567890abcdef")
+        '********cdef'
+        >>> mask_token("abc")
+        '********'
+    """
+    if len(token) > 4:
+        return TOKEN_MASK + token[-4:]
+    return TOKEN_MASK
+
+
+def format_auth_error(
+    response: "httpx.Response",
+    operation: str,
+    token: str | None = None,
+) -> str:
+    """Format an authentication error message with optional masked token.
+
+    Args:
+        response: The HTTP response object.
+        operation: Description of the operation that failed (e.g., "Upload", "Download").
+        token: Optional token to include (masked) in the error message.
+
+    Returns:
+        Formatted error message string.
+    """
+    try:
+        detail = response.json().get("detail", response.text)
+    except Exception:
+        detail = response.text
+
+    base_msg = f"{operation} failed ({response.status_code}): {detail}"
+
+    # Add masked token for auth errors to help debug wrong-token issues
+    if response.status_code in (401, 403) and token:
+        base_msg += f" (token: {mask_token(token)})"
+
+    return base_msg
+
+
+def handle_http_error(
+    response: "httpx.Response",
+    operation: str,
+    token: str | None = None,
+) -> None:
+    """Handle HTTP error responses, raising ClickException.
+
+    This is the unified error handler for all CLI commands. It extracts
+    error details from HTTP responses and formats them consistently.
+
+    For authentication errors (401/403), includes the masked token in the
+    error message to help users identify which token was used.
+
+    Args:
+        response: The HTTP response object.
+        operation: Description of the operation that failed.
+        token: Optional token to include (masked) for auth errors.
+
+    Raises:
+        click.ClickException: Always raised with formatted error message.
+    """
+    raise click.ClickException(format_auth_error(response, operation, token))

--- a/src/magpie/cli/utils.py
+++ b/src/magpie/cli/utils.py
@@ -1,84 +1,24 @@
-"""CLI utility functions."""
+"""CLI utility functions.
+
+This module re-exports error handling functions from the errors module
+for backward compatibility. New code should import directly from
+magpie.cli.errors instead.
+"""
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+# Re-export error handling functions for backward compatibility
+# New code should import from magpie.cli.errors directly
+from magpie.cli.errors import (
+    TOKEN_MASK,
+    format_auth_error,
+    handle_http_error,
+    mask_token,
+)
 
-import click
-
-if TYPE_CHECKING:
-    import httpx
-
-# Standard mask for hiding sensitive token values
-TOKEN_MASK = "********"  # nosec B105 - display placeholder, not a real password
-
-
-def mask_token(token: str) -> str:
-    """Mask a token for display, showing only last 4 characters.
-
-    Args:
-        token: The token to mask.
-
-    Returns:
-        Masked token string with last 4 chars visible, or just the mask
-        if token is 4 chars or shorter.
-
-    Examples:
-        >>> mask_token("mgp_1234567890abcdef")
-        '********cdef'
-        >>> mask_token("abc")
-        '********'
-    """
-    if len(token) > 4:
-        return TOKEN_MASK + token[-4:]
-    return TOKEN_MASK
-
-
-def format_auth_error(
-    response: "httpx.Response",
-    operation: str,
-    token: str | None = None,
-) -> str:
-    """Format an authentication error message with optional masked token.
-
-    Args:
-        response: The HTTP response object.
-        operation: Description of the operation that failed (e.g., "Upload", "Download").
-        token: Optional token to include (masked) in the error message.
-
-    Returns:
-        Formatted error message string.
-    """
-    try:
-        detail = response.json().get("detail", response.text)
-    except Exception:
-        detail = response.text
-
-    base_msg = f"{operation} failed ({response.status_code}): {detail}"
-
-    # Add masked token for auth errors to help debug wrong-token issues
-    if response.status_code in (401, 403) and token:
-        base_msg += f" (token: {mask_token(token)})"
-
-    return base_msg
-
-
-def handle_http_error(
-    response: "httpx.Response",
-    operation: str,
-    token: str | None = None,
-) -> None:
-    """Handle HTTP error responses, raising ClickException.
-
-    For authentication errors (401/403), includes the masked token in the
-    error message to help users identify which token was used.
-
-    Args:
-        response: The HTTP response object.
-        operation: Description of the operation that failed.
-        token: Optional token to include (masked) for auth errors.
-
-    Raises:
-        click.ClickException: Always raised with formatted error message.
-    """
-    raise click.ClickException(format_auth_error(response, operation, token))
+__all__ = [
+    "TOKEN_MASK",
+    "format_auth_error",
+    "handle_http_error",
+    "mask_token",
+]

--- a/tests/unit/test_cli_utils.py
+++ b/tests/unit/test_cli_utils.py
@@ -1,4 +1,4 @@
-"""Tests for CLI utility functions."""
+"""Tests for CLI error handling utilities."""
 
 from __future__ import annotations
 
@@ -7,7 +7,35 @@ from unittest.mock import Mock
 import click
 import pytest
 
-from magpie.cli.utils import TOKEN_MASK, format_auth_error, handle_http_error, mask_token
+from magpie.cli.errors import TOKEN_MASK, format_auth_error, handle_http_error, mask_token
+
+
+class TestBackwardCompatibility:
+    """Tests for backward compatibility with utils module re-exports."""
+
+    def test_utils_reexports_token_mask(self) -> None:
+        """TOKEN_MASK is re-exported from utils for backward compatibility."""
+        from magpie.cli.utils import TOKEN_MASK as utils_mask
+
+        assert utils_mask == TOKEN_MASK
+
+    def test_utils_reexports_mask_token(self) -> None:
+        """mask_token is re-exported from utils for backward compatibility."""
+        from magpie.cli.utils import mask_token as utils_mask_token
+
+        assert utils_mask_token is mask_token
+
+    def test_utils_reexports_format_auth_error(self) -> None:
+        """format_auth_error is re-exported from utils for backward compatibility."""
+        from magpie.cli.utils import format_auth_error as utils_format
+
+        assert utils_format is format_auth_error
+
+    def test_utils_reexports_handle_http_error(self) -> None:
+        """handle_http_error is re-exported from utils for backward compatibility."""
+        from magpie.cli.utils import handle_http_error as utils_handle
+
+        assert utils_handle is handle_http_error
 
 
 class TestMaskToken:


### PR DESCRIPTION
## Summary

- Create `src/magpie/cli/errors.py` as the dedicated module for CLI error handling
- Move `handle_http_error`, `format_auth_error`, `mask_token`, and `TOKEN_MASK` from `utils.py` to `errors.py`
- Update all 11 CLI command files to import from the new errors module
- Remove the duplicate `_handle_error()` function from `url.py`
- Update `utils.py` to re-export symbols for backward compatibility
- Add tests for backward compatibility of re-exports

## Test plan

- [x] All unit tests pass (`uv run pytest tests/unit/ -x`)
- [x] Ruff check passes with no errors
- [x] Backward compatibility tests verify that imports from `utils.py` still work
- [ ] CI pipeline passes

Fixes #70

Generated with Claude Code (Claude Opus 4.5)