### PR TITLE
Refactor: Consolidate GC logic into shared module

### DIFF
--- a/src/magpie/cli/commands/gc.py
+++ b/src/magpie/cli/commands/gc.py
@@ -6,6 +6,7 @@ import click
 
 from magpie.cli import CLIContext
 from magpie.cli.errors import handle_http_error, mask_token
+from magpie.storage.gc import format_size
 
 
 @click.command()
@@ -76,7 +77,7 @@ def gc(ctx: CLIContext, dry_run: bool) -> None:
     action = "Would delete" if dry_run else "Deleted"
     click.echo(f"  {action}: {data['blobs_deleted']} blob(s)")
     click.echo(
-        f"  Space {'reclaimable' if dry_run else 'reclaimed'}: {_format_size(data['space_reclaimed_bytes'])}"
+        f"  Space {'reclaimable' if dry_run else 'reclaimed'}: {format_size(data['space_reclaimed_bytes'])}"
     )
 
     # Display items removed (directories + manifest files)
@@ -84,22 +85,3 @@ def gc(ctx: CLIContext, dry_run: bool) -> None:
     if items_removed > 0:
         action = "Would remove" if dry_run else "Removed"
         click.echo(f"  {action} empty items: {items_removed}")
-
-
-def _format_size(size_bytes: int) -> str:
-    """Format byte size as human-readable string.
-
-    Args:
-        size_bytes: Size in bytes.
-
-    Returns:
-        Human-readable size string (e.g., "1.5 MB").
-    """
-    if size_bytes < 1024:
-        return f"{size_bytes} B"
-    elif size_bytes < 1024 * 1024:
-        return f"{size_bytes / 1024:.1f} KB"
-    elif size_bytes < 1024 * 1024 * 1024:
-        return f"{size_bytes / (1024 * 1024):.1f} MB"
-    else:
-        return f"{size_bytes / (1024 * 1024 * 1024):.1f} GB"

--- a/src/magpie/ctl/commands/gc.py
+++ b/src/magpie/ctl/commands/gc.py
@@ -126,6 +126,9 @@ def _run_gc_with_progress(
     function handles all the actual work (scanning, deletion, cleanup) while
     this wrapper manages progress bar display via the callback mechanism.
 
+    Uses a single-pass approach for actual GC work. The delete progress bar
+    total is updated dynamically when the first delete callback arrives.
+
     Args:
         storage_path: Base storage path containing artifacts.
         retention_days: Delete untagged blobs older than this many days.
@@ -137,7 +140,6 @@ def _run_gc_with_progress(
     Returns:
         Tuple of (GCResult, list of blobs to delete).
     """
-
     # Pre-scan to get artifact count for progress bar
     scan_manifest_files = list(storage_path.rglob(".magpie"))
     scan_total = len(scan_manifest_files)
@@ -149,7 +151,7 @@ def _run_gc_with_progress(
         scan_task_id: object = None
         delete_progress: object = None
         delete_task_id: object = None
-        delete_total: int = 0
+        delete_total_set: bool = False
 
     state = ProgressState()
 
@@ -157,58 +159,53 @@ def _run_gc_with_progress(
         """Handle progress updates from run_gc()."""
         if phase == "scan" and state.scan_progress is not None and state.scan_task_id is not None:
             state.scan_progress.update(state.scan_task_id, completed=current)
-        elif (
-            phase == "delete"
-            and state.delete_progress is not None
-            and state.delete_task_id is not None
-        ):
-            state.delete_progress.update(state.delete_task_id, completed=current)
+        elif phase == "delete":
+            # First delete callback tells us the total, update progress bar
+            if not state.delete_total_set and total > 0:
+                state.delete_total_set = True
+                if state.delete_progress is not None and state.delete_task_id is not None:
+                    state.delete_progress.update(state.delete_task_id, total=total)
 
-    # Phase 1: Run scan with progress bar
-    # For dry-run or reconcile-only, this is the only phase
-    # For actual deletion, run_gc() will also handle deletion and cleanup
-    with count_progress("Scanning artifacts", scan_total, quiet=quiet) as (progress, task_id):
-        state.scan_progress = progress
-        state.scan_task_id = task_id
+            if state.delete_progress is not None and state.delete_task_id is not None:
+                state.delete_progress.update(state.delete_task_id, completed=current)
 
-        # If not dry-run and there will be deletions, we need a second progress bar
-        # But we don't know how many blobs until after scan, so we do a pre-scan
-        # to count blobs, then run the actual GC
-        if not dry_run and not reconcile_only:
-            # First, do a dry-run scan to count blobs
-            _, preview_blobs = run_gc(
-                storage_path=storage_path,
-                retention_days=retention_days,
-                dry_run=True,
-                reconcile_only=reconcile_only,
-                progress_callback=progress_callback,
-            )
-            state.delete_total = len(preview_blobs)
+    # For dry-run or reconcile-only, we just need the scan progress bar
+    if dry_run or reconcile_only:
+        with count_progress("Scanning artifacts", scan_total, quiet=quiet) as (progress, task_id):
+            state.scan_progress = progress
+            state.scan_task_id = task_id
 
-    # Phase 2: If we have blobs to delete, run actual deletion with progress
-    if not dry_run and not reconcile_only and state.delete_total > 0:
-        with count_progress("Deleting blobs", state.delete_total, quiet=quiet) as (
-            progress,
-            task_id,
-        ):
-            state.delete_progress = progress
-            state.delete_task_id = task_id
-
-            # Run actual GC with deletion
             result, blobs_to_delete = run_gc(
                 storage_path=storage_path,
                 retention_days=retention_days,
-                dry_run=False,
+                dry_run=dry_run,
                 reconcile_only=reconcile_only,
                 progress_callback=progress_callback,
             )
-    else:
-        # Dry-run or reconcile-only: just return the scan results
+        return result, blobs_to_delete
+
+    # For actual deletion, we run run_gc once with both progress bars active.
+    # The scan progress bar shows artifact scanning progress.
+    # The delete progress bar starts with total=0 and is updated dynamically
+    # when the first delete callback tells us how many blobs there are.
+    #
+    # Note: We could show sequential progress bars (scan, then delete), but that
+    # would require either running GC twice (once for preview, once for actual)
+    # or restructuring run_gc to yield between phases. For simplicity, we show
+    # both bars and update them as callbacks arrive.
+    with count_progress("Scanning artifacts", scan_total, quiet=quiet) as (
+        scan_prog,
+        scan_tid,
+    ):
+        state.scan_progress = scan_prog
+        state.scan_task_id = scan_tid
+
+        # Run GC - callbacks will update both progress bars as appropriate
         result, blobs_to_delete = run_gc(
             storage_path=storage_path,
             retention_days=retention_days,
-            dry_run=dry_run,
-            reconcile_only=reconcile_only,
+            dry_run=False,
+            reconcile_only=False,
             progress_callback=progress_callback,
         )
 
@@ -222,8 +219,9 @@ def _print_summary(result: GCResult, dry_run: bool, reconcile_only: bool, debug:
     click.echo(f"  Artifacts scanned: {result.artifacts_scanned}")
     click.echo(f"  Blobs found: {result.blobs_found}")
 
-    # In dry run, blobs_deleted is the count that would be deleted (== untagged)
-    click.echo(f"  Untagged blobs: {result.blobs_deleted}")
+    # blobs_deleted represents untagged blobs that are old enough to be deleted
+    # (older than retention_days), not all untagged blobs
+    click.echo(f"  Untagged blobs (eligible for deletion): {result.blobs_deleted}")
 
     click.echo(f"  Symlinks checked: {result.symlinks_checked}")
 

--- a/src/magpie/ctl/commands/gc.py
+++ b/src/magpie/ctl/commands/gc.py
@@ -2,30 +2,11 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from datetime import datetime, timezone
-from pathlib import Path
-
 import click
 
 from magpie.cli.progress import count_progress
 from magpie.ctl import CTLContext
-from magpie.storage.cleanup import CleanupStats, cleanup_artifact_directories
-from magpie.storage.manifest import read_manifest
-from magpie.storage.metadata import read_metadata
-from magpie.storage.symlinks import reconcile_symlinks
-
-
-@dataclass
-class BlobToDelete:
-    """Information about a blob scheduled for deletion."""
-
-    blob_file: Path
-    artifact_path: str
-    blob_hash: str
-    age_days: int
-    size: int
-    metadata_file: Path | None
+from magpie.storage.gc import BlobToDelete, GCResult, format_size, run_gc
 
 
 @click.command()
@@ -100,259 +81,180 @@ def gc(
         click.echo(f"Storage path: {storage_path}", err=True)
         click.echo(f"Retention days: {retention_days}", err=True)
 
-    # Track statistics
-    total_artifacts = 0
-    total_blobs_found = 0
-    untagged_blobs = 0
-    deleted_bytes = 0
-    symlinks_checked = 0
-    symlinks_fixed = 0
-    symlinks_fixed_details: list[str] = []
-    cleanup_stats = CleanupStats()
+    # Run GC with progress display using a two-phase approach
+    # Phase 1: Scan (with progress bar)
+    # Phase 2: Delete (with progress bar)
+    result, blobs_to_delete = _run_gc_with_progress(
+        storage_path=storage_path,
+        retention_days=retention_days,
+        dry_run=dry_run,
+        reconcile_only=reconcile_only,
+        quiet=quiet,
+        debug=ctx.debug,
+    )
 
-    now = datetime.now(timezone.utc)
+    # Print dry-run deletion preview
+    if dry_run and not reconcile_only and blobs_to_delete:
+        for blob in blobs_to_delete:
+            click.echo(
+                f"Would delete: {blob.artifact_path}/blobs/{blob.blob_hash[:12]}... "
+                f"({blob.age_days} days old, {format_size(blob.size)})"
+            )
 
-    # Pre-scan to count artifacts for progress bar
-    manifest_files = list(storage_path.rglob(".magpie"))
-    total_manifest_count = len(manifest_files)
-
-    # Collect artifact directories for cleanup pass (after blob deletion)
-    artifact_dirs_to_cleanup: list[Path] = []
-
-    # Collect blobs to delete (for progress bar during deletion phase)
-    blobs_to_delete: list[BlobToDelete] = []
-
-    # Phase 1: Scan artifacts
-    with count_progress("Scanning artifacts", total_manifest_count, quiet=quiet) as (
-        progress,
-        task_id,
-    ):
-        for manifest_file in manifest_files:
-            artifact_dir = manifest_file.parent
-            artifact_path = str(artifact_dir.relative_to(storage_path))
-            total_artifacts += 1
-
-            if ctx.debug:
-                click.echo(f"Processing artifact: {artifact_path}", err=True)
-
-            # Read manifest to get tagged hashes
-            # Manifest stores full hashes, but blobs are stored with short hashes (8 chars)
-            manifest = read_manifest(artifact_dir)
-            tagged_hashes = {h[:8] for h in manifest.tags.values()}
-
-            # Track artifact directory for cleanup pass
-            artifact_dirs_to_cleanup.append(artifact_dir)
-
-            # Reconcile symlinks for this artifact
-            stats = reconcile_symlinks(artifact_dir, manifest)
-            symlinks_checked += stats.checked
-            symlinks_fixed += stats.fixed
-
-            # Build detail string if there were fixes for this artifact
-            if stats.fixed > 0:
-                details_parts = []
-                if stats.created_tags:
-                    details_parts.append(f"created '{', '.join(stats.created_tags)}'")
-                if stats.removed_tags:
-                    details_parts.append(f"removed '{', '.join(stats.removed_tags)}'")
-                if stats.updated_tags:
-                    details_parts.append(f"updated '{', '.join(stats.updated_tags)}'")
-                symlinks_fixed_details.append(f"{artifact_path}: {', '.join(details_parts)}")
-
-            if not reconcile_only:
-                # Find all blobs in blobs/ directory
-                blobs_dir = artifact_dir / "blobs"
-                if blobs_dir.exists():
-                    for blob_file in blobs_dir.iterdir():
-                        if not blob_file.is_file():
-                            continue
-
-                        total_blobs_found += 1
-                        blob_hash = blob_file.name
-
-                        # Check if blob is tagged
-                        if blob_hash in tagged_hashes:
-                            continue
-
-                        untagged_blobs += 1
-
-                        # Get blob age from metadata or file mtime
-                        blob_age_days = _get_blob_age_days(artifact_dir, blob_hash, now)
-
-                        if blob_age_days is None:
-                            # Can't determine age, skip
-                            if ctx.debug:
-                                click.echo(
-                                    f"  Skipping blob {blob_hash[:12]}... (unknown age)", err=True
-                                )
-                            continue
-
-                        # Check if blob is older than retention period
-                        if blob_age_days < retention_days:
-                            if ctx.debug:
-                                click.echo(
-                                    f"  Keeping blob {blob_hash[:12]}... "
-                                    f"({blob_age_days} days old < {retention_days})",
-                                    err=True,
-                                )
-                            continue
-
-                        # Mark blob for deletion
-                        blob_size = blob_file.stat().st_size
-                        metadata_file = artifact_dir / "metadata" / f"{blob_hash}.json"
-
-                        blobs_to_delete.append(
-                            BlobToDelete(
-                                blob_file=blob_file,
-                                artifact_path=artifact_path,
-                                blob_hash=blob_hash,
-                                age_days=blob_age_days,
-                                size=blob_size,
-                                metadata_file=metadata_file if metadata_file.exists() else None,
-                            )
-                        )
-
-            # Update progress
-            if progress is not None and task_id is not None:
-                progress.update(task_id, advance=1)
-
-    # Phase 2: Delete blobs (if not reconcile-only)
-    deleted_blobs = 0
-    if not reconcile_only and blobs_to_delete:
-        if dry_run:
-            # In dry-run mode, just print what would be deleted
-            for blob in blobs_to_delete:
-                click.echo(
-                    f"Would delete: {blob.artifact_path}/blobs/{blob.blob_hash[:12]}... "
-                    f"({blob.age_days} days old, {_format_size(blob.size)})"
-                )
-                deleted_bytes += blob.size
-            deleted_blobs = len(blobs_to_delete)
-        else:
-            # Actually delete blobs with progress bar
-            with count_progress("Deleting blobs", len(blobs_to_delete), quiet=quiet) as (
-                progress,
-                task_id,
-            ):
-                for blob in blobs_to_delete:
-                    if ctx.debug:
-                        click.echo(
-                            f"  Deleting blob {blob.blob_hash[:12]}... ({blob.age_days} days old)",
-                            err=True,
-                        )
-
-                    blob.blob_file.unlink()
-
-                    # Also delete metadata sidecar if it exists
-                    if blob.metadata_file is not None:
-                        blob.metadata_file.unlink()
-
-                    deleted_blobs += 1
-                    deleted_bytes += blob.size
-
-                    # Update progress
-                    if progress is not None and task_id is not None:
-                        progress.update(task_id, advance=1)
-
-    # Cleanup pass: remove empty directories after blob deletion
-    if not reconcile_only:
-        for artifact_dir in artifact_dirs_to_cleanup:
-            stats = cleanup_artifact_directories(artifact_dir, storage_path, dry_run)
-            cleanup_stats.empty_blobs_dirs += stats.empty_blobs_dirs
-            cleanup_stats.empty_metadata_dirs += stats.empty_metadata_dirs
-            cleanup_stats.empty_manifests += stats.empty_manifests
-            cleanup_stats.empty_artifact_dirs += stats.empty_artifact_dirs
-            cleanup_stats.empty_parent_dirs += stats.empty_parent_dirs
-            cleanup_stats.removed_paths.extend(stats.removed_paths)
-
-        # Report directories that would be / were removed
-        if dry_run and cleanup_stats.removed_paths:
-            for path in cleanup_stats.removed_paths:
-                click.echo(f"Would remove: {path}")
+    # Print dry-run directory removal preview
+    if dry_run and not reconcile_only and result.cleanup_stats.removed_paths:
+        for path in result.cleanup_stats.removed_paths:
+            click.echo(f"Would remove: {path}")
 
     # Print summary
+    _print_summary(result, dry_run, reconcile_only, ctx.debug)
+
+
+def _run_gc_with_progress(
+    storage_path,
+    retention_days: int,
+    dry_run: bool,
+    reconcile_only: bool,
+    quiet: bool,
+    debug: bool,
+) -> tuple[GCResult, list[BlobToDelete]]:
+    """Run GC with rich progress bars.
+
+    This wraps run_gc() with progress display for CTL.
+
+    Returns:
+        Tuple of (GCResult, list of blobs to delete).
+    """
+    # We need to run in phases to show progress bars properly
+    # Phase 1: Scan artifacts
+    scan_manifest_files = list(storage_path.rglob(".magpie"))
+    scan_total = len(scan_manifest_files)
+
+    # Create progress tracking state
+    scan_progress_ctx = None
+    scan_task_id = None
+    delete_progress_ctx = None
+    delete_task_id = None
+
+    # Use a two-pass approach:
+    # Pass 1: Scan with progress bar
+    with count_progress("Scanning artifacts", scan_total, quiet=quiet) as (progress, task_id):
+        scan_progress_ctx = progress
+        scan_task_id = task_id
+
+        def scan_callback(phase: str, current: int, total: int) -> None:
+            if phase == "scan" and scan_progress_ctx is not None and scan_task_id is not None:
+                scan_progress_ctx.update(scan_task_id, completed=current)
+
+        # Run scan phase only (dry_run=True to skip deletion in first pass)
+        result, blobs_to_delete = run_gc(
+            storage_path=storage_path,
+            retention_days=retention_days,
+            dry_run=True,  # Always dry-run in scan phase
+            reconcile_only=reconcile_only,
+            progress_callback=scan_callback,
+        )
+
+    # Pass 2: Delete blobs with progress bar (if not dry-run and not reconcile-only)
+    if not dry_run and not reconcile_only and blobs_to_delete:
+        with count_progress("Deleting blobs", len(blobs_to_delete), quiet=quiet) as (
+            progress,
+            task_id,
+        ):
+            delete_progress_ctx = progress
+            delete_task_id = task_id
+
+            for idx, blob in enumerate(blobs_to_delete):
+                if debug:
+                    click.echo(
+                        f"  Deleting blob {blob.blob_hash[:12]}... ({blob.age_days} days old)",
+                        err=True,
+                    )
+
+                blob.blob_file.unlink()
+
+                # Also delete metadata sidecar if it exists
+                if blob.metadata_file is not None:
+                    blob.metadata_file.unlink()
+
+                # Update progress
+                if delete_progress_ctx is not None and delete_task_id is not None:
+                    delete_progress_ctx.update(delete_task_id, advance=1)
+
+        # Update result with actual deletion stats
+        result.blobs_deleted = len(blobs_to_delete)
+        result.space_reclaimed_bytes = sum(b.size for b in blobs_to_delete)
+
+        # Re-run cleanup after actual deletion
+        from magpie.storage.cleanup import cleanup_artifact_directories
+
+        # Collect artifact dirs from blobs_to_delete
+        artifact_dirs = set()
+        for blob in blobs_to_delete:
+            artifact_dirs.add(blob.blob_file.parent.parent)
+
+        # Also need to cleanup artifacts that had only symlink fixes
+        # Re-scan for all artifact dirs
+        for manifest_file in storage_path.rglob(".magpie"):
+            artifact_dirs.add(manifest_file.parent)
+
+        # Run cleanup
+        from magpie.storage.cleanup import CleanupStats
+
+        combined_stats = CleanupStats()
+        for artifact_dir in artifact_dirs:
+            stats = cleanup_artifact_directories(artifact_dir, storage_path, dry_run=False)
+            combined_stats.empty_blobs_dirs += stats.empty_blobs_dirs
+            combined_stats.empty_metadata_dirs += stats.empty_metadata_dirs
+            combined_stats.empty_manifests += stats.empty_manifests
+            combined_stats.empty_artifact_dirs += stats.empty_artifact_dirs
+            combined_stats.empty_parent_dirs += stats.empty_parent_dirs
+            combined_stats.removed_paths.extend(stats.removed_paths)
+
+        result.cleanup_stats = combined_stats
+        result.items_removed = combined_stats.total_removed
+
+    return result, blobs_to_delete
+
+
+def _print_summary(result: GCResult, dry_run: bool, reconcile_only: bool, debug: bool) -> None:
+    """Print GC summary to stdout."""
     click.echo("")
     click.echo("GC Summary:")
-    click.echo(f"  Artifacts scanned: {total_artifacts}")
-    click.echo(f"  Blobs found: {total_blobs_found}")
-    click.echo(f"  Untagged blobs: {untagged_blobs}")
-    click.echo(f"  Symlinks checked: {symlinks_checked}")
+    click.echo(f"  Artifacts scanned: {result.artifacts_scanned}")
+    click.echo(f"  Blobs found: {result.blobs_found}")
+
+    # In dry run, blobs_deleted is the count that would be deleted (== untagged)
+    click.echo(f"  Untagged blobs: {result.blobs_deleted}")
+
+    click.echo(f"  Symlinks checked: {result.symlinks_checked}")
 
     # Display symlinks fixed with optional details
-    if symlinks_fixed == 0:
-        click.echo(f"  Symlinks fixed: {symlinks_fixed}")
+    if result.symlinks_fixed == 0:
+        click.echo(f"  Symlinks fixed: {result.symlinks_fixed}")
     else:
-        details_str = "; ".join(symlinks_fixed_details)
-        click.echo(f"  Symlinks fixed: {symlinks_fixed} ({details_str})")
+        details_str = "; ".join(str(d) for d in result.symlink_fix_details)
+        click.echo(f"  Symlinks fixed: {result.symlinks_fixed} ({details_str})")
 
     if not reconcile_only:
         action = "Would delete" if dry_run else "Deleted"
-        click.echo(f"  {action}: {deleted_blobs} blob(s), {_format_size(deleted_bytes)}")
+        click.echo(
+            f"  {action}: {result.blobs_deleted} blob(s), {format_size(result.space_reclaimed_bytes)}"
+        )
 
         # Report directory cleanup
-        if cleanup_stats.total_removed > 0:
+        if result.items_removed > 0:
             action = "Would remove" if dry_run else "Removed"
-            click.echo(f"  {action} empty items: {cleanup_stats.total_removed}")
-            if ctx.debug:
-                if cleanup_stats.empty_blobs_dirs:
-                    click.echo(f"    - blobs/ dirs: {cleanup_stats.empty_blobs_dirs}", err=True)
-                if cleanup_stats.empty_metadata_dirs:
-                    click.echo(
-                        f"    - metadata/ dirs: {cleanup_stats.empty_metadata_dirs}", err=True
-                    )
-                if cleanup_stats.empty_manifests:
-                    click.echo(f"    - .magpie files: {cleanup_stats.empty_manifests}", err=True)
-                if cleanup_stats.empty_artifact_dirs:
-                    click.echo(
-                        f"    - artifact dirs: {cleanup_stats.empty_artifact_dirs}", err=True
-                    )
-                if cleanup_stats.empty_parent_dirs:
-                    click.echo(f"    - parent dirs: {cleanup_stats.empty_parent_dirs}", err=True)
-
-
-def _get_blob_age_days(artifact_dir: Path, blob_hash: str, now: datetime) -> int | None:
-    """Get blob age in days from metadata or file mtime.
-
-    Args:
-        artifact_dir: Path to artifact directory.
-        blob_hash: Full blob hash.
-        now: Current datetime for comparison.
-
-    Returns:
-        Age in days, or None if age cannot be determined.
-    """
-    try:
-        # Try to get age from metadata
-        metadata = read_metadata(artifact_dir, blob_hash)
-        upload_time = metadata.uploaded_at
-        if upload_time.tzinfo is None:
-            upload_time = upload_time.replace(tzinfo=timezone.utc)
-        age = now - upload_time
-        return age.days
-    except Exception:
-        # Fall back to file mtime
-        blob_file = artifact_dir / "blobs" / blob_hash
-        if blob_file.exists():
-            mtime = datetime.fromtimestamp(blob_file.stat().st_mtime, tz=timezone.utc)
-            age = now - mtime
-            return age.days
-        return None
-
-
-def _format_size(size_bytes: int) -> str:
-    """Format byte size as human-readable string.
-
-    Args:
-        size_bytes: Size in bytes.
-
-    Returns:
-        Human-readable size string (e.g., "1.5 MB").
-    """
-    if size_bytes < 1024:
-        return f"{size_bytes} B"
-    elif size_bytes < 1024 * 1024:
-        return f"{size_bytes / 1024:.1f} KB"
-    elif size_bytes < 1024 * 1024 * 1024:
-        return f"{size_bytes / (1024 * 1024):.1f} MB"
-    else:
-        return f"{size_bytes / (1024 * 1024 * 1024):.1f} GB"
+            click.echo(f"  {action} empty items: {result.items_removed}")
+            if debug:
+                stats = result.cleanup_stats
+                if stats.empty_blobs_dirs:
+                    click.echo(f"    - blobs/ dirs: {stats.empty_blobs_dirs}", err=True)
+                if stats.empty_metadata_dirs:
+                    click.echo(f"    - metadata/ dirs: {stats.empty_metadata_dirs}", err=True)
+                if stats.empty_manifests:
+                    click.echo(f"    - .magpie files: {stats.empty_manifests}", err=True)
+                if stats.empty_artifact_dirs:
+                    click.echo(f"    - artifact dirs: {stats.empty_artifact_dirs}", err=True)
+                if stats.empty_parent_dirs:
+                    click.echo(f"    - parent dirs: {stats.empty_parent_dirs}", err=True)

--- a/src/magpie/ctl/commands/gc.py
+++ b/src/magpie/ctl/commands/gc.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import click
 
 from magpie.cli.progress import count_progress
@@ -111,7 +113,7 @@ def gc(
 
 
 def _run_gc_with_progress(
-    storage_path,
+    storage_path: Path,
     retention_days: int,
     dry_run: bool,
     reconcile_only: bool,
@@ -120,99 +122,95 @@ def _run_gc_with_progress(
 ) -> tuple[GCResult, list[BlobToDelete]]:
     """Run GC with rich progress bars.
 
-    This wraps run_gc() with progress display for CTL.
+    This wraps run_gc() with progress display for CTL. The shared run_gc()
+    function handles all the actual work (scanning, deletion, cleanup) while
+    this wrapper manages progress bar display via the callback mechanism.
+
+    Args:
+        storage_path: Base storage path containing artifacts.
+        retention_days: Delete untagged blobs older than this many days.
+        dry_run: If True, preview what would be deleted without making changes.
+        reconcile_only: If True, only reconcile symlinks, don't delete blobs.
+        quiet: If True, suppress progress output.
+        debug: If True, output debug messages.
 
     Returns:
         Tuple of (GCResult, list of blobs to delete).
     """
-    # We need to run in phases to show progress bars properly
-    # Phase 1: Scan artifacts
+
+    # Pre-scan to get artifact count for progress bar
     scan_manifest_files = list(storage_path.rglob(".magpie"))
     scan_total = len(scan_manifest_files)
 
-    # Create progress tracking state
-    scan_progress_ctx = None
-    scan_task_id = None
-    delete_progress_ctx = None
-    delete_task_id = None
+    # Track progress state across phases
+    # We use a class to allow the nested callback to update state
+    class ProgressState:
+        scan_progress: object = None
+        scan_task_id: object = None
+        delete_progress: object = None
+        delete_task_id: object = None
+        delete_total: int = 0
 
-    # Use a two-pass approach:
-    # Pass 1: Scan with progress bar
+    state = ProgressState()
+
+    def progress_callback(phase: str, current: int, total: int) -> None:
+        """Handle progress updates from run_gc()."""
+        if phase == "scan" and state.scan_progress is not None and state.scan_task_id is not None:
+            state.scan_progress.update(state.scan_task_id, completed=current)
+        elif (
+            phase == "delete"
+            and state.delete_progress is not None
+            and state.delete_task_id is not None
+        ):
+            state.delete_progress.update(state.delete_task_id, completed=current)
+
+    # Phase 1: Run scan with progress bar
+    # For dry-run or reconcile-only, this is the only phase
+    # For actual deletion, run_gc() will also handle deletion and cleanup
     with count_progress("Scanning artifacts", scan_total, quiet=quiet) as (progress, task_id):
-        scan_progress_ctx = progress
-        scan_task_id = task_id
+        state.scan_progress = progress
+        state.scan_task_id = task_id
 
-        def scan_callback(phase: str, current: int, total: int) -> None:
-            if phase == "scan" and scan_progress_ctx is not None and scan_task_id is not None:
-                scan_progress_ctx.update(scan_task_id, completed=current)
+        # If not dry-run and there will be deletions, we need a second progress bar
+        # But we don't know how many blobs until after scan, so we do a pre-scan
+        # to count blobs, then run the actual GC
+        if not dry_run and not reconcile_only:
+            # First, do a dry-run scan to count blobs
+            _, preview_blobs = run_gc(
+                storage_path=storage_path,
+                retention_days=retention_days,
+                dry_run=True,
+                reconcile_only=reconcile_only,
+                progress_callback=progress_callback,
+            )
+            state.delete_total = len(preview_blobs)
 
-        # Run scan phase only (dry_run=True to skip deletion in first pass)
-        result, blobs_to_delete = run_gc(
-            storage_path=storage_path,
-            retention_days=retention_days,
-            dry_run=True,  # Always dry-run in scan phase
-            reconcile_only=reconcile_only,
-            progress_callback=scan_callback,
-        )
-
-    # Pass 2: Delete blobs with progress bar (if not dry-run and not reconcile-only)
-    if not dry_run and not reconcile_only and blobs_to_delete:
-        with count_progress("Deleting blobs", len(blobs_to_delete), quiet=quiet) as (
+    # Phase 2: If we have blobs to delete, run actual deletion with progress
+    if not dry_run and not reconcile_only and state.delete_total > 0:
+        with count_progress("Deleting blobs", state.delete_total, quiet=quiet) as (
             progress,
             task_id,
         ):
-            delete_progress_ctx = progress
-            delete_task_id = task_id
+            state.delete_progress = progress
+            state.delete_task_id = task_id
 
-            for idx, blob in enumerate(blobs_to_delete):
-                if debug:
-                    click.echo(
-                        f"  Deleting blob {blob.blob_hash[:12]}... ({blob.age_days} days old)",
-                        err=True,
-                    )
-
-                blob.blob_file.unlink()
-
-                # Also delete metadata sidecar if it exists
-                if blob.metadata_file is not None:
-                    blob.metadata_file.unlink()
-
-                # Update progress
-                if delete_progress_ctx is not None and delete_task_id is not None:
-                    delete_progress_ctx.update(delete_task_id, advance=1)
-
-        # Update result with actual deletion stats
-        result.blobs_deleted = len(blobs_to_delete)
-        result.space_reclaimed_bytes = sum(b.size for b in blobs_to_delete)
-
-        # Re-run cleanup after actual deletion
-        from magpie.storage.cleanup import cleanup_artifact_directories
-
-        # Collect artifact dirs from blobs_to_delete
-        artifact_dirs = set()
-        for blob in blobs_to_delete:
-            artifact_dirs.add(blob.blob_file.parent.parent)
-
-        # Also need to cleanup artifacts that had only symlink fixes
-        # Re-scan for all artifact dirs
-        for manifest_file in storage_path.rglob(".magpie"):
-            artifact_dirs.add(manifest_file.parent)
-
-        # Run cleanup
-        from magpie.storage.cleanup import CleanupStats
-
-        combined_stats = CleanupStats()
-        for artifact_dir in artifact_dirs:
-            stats = cleanup_artifact_directories(artifact_dir, storage_path, dry_run=False)
-            combined_stats.empty_blobs_dirs += stats.empty_blobs_dirs
-            combined_stats.empty_metadata_dirs += stats.empty_metadata_dirs
-            combined_stats.empty_manifests += stats.empty_manifests
-            combined_stats.empty_artifact_dirs += stats.empty_artifact_dirs
-            combined_stats.empty_parent_dirs += stats.empty_parent_dirs
-            combined_stats.removed_paths.extend(stats.removed_paths)
-
-        result.cleanup_stats = combined_stats
-        result.items_removed = combined_stats.total_removed
+            # Run actual GC with deletion
+            result, blobs_to_delete = run_gc(
+                storage_path=storage_path,
+                retention_days=retention_days,
+                dry_run=False,
+                reconcile_only=reconcile_only,
+                progress_callback=progress_callback,
+            )
+    else:
+        # Dry-run or reconcile-only: just return the scan results
+        result, blobs_to_delete = run_gc(
+            storage_path=storage_path,
+            retention_days=retention_days,
+            dry_run=dry_run,
+            reconcile_only=reconcile_only,
+            progress_callback=progress_callback,
+        )
 
     return result, blobs_to_delete
 

--- a/src/magpie/ctl/commands/gc.py
+++ b/src/magpie/ctl/commands/gc.py
@@ -200,14 +200,22 @@ def _run_gc_with_progress(
         state.scan_progress = scan_prog
         state.scan_task_id = scan_tid
 
-        # Run GC - callbacks will update both progress bars as appropriate
-        result, blobs_to_delete = run_gc(
-            storage_path=storage_path,
-            retention_days=retention_days,
-            dry_run=False,
-            reconcile_only=False,
-            progress_callback=progress_callback,
-        )
+        # Delete progress bar starts with total=0; callback will set total when known.
+        with count_progress("Deleting blobs", 0, quiet=quiet) as (
+            delete_prog,
+            delete_tid,
+        ):
+            state.delete_progress = delete_prog
+            state.delete_task_id = delete_tid
+
+            # Run GC - callbacks will update both progress bars as appropriate
+            result, blobs_to_delete = run_gc(
+                storage_path=storage_path,
+                retention_days=retention_days,
+                dry_run=False,
+                reconcile_only=False,
+                progress_callback=progress_callback,
+            )
 
     return result, blobs_to_delete
 

--- a/src/magpie/server/routes/gc.py
+++ b/src/magpie/server/routes/gc.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from pathlib import Path
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, Query
@@ -12,10 +10,7 @@ from pydantic import BaseModel
 from magpie.auth.service import TokenInfo
 from magpie.config import MagpieSettings, get_settings
 from magpie.server.deps import require_admin_scope
-from magpie.storage.cleanup import cleanup_artifact_directories
-from magpie.storage.manifest import read_manifest
-from magpie.storage.metadata import read_metadata
-from magpie.storage.symlinks import reconcile_symlinks
+from magpie.storage.gc import run_gc
 
 router = APIRouter()
 
@@ -62,120 +57,35 @@ async def trigger_gc(
         retention_days_override if retention_days_override is not None else settings.retention_days
     )
 
-    # Track statistics
-    total_artifacts = 0
-    total_blobs_found = 0
-    deleted_blobs = 0
-    deleted_bytes = 0
-    symlinks_checked = 0
-    symlinks_fixed = 0
-    items_removed = 0
+    # Run GC using shared implementation
+    if not storage_path.exists():
+        # Return empty result if storage doesn't exist yet
+        return GCResponse(
+            dry_run=dry_run,
+            artifacts_scanned=0,
+            blobs_found=0,
+            blobs_deleted=0,
+            space_reclaimed_bytes=0,
+            symlinks_checked=0,
+            symlinks_fixed=0,
+            items_removed=0,
+        )
 
-    now = datetime.now(timezone.utc)
-
-    # Collect artifact directories for cleanup pass
-    artifact_dirs_to_cleanup: list[Path] = []
-
-    # Find all artifact directories (containing .magpie manifest)
-    if storage_path.exists():
-        for manifest_file in storage_path.rglob(".magpie"):
-            artifact_dir = manifest_file.parent
-            total_artifacts += 1
-
-            # Read manifest to get tagged hashes
-            manifest = read_manifest(artifact_dir)
-            tagged_hashes = set(manifest.tags.values())
-
-            # Reconcile symlinks for this artifact
-            stats = reconcile_symlinks(artifact_dir, manifest)
-            symlinks_checked += stats.checked
-            symlinks_fixed += stats.fixed
-
-            # Track artifact directory for cleanup pass
-            artifact_dirs_to_cleanup.append(artifact_dir)
-
-            # Find all blobs in blobs/ directory
-            blobs_dir = artifact_dir / "blobs"
-            if not blobs_dir.exists():
-                continue
-
-            for blob_file in blobs_dir.iterdir():
-                if not blob_file.is_file():
-                    continue
-
-                total_blobs_found += 1
-                blob_hash = blob_file.name
-
-                # Check if blob is tagged
-                if blob_hash in tagged_hashes:
-                    continue
-
-                # Get blob age from metadata or file mtime
-                blob_age_days = _get_blob_age_days(artifact_dir, blob_hash, now)
-
-                if blob_age_days is None:
-                    # Can't determine age, skip
-                    continue
-
-                # Check if blob is older than retention period
-                if blob_age_days < retention_days:
-                    continue
-
-                # Delete old untagged blob
-                blob_size = blob_file.stat().st_size
-
-                if not dry_run:
-                    blob_file.unlink()
-
-                    # Also delete metadata sidecar if it exists
-                    metadata_file = artifact_dir / "metadata" / f"{blob_hash}.json"
-                    if metadata_file.exists():
-                        metadata_file.unlink()
-
-                deleted_blobs += 1
-                deleted_bytes += blob_size
-
-        # Cleanup pass: remove empty directories and manifests after blob deletion
-        for artifact_dir in artifact_dirs_to_cleanup:
-            stats = cleanup_artifact_directories(artifact_dir, storage_path, dry_run)
-            items_removed += stats.total_removed
+    result, _ = run_gc(
+        storage_path=storage_path,
+        retention_days=retention_days,
+        dry_run=dry_run,
+        reconcile_only=False,
+        progress_callback=None,
+    )
 
     return GCResponse(
         dry_run=dry_run,
-        artifacts_scanned=total_artifacts,
-        blobs_found=total_blobs_found,
-        blobs_deleted=deleted_blobs,
-        space_reclaimed_bytes=deleted_bytes,
-        symlinks_checked=symlinks_checked,
-        symlinks_fixed=symlinks_fixed,
-        items_removed=items_removed,
+        artifacts_scanned=result.artifacts_scanned,
+        blobs_found=result.blobs_found,
+        blobs_deleted=result.blobs_deleted,
+        space_reclaimed_bytes=result.space_reclaimed_bytes,
+        symlinks_checked=result.symlinks_checked,
+        symlinks_fixed=result.symlinks_fixed,
+        items_removed=result.items_removed,
     )
-
-
-def _get_blob_age_days(artifact_dir, blob_hash: str, now: datetime) -> int | None:
-    """Get blob age in days from metadata or file mtime.
-
-    Args:
-        artifact_dir: Path to artifact directory.
-        blob_hash: Full blob hash.
-        now: Current datetime for comparison.
-
-    Returns:
-        Age in days, or None if age cannot be determined.
-    """
-    try:
-        # Try to get age from metadata
-        metadata = read_metadata(artifact_dir, blob_hash)
-        upload_time = metadata.uploaded_at
-        if upload_time.tzinfo is None:
-            upload_time = upload_time.replace(tzinfo=timezone.utc)
-        age = now - upload_time
-        return age.days
-    except Exception:
-        # Fall back to file mtime
-        blob_file = artifact_dir / "blobs" / blob_hash
-        if blob_file.exists():
-            mtime = datetime.fromtimestamp(blob_file.stat().st_mtime, tz=timezone.utc)
-            age = now - mtime
-            return age.days
-        return None

--- a/src/magpie/storage/__init__.py
+++ b/src/magpie/storage/__init__.py
@@ -17,6 +17,15 @@ from magpie.storage.exceptions import (
     ManifestCorruptError,
     StorageError,
 )
+from magpie.storage.gc import (
+    BlobToDelete,
+    GCResult,
+    ProgressCallback,
+    SymlinkFixDetail,
+    format_size,
+    get_blob_age_days,
+    run_gc,
+)
 from magpie.storage.hash import compute_hash, short_hash
 from magpie.storage.manifest import (
     Manifest,
@@ -80,6 +89,14 @@ __all__ = [
     # Cleanup operations
     "CleanupStats",
     "cleanup_artifact_directories",
+    # GC operations
+    "GCResult",
+    "BlobToDelete",
+    "SymlinkFixDetail",
+    "ProgressCallback",
+    "run_gc",
+    "get_blob_age_days",
+    "format_size",
     # Exceptions
     "StorageError",
     "ArtifactNotFoundError",

--- a/src/magpie/storage/gc.py
+++ b/src/magpie/storage/gc.py
@@ -1,0 +1,382 @@
+"""Core garbage collection logic for artifact storage.
+
+This module provides the shared GC implementation used by CLI, CTL, and server
+entry points. The entry points are thin wrappers that handle I/O formatting
+while this module contains the core logic.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable
+
+from magpie.storage.cleanup import CleanupStats, cleanup_artifact_directories
+from magpie.storage.manifest import read_manifest
+from magpie.storage.metadata import read_metadata
+from magpie.storage.symlinks import ReconcileStats, reconcile_symlinks
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class BlobToDelete:
+    """Information about a blob scheduled for deletion."""
+
+    blob_file: Path
+    artifact_path: str
+    blob_hash: str
+    age_days: int
+    size: int
+    metadata_file: Path | None
+
+
+@dataclass
+class SymlinkFixDetail:
+    """Details about symlink fixes for a single artifact."""
+
+    artifact_path: str
+    created_tags: list[str] = field(default_factory=list)
+    removed_tags: list[str] = field(default_factory=list)
+    updated_tags: list[str] = field(default_factory=list)
+
+    def __str__(self) -> str:
+        """Format as human-readable string."""
+        parts = []
+        if self.created_tags:
+            parts.append(f"created '{', '.join(self.created_tags)}'")
+        if self.removed_tags:
+            parts.append(f"removed '{', '.join(self.removed_tags)}'")
+        if self.updated_tags:
+            parts.append(f"updated '{', '.join(self.updated_tags)}'")
+        return f"{self.artifact_path}: {', '.join(parts)}"
+
+
+@dataclass
+class GCResult:
+    """Result of a garbage collection operation.
+
+    This dataclass contains all statistics from a GC run, suitable for
+    JSON serialization (server) or formatted output (CLI/CTL).
+    """
+
+    artifacts_scanned: int = 0
+    blobs_found: int = 0
+    blobs_deleted: int = 0
+    space_reclaimed_bytes: int = 0
+    symlinks_checked: int = 0
+    symlinks_fixed: int = 0
+    items_removed: int = 0
+    symlink_fix_details: list[SymlinkFixDetail] = field(default_factory=list)
+    cleanup_stats: CleanupStats = field(default_factory=CleanupStats)
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "artifacts_scanned": self.artifacts_scanned,
+            "blobs_found": self.blobs_found,
+            "blobs_deleted": self.blobs_deleted,
+            "space_reclaimed_bytes": self.space_reclaimed_bytes,
+            "symlinks_checked": self.symlinks_checked,
+            "symlinks_fixed": self.symlinks_fixed,
+            "items_removed": self.items_removed,
+        }
+
+
+# Type alias for progress callbacks
+# callback(phase: str, current: int, total: int) where phase is "scan" or "delete"
+ProgressCallback = Callable[[str, int, int], None]
+
+
+def get_blob_age_days(artifact_dir: Path, blob_hash: str, now: datetime) -> int | None:
+    """Get blob age in days from metadata or file mtime.
+
+    Args:
+        artifact_dir: Path to artifact directory.
+        blob_hash: Blob hash (short 8-char format used for file lookup).
+        now: Current datetime for comparison.
+
+    Returns:
+        Age in days, or None if age cannot be determined.
+    """
+    try:
+        # Try to get age from metadata
+        metadata = read_metadata(artifact_dir, blob_hash)
+        upload_time = metadata.uploaded_at
+        if upload_time.tzinfo is None:
+            upload_time = upload_time.replace(tzinfo=timezone.utc)
+        age = now - upload_time
+        return age.days
+    except Exception:
+        # Fall back to file mtime
+        blob_file = artifact_dir / "blobs" / blob_hash
+        if blob_file.exists():
+            mtime = datetime.fromtimestamp(blob_file.stat().st_mtime, tz=timezone.utc)
+            age = now - mtime
+            return age.days
+        return None
+
+
+def _scan_artifacts(
+    storage_path: Path,
+    retention_days: int,
+    reconcile_only: bool,
+    now: datetime,
+    progress_callback: ProgressCallback | None,
+) -> tuple[GCResult, list[BlobToDelete], list[Path]]:
+    """Scan all artifacts and identify blobs for deletion.
+
+    Args:
+        storage_path: Base storage path.
+        retention_days: Delete untagged blobs older than this.
+        reconcile_only: If True, only reconcile symlinks, don't collect blobs.
+        now: Current datetime for age calculations.
+        progress_callback: Optional callback for progress updates.
+
+    Returns:
+        Tuple of (partial GCResult, blobs to delete, artifact dirs for cleanup).
+    """
+    result = GCResult()
+    blobs_to_delete: list[BlobToDelete] = []
+    artifact_dirs_to_cleanup: list[Path] = []
+
+    # Find all artifact directories (containing .magpie manifest)
+    manifest_files = list(storage_path.rglob(".magpie"))
+    total_manifests = len(manifest_files)
+
+    for idx, manifest_file in enumerate(manifest_files):
+        artifact_dir = manifest_file.parent
+        artifact_path = str(artifact_dir.relative_to(storage_path))
+        result.artifacts_scanned += 1
+
+        logger.debug("Processing artifact: %s", artifact_path)
+
+        # Read manifest to get tagged hashes
+        # Manifest stores full hashes, but blobs are stored with short hashes (8 chars)
+        manifest = read_manifest(artifact_dir)
+        tagged_hashes = {h[:8] for h in manifest.tags.values()}
+
+        # Track artifact directory for cleanup pass
+        artifact_dirs_to_cleanup.append(artifact_dir)
+
+        # Reconcile symlinks for this artifact
+        stats: ReconcileStats = reconcile_symlinks(artifact_dir, manifest)
+        result.symlinks_checked += stats.checked
+        result.symlinks_fixed += stats.fixed
+
+        # Record fix details if there were fixes
+        if stats.fixed > 0:
+            result.symlink_fix_details.append(
+                SymlinkFixDetail(
+                    artifact_path=artifact_path,
+                    created_tags=list(stats.created_tags),
+                    removed_tags=list(stats.removed_tags),
+                    updated_tags=list(stats.updated_tags),
+                )
+            )
+
+        if not reconcile_only:
+            # Find all blobs in blobs/ directory
+            blobs_dir = artifact_dir / "blobs"
+            if blobs_dir.exists():
+                for blob_file in blobs_dir.iterdir():
+                    if not blob_file.is_file():
+                        continue
+
+                    result.blobs_found += 1
+                    blob_hash = blob_file.name
+
+                    # Check if blob is tagged
+                    if blob_hash in tagged_hashes:
+                        continue
+
+                    # Get blob age from metadata or file mtime
+                    blob_age_days = get_blob_age_days(artifact_dir, blob_hash, now)
+
+                    if blob_age_days is None:
+                        logger.debug("Skipping blob %s (unknown age)", blob_hash[:12])
+                        continue
+
+                    # Check if blob is older than retention period
+                    if blob_age_days < retention_days:
+                        logger.debug(
+                            "Keeping blob %s (%d days old < %d)",
+                            blob_hash[:12],
+                            blob_age_days,
+                            retention_days,
+                        )
+                        continue
+
+                    # Mark blob for deletion
+                    blob_size = blob_file.stat().st_size
+                    metadata_file = artifact_dir / "metadata" / f"{blob_hash}.json"
+
+                    blobs_to_delete.append(
+                        BlobToDelete(
+                            blob_file=blob_file,
+                            artifact_path=artifact_path,
+                            blob_hash=blob_hash,
+                            age_days=blob_age_days,
+                            size=blob_size,
+                            metadata_file=metadata_file if metadata_file.exists() else None,
+                        )
+                    )
+
+        # Report progress
+        if progress_callback is not None:
+            progress_callback("scan", idx + 1, total_manifests)
+
+    return result, blobs_to_delete, artifact_dirs_to_cleanup
+
+
+def _delete_blobs(
+    blobs_to_delete: list[BlobToDelete],
+    dry_run: bool,
+    progress_callback: ProgressCallback | None,
+) -> tuple[int, int]:
+    """Delete the collected blobs.
+
+    Args:
+        blobs_to_delete: List of blobs to delete.
+        dry_run: If True, don't actually delete.
+        progress_callback: Optional callback for progress updates.
+
+    Returns:
+        Tuple of (blobs deleted count, bytes reclaimed).
+    """
+    deleted_blobs = 0
+    deleted_bytes = 0
+    total_blobs = len(blobs_to_delete)
+
+    for idx, blob in enumerate(blobs_to_delete):
+        if not dry_run:
+            logger.debug("Deleting blob %s (%d days old)", blob.blob_hash[:12], blob.age_days)
+
+            blob.blob_file.unlink()
+
+            # Also delete metadata sidecar if it exists
+            if blob.metadata_file is not None:
+                blob.metadata_file.unlink()
+
+        deleted_blobs += 1
+        deleted_bytes += blob.size
+
+        # Report progress
+        if progress_callback is not None:
+            progress_callback("delete", idx + 1, total_blobs)
+
+    return deleted_blobs, deleted_bytes
+
+
+def _cleanup_directories(
+    artifact_dirs: list[Path],
+    storage_path: Path,
+    dry_run: bool,
+) -> CleanupStats:
+    """Clean up empty directories after blob deletion.
+
+    Args:
+        artifact_dirs: List of artifact directories to check.
+        storage_path: Base storage path.
+        dry_run: If True, don't actually remove.
+
+    Returns:
+        Combined CleanupStats from all artifacts.
+    """
+    combined_stats = CleanupStats()
+
+    for artifact_dir in artifact_dirs:
+        stats = cleanup_artifact_directories(artifact_dir, storage_path, dry_run)
+        combined_stats.empty_blobs_dirs += stats.empty_blobs_dirs
+        combined_stats.empty_metadata_dirs += stats.empty_metadata_dirs
+        combined_stats.empty_manifests += stats.empty_manifests
+        combined_stats.empty_artifact_dirs += stats.empty_artifact_dirs
+        combined_stats.empty_parent_dirs += stats.empty_parent_dirs
+        combined_stats.removed_paths.extend(stats.removed_paths)
+
+    return combined_stats
+
+
+def run_gc(
+    storage_path: Path,
+    retention_days: int,
+    dry_run: bool = False,
+    reconcile_only: bool = False,
+    progress_callback: ProgressCallback | None = None,
+) -> tuple[GCResult, list[BlobToDelete]]:
+    """Run garbage collection on artifact storage.
+
+    This is the core GC implementation. It:
+    1. Scans all artifact directories
+    2. Reconciles symlinks to match manifests
+    3. Identifies untagged blobs older than retention period
+    4. Deletes those blobs (unless dry_run or reconcile_only)
+    5. Cleans up empty directories
+
+    Args:
+        storage_path: Base storage path containing artifacts.
+        retention_days: Delete untagged blobs older than this many days.
+        dry_run: If True, preview what would be deleted without making changes.
+        reconcile_only: If True, only reconcile symlinks, don't delete blobs.
+        progress_callback: Optional callback for progress updates.
+            Called with (phase, current, total) where phase is "scan" or "delete".
+
+    Returns:
+        Tuple of (GCResult with statistics, list of blobs deleted/to-delete).
+        The blob list is useful for dry-run reporting.
+
+    Raises:
+        FileNotFoundError: If storage_path does not exist.
+    """
+    if not storage_path.exists():
+        raise FileNotFoundError(f"Storage path does not exist: {storage_path}")
+
+    now = datetime.now(timezone.utc)
+
+    # Phase 1: Scan artifacts
+    result, blobs_to_delete, artifact_dirs = _scan_artifacts(
+        storage_path=storage_path,
+        retention_days=retention_days,
+        reconcile_only=reconcile_only,
+        now=now,
+        progress_callback=progress_callback,
+    )
+
+    # Phase 2: Delete blobs (if not reconcile-only)
+    if not reconcile_only and blobs_to_delete:
+        deleted_blobs, deleted_bytes = _delete_blobs(
+            blobs_to_delete=blobs_to_delete,
+            dry_run=dry_run,
+            progress_callback=progress_callback,
+        )
+        result.blobs_deleted = deleted_blobs
+        result.space_reclaimed_bytes = deleted_bytes
+
+    # Phase 3: Cleanup empty directories
+    if not reconcile_only:
+        cleanup_stats = _cleanup_directories(artifact_dirs, storage_path, dry_run)
+        result.cleanup_stats = cleanup_stats
+        result.items_removed = cleanup_stats.total_removed
+
+    return result, blobs_to_delete
+
+
+def format_size(size_bytes: int) -> str:
+    """Format byte size as human-readable string.
+
+    Args:
+        size_bytes: Size in bytes.
+
+    Returns:
+        Human-readable size string (e.g., "1.5 MB").
+    """
+    if size_bytes < 1024:
+        return f"{size_bytes} B"
+    elif size_bytes < 1024 * 1024:
+        return f"{size_bytes / 1024:.1f} KB"
+    elif size_bytes < 1024 * 1024 * 1024:
+        return f"{size_bytes / (1024 * 1024):.1f} MB"
+    else:
+        return f"{size_bytes / (1024 * 1024 * 1024):.1f} GB"

--- a/src/magpie/storage/gc.py
+++ b/src/magpie/storage/gc.py
@@ -7,6 +7,7 @@ while this module contains the core logic.
 
 from __future__ import annotations
 
+import json
 import logging
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -14,6 +15,7 @@ from pathlib import Path
 from typing import Callable
 
 from magpie.storage.cleanup import CleanupStats, cleanup_artifact_directories
+from magpie.storage.exceptions import ArtifactNotFoundError
 from magpie.storage.manifest import read_manifest
 from magpie.storage.metadata import read_metadata
 from magpie.storage.symlinks import ReconcileStats, reconcile_symlinks
@@ -73,7 +75,13 @@ class GCResult:
     cleanup_stats: CleanupStats = field(default_factory=CleanupStats)
 
     def to_dict(self) -> dict:
-        """Convert to dictionary for JSON serialization."""
+        """Convert to dictionary for JSON serialization.
+
+        Note: symlink_fix_details and cleanup_stats are intentionally excluded
+        from the JSON output. These fields contain detailed information used
+        only for CLI/CTL display (e.g., which specific tags were fixed). The
+        server API returns just the summary statistics.
+        """
         return {
             "artifacts_scanned": self.artifacts_scanned,
             "blobs_found": self.blobs_found,
@@ -101,10 +109,6 @@ def get_blob_age_days(artifact_dir: Path, blob_hash: str, now: datetime) -> int 
     Returns:
         Age in days, or None if age cannot be determined.
     """
-    import json
-
-    from magpie.storage.exceptions import ArtifactNotFoundError
-
     blob_file = artifact_dir / "blobs" / blob_hash
 
     try:

--- a/src/magpie/storage/gc.py
+++ b/src/magpie/storage/gc.py
@@ -101,6 +101,12 @@ def get_blob_age_days(artifact_dir: Path, blob_hash: str, now: datetime) -> int 
     Returns:
         Age in days, or None if age cannot be determined.
     """
+    import json
+
+    from magpie.storage.exceptions import ArtifactNotFoundError
+
+    blob_file = artifact_dir / "blobs" / blob_hash
+
     try:
         # Try to get age from metadata
         metadata = read_metadata(artifact_dir, blob_hash)
@@ -109,14 +115,19 @@ def get_blob_age_days(artifact_dir: Path, blob_hash: str, now: datetime) -> int 
             upload_time = upload_time.replace(tzinfo=timezone.utc)
         age = now - upload_time
         return age.days
-    except Exception:
-        # Fall back to file mtime
-        blob_file = artifact_dir / "blobs" / blob_hash
-        if blob_file.exists():
-            mtime = datetime.fromtimestamp(blob_file.stat().st_mtime, tz=timezone.utc)
-            age = now - mtime
-            return age.days
-        return None
+    except (FileNotFoundError, ArtifactNotFoundError, json.JSONDecodeError, KeyError, ValueError):
+        # Expected cases: metadata doesn't exist, is malformed, or missing fields
+        pass
+    except (PermissionError, OSError) as e:
+        # Unexpected I/O errors - log and fall back
+        logger.warning("Error reading metadata for blob %s: %s", blob_hash[:12], e)
+
+    # Fall back to file mtime
+    if blob_file.exists():
+        mtime = datetime.fromtimestamp(blob_file.stat().st_mtime, tz=timezone.utc)
+        age = now - mtime
+        return age.days
+    return None
 
 
 def _scan_artifacts(

--- a/tests/unit/test_ctl_init_gc.py
+++ b/tests/unit/test_ctl_init_gc.py
@@ -200,7 +200,7 @@ class TestGCCommand:
             result = cli_runner.invoke(cli, ["gc", "--dry-run"])
 
         assert result.exit_code == 0, f"Output: {result.output}"
-        assert "Untagged blobs: 1" in result.output
+        assert "Untagged blobs (eligible for deletion): 1" in result.output
 
     def test_gc_dry_run_does_not_modify(
         self, cli_runner: CliRunner, test_settings: MagpieSettings

--- a/tests/unit/test_gc.py
+++ b/tests/unit/test_gc.py
@@ -367,6 +367,49 @@ class TestRunGC:
         assert result.blobs_deleted == 0
         assert blob_file.exists()
 
+    def test_preserves_tagged_blobs_with_full_sha256_hash(self, storage_root: Path) -> None:
+        """Tagged blobs with full SHA-256 hashes are preserved.
+
+        Regression test for issue where GC used full 64-char hashes for tag
+        comparison, but blob files use short 8-char hashes. This caused tagged
+        blobs to be incorrectly garbage collected because "abcd1234..." (64 chars)
+        != "abcd1234" (8 chars).
+
+        The fix is to truncate manifest hashes to 8 chars before comparison:
+            tagged_hashes = {h[:8] for h in manifest.tags.values()}
+        """
+        # Use a realistic full SHA-256 hash (64 hex characters)
+        full_hash = "a1b2c3d4e5f67890abcdef1234567890fedcba0987654321a1b2c3d4e5f67890"
+        assert len(full_hash) == 64, "Test requires 64-char hash"
+
+        artifact_dir = create_artifact_with_blobs(
+            storage_root,
+            "test/artifact",
+            tagged_hashes={"latest": full_hash},
+            untagged_hashes=[],
+            blob_ages_days={full_hash: 365},  # Very old but tagged
+        )
+
+        # Blob file uses short hash (first 8 chars)
+        short_hash = full_hash[:8]
+        blob_file = artifact_dir / "blobs" / short_hash
+        assert blob_file.exists()
+        assert blob_file.name == "a1b2c3d4"
+
+        result, blobs = run_gc(
+            storage_path=storage_root,
+            retention_days=30,
+            dry_run=False,
+        )
+
+        # The blob should NOT be deleted because it's tagged
+        # If full hashes were used for comparison, this would fail
+        assert result.blobs_deleted == 0, (
+            "Tagged blob was deleted! "
+            "GC may be using full hashes instead of short hashes for tag lookup."
+        )
+        assert blob_file.exists(), "Tagged blob file was deleted"
+
     def test_reconcile_only_skips_deletion(self, storage_root: Path) -> None:
         """reconcile_only mode only fixes symlinks."""
         artifact_dir = create_artifact_with_blobs(

--- a/tests/unit/test_gc.py
+++ b/tests/unit/test_gc.py
@@ -1,0 +1,516 @@
+"""Unit tests for shared GC module."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from magpie.storage.gc import (
+    BlobToDelete,
+    GCResult,
+    SymlinkFixDetail,
+    format_size,
+    get_blob_age_days,
+    run_gc,
+)
+
+
+@pytest.fixture
+def storage_root(tmp_path: Path) -> Path:
+    """Create a temporary storage root directory."""
+    root = tmp_path / "storage"
+    root.mkdir()
+    return root
+
+
+def create_artifact_with_blobs(
+    storage_path: Path,
+    artifact_path: str,
+    tagged_hashes: dict[str, str],
+    untagged_hashes: list[str],
+    blob_ages_days: dict[str, int] | None = None,
+) -> Path:
+    """Helper to create an artifact directory with blobs and manifest.
+
+    Simulates the actual storage scheme where:
+    - Manifest stores full hashes
+    - Blob files use first 8 chars of hash
+    - Metadata files use first 8 chars of hash (but contain full hash inside)
+
+    Args:
+        storage_path: Base storage path.
+        artifact_path: Relative artifact path.
+        tagged_hashes: Dict of tag_name -> hash for tagged blobs.
+        untagged_hashes: List of hashes for untagged blobs.
+        blob_ages_days: Optional dict of hash -> age in days for metadata.
+
+    Returns:
+        Path to the artifact directory.
+    """
+    artifact_dir = storage_path / artifact_path
+    blobs_dir = artifact_dir / "blobs"
+    metadata_dir = artifact_dir / "metadata"
+    blobs_dir.mkdir(parents=True, exist_ok=True)
+    metadata_dir.mkdir(parents=True, exist_ok=True)
+
+    # Create manifest (stores full hashes)
+    manifest = {
+        "version": 1,
+        "tags": tagged_hashes,
+    }
+    manifest_file = artifact_dir / ".magpie"
+    manifest_file.write_text(json.dumps(manifest), encoding="utf-8")
+
+    # Create all blobs and their metadata
+    all_hashes = list(tagged_hashes.values()) + untagged_hashes
+    blob_ages_days = blob_ages_days or {}
+
+    for blob_hash in all_hashes:
+        # Blob and metadata files use short hash (first 8 chars)
+        short_hash = blob_hash[:8]
+
+        # Create blob file with short hash name
+        blob_file = blobs_dir / short_hash
+        blob_file.write_bytes(b"test content for " + blob_hash.encode())
+
+        # Create metadata with upload timestamp (short hash filename, full hash inside)
+        age_days = blob_ages_days.get(blob_hash, 0)
+        upload_time = datetime.now(timezone.utc) - timedelta(days=age_days)
+        metadata = {
+            "hash": blob_hash,  # Full hash stored inside metadata
+            "uploaded_by": "test",
+            "uploaded_at": upload_time.isoformat(),
+            "source_uri": None,
+        }
+        metadata_file = metadata_dir / f"{short_hash}.json"
+        metadata_file.write_text(json.dumps(metadata), encoding="utf-8")
+
+    return artifact_dir
+
+
+class TestFormatSize:
+    """Tests for format_size function."""
+
+    def test_bytes(self) -> None:
+        """Formats bytes correctly."""
+        assert format_size(0) == "0 B"
+        assert format_size(100) == "100 B"
+        assert format_size(1023) == "1023 B"
+
+    def test_kilobytes(self) -> None:
+        """Formats kilobytes correctly."""
+        assert format_size(1024) == "1.0 KB"
+        assert format_size(1536) == "1.5 KB"
+        assert format_size(1024 * 1024 - 1) == "1024.0 KB"
+
+    def test_megabytes(self) -> None:
+        """Formats megabytes correctly."""
+        assert format_size(1024 * 1024) == "1.0 MB"
+        assert format_size(1024 * 1024 * 1.5) == "1.5 MB"
+        assert format_size(1024 * 1024 * 1024 - 1) == "1024.0 MB"
+
+    def test_gigabytes(self) -> None:
+        """Formats gigabytes correctly."""
+        assert format_size(1024 * 1024 * 1024) == "1.0 GB"
+        assert format_size(1024 * 1024 * 1024 * 2.5) == "2.5 GB"
+
+
+class TestGetBlobAgeDays:
+    """Tests for get_blob_age_days function."""
+
+    def test_gets_age_from_metadata(self, storage_root: Path) -> None:
+        """Gets blob age from metadata file."""
+        artifact_dir = create_artifact_with_blobs(
+            storage_root,
+            "test/artifact",
+            tagged_hashes={},
+            untagged_hashes=["hash1234567890"],
+            blob_ages_days={"hash1234567890": 30},
+        )
+
+        now = datetime.now(timezone.utc)
+        age = get_blob_age_days(artifact_dir, "hash1234", now)
+
+        assert age == 30
+
+    def test_falls_back_to_mtime(self, storage_root: Path) -> None:
+        """Falls back to file mtime when metadata is missing."""
+        artifact_dir = create_artifact_with_blobs(
+            storage_root,
+            "test/artifact",
+            tagged_hashes={},
+            untagged_hashes=["hash1234567890"],
+        )
+
+        # Delete metadata to force mtime fallback
+        metadata_file = artifact_dir / "metadata" / "hash1234.json"
+        metadata_file.unlink()
+
+        now = datetime.now(timezone.utc)
+        age = get_blob_age_days(artifact_dir, "hash1234", now)
+
+        # File was just created, so age should be 0
+        assert age == 0
+
+    def test_returns_none_for_missing_blob(self, storage_root: Path) -> None:
+        """Returns None when blob doesn't exist."""
+        artifact_dir = storage_root / "test/artifact"
+        artifact_dir.mkdir(parents=True)
+
+        now = datetime.now(timezone.utc)
+        age = get_blob_age_days(artifact_dir, "nonexistent", now)
+
+        assert age is None
+
+
+class TestGCResult:
+    """Tests for GCResult dataclass."""
+
+    def test_default_values(self) -> None:
+        """Default values are all zero/empty."""
+        result = GCResult()
+        assert result.artifacts_scanned == 0
+        assert result.blobs_found == 0
+        assert result.blobs_deleted == 0
+        assert result.space_reclaimed_bytes == 0
+        assert result.symlinks_checked == 0
+        assert result.symlinks_fixed == 0
+        assert result.items_removed == 0
+        assert result.symlink_fix_details == []
+
+    def test_to_dict(self) -> None:
+        """to_dict returns correct dictionary."""
+        result = GCResult(
+            artifacts_scanned=5,
+            blobs_found=10,
+            blobs_deleted=2,
+            space_reclaimed_bytes=1024,
+            symlinks_checked=5,
+            symlinks_fixed=1,
+            items_removed=3,
+        )
+        d = result.to_dict()
+        assert d["artifacts_scanned"] == 5
+        assert d["blobs_found"] == 10
+        assert d["blobs_deleted"] == 2
+        assert d["space_reclaimed_bytes"] == 1024
+        assert d["symlinks_checked"] == 5
+        assert d["symlinks_fixed"] == 1
+        assert d["items_removed"] == 3
+
+
+class TestSymlinkFixDetail:
+    """Tests for SymlinkFixDetail dataclass."""
+
+    def test_str_format(self) -> None:
+        """String format is correct."""
+        detail = SymlinkFixDetail(
+            artifact_path="test/artifact",
+            created_tags=["latest"],
+            removed_tags=["old"],
+            updated_tags=["stable"],
+        )
+        s = str(detail)
+        assert "test/artifact" in s
+        assert "created 'latest'" in s
+        assert "removed 'old'" in s
+        assert "updated 'stable'" in s
+
+    def test_str_format_partial(self) -> None:
+        """String format works with partial data."""
+        detail = SymlinkFixDetail(
+            artifact_path="test/artifact",
+            created_tags=["latest"],
+        )
+        s = str(detail)
+        assert "test/artifact" in s
+        assert "created 'latest'" in s
+        assert "removed" not in s
+        assert "updated" not in s
+
+
+class TestRunGC:
+    """Tests for run_gc function."""
+
+    def test_raises_for_missing_storage(self, tmp_path: Path) -> None:
+        """Raises FileNotFoundError for missing storage path."""
+        with pytest.raises(FileNotFoundError):
+            run_gc(
+                storage_path=tmp_path / "nonexistent",
+                retention_days=30,
+            )
+
+    def test_scans_empty_storage(self, storage_root: Path) -> None:
+        """Handles empty storage gracefully."""
+        result, blobs = run_gc(
+            storage_path=storage_root,
+            retention_days=30,
+        )
+
+        assert result.artifacts_scanned == 0
+        assert result.blobs_found == 0
+        assert blobs == []
+
+    def test_identifies_untagged_blobs(self, storage_root: Path) -> None:
+        """Identifies untagged blobs correctly."""
+        create_artifact_with_blobs(
+            storage_root,
+            "test/artifact",
+            tagged_hashes={"latest": "tagged_hash_abc"},
+            untagged_hashes=["untagged_hash_xyz"],
+            blob_ages_days={"tagged_hash_abc": 0, "untagged_hash_xyz": 100},
+        )
+
+        result, blobs = run_gc(
+            storage_path=storage_root,
+            retention_days=30,
+            dry_run=True,
+        )
+
+        assert result.artifacts_scanned == 1
+        assert result.blobs_found == 2
+        assert result.blobs_deleted == 1
+        assert len(blobs) == 1
+        assert blobs[0].blob_hash == "untagged"
+
+    def test_dry_run_does_not_delete(self, storage_root: Path) -> None:
+        """Dry run doesn't delete blobs."""
+        artifact_dir = create_artifact_with_blobs(
+            storage_root,
+            "test/artifact",
+            tagged_hashes={"latest": "tagged_hash_abc"},
+            untagged_hashes=["untagged_hash_xyz"],
+            blob_ages_days={"tagged_hash_abc": 0, "untagged_hash_xyz": 100},
+        )
+
+        blob_file = artifact_dir / "blobs" / "untagged"
+        assert blob_file.exists()
+
+        result, blobs = run_gc(
+            storage_path=storage_root,
+            retention_days=30,
+            dry_run=True,
+        )
+
+        assert result.blobs_deleted == 1
+        assert blob_file.exists()  # Still exists after dry run
+
+    def test_deletes_expired_blobs(self, storage_root: Path) -> None:
+        """Deletes untagged blobs older than retention period."""
+        artifact_dir = create_artifact_with_blobs(
+            storage_root,
+            "test/artifact",
+            tagged_hashes={"latest": "tagged_hash_abc"},
+            untagged_hashes=["old_untagged_xyz"],
+            blob_ages_days={"tagged_hash_abc": 0, "old_untagged_xyz": 100},
+        )
+
+        blob_file = artifact_dir / "blobs" / "old_unta"
+        assert blob_file.exists()
+
+        result, blobs = run_gc(
+            storage_path=storage_root,
+            retention_days=30,
+            dry_run=False,
+        )
+
+        assert result.blobs_deleted == 1
+        assert not blob_file.exists()  # Deleted
+
+    def test_preserves_young_blobs(self, storage_root: Path) -> None:
+        """Doesn't delete blobs younger than retention period."""
+        artifact_dir = create_artifact_with_blobs(
+            storage_root,
+            "test/artifact",
+            tagged_hashes={"latest": "tagged_hash_abc"},
+            untagged_hashes=["young_untagged_xyz"],
+            blob_ages_days={
+                "tagged_hash_abc": 0,
+                "young_untagged_xyz": 10,  # Less than 30 day retention
+            },
+        )
+
+        blob_file = artifact_dir / "blobs" / "young_un"
+        assert blob_file.exists()
+
+        result, blobs = run_gc(
+            storage_path=storage_root,
+            retention_days=30,
+            dry_run=False,
+        )
+
+        assert result.blobs_deleted == 0
+        assert blob_file.exists()
+
+    def test_preserves_tagged_blobs(self, storage_root: Path) -> None:
+        """Never deletes tagged blobs regardless of age."""
+        artifact_dir = create_artifact_with_blobs(
+            storage_root,
+            "test/artifact",
+            tagged_hashes={"latest": "old_tagged_hash"},
+            untagged_hashes=[],
+            blob_ages_days={"old_tagged_hash": 365},  # Very old but tagged
+        )
+
+        blob_file = artifact_dir / "blobs" / "old_tagg"
+        assert blob_file.exists()
+
+        result, blobs = run_gc(
+            storage_path=storage_root,
+            retention_days=30,
+            dry_run=False,
+        )
+
+        assert result.blobs_deleted == 0
+        assert blob_file.exists()
+
+    def test_reconcile_only_skips_deletion(self, storage_root: Path) -> None:
+        """reconcile_only mode only fixes symlinks."""
+        artifact_dir = create_artifact_with_blobs(
+            storage_root,
+            "test/artifact",
+            tagged_hashes={"latest": "tagged_hash_abc"},
+            untagged_hashes=["old_untagged_xyz"],
+            blob_ages_days={"tagged_hash_abc": 0, "old_untagged_xyz": 100},
+        )
+
+        blob_file = artifact_dir / "blobs" / "old_unta"
+        assert blob_file.exists()
+
+        result, blobs = run_gc(
+            storage_path=storage_root,
+            retention_days=30,
+            reconcile_only=True,
+        )
+
+        # No blobs should be collected for deletion
+        assert result.blobs_found == 0  # Not scanned for deletion
+        assert result.blobs_deleted == 0
+        assert blobs == []
+        assert blob_file.exists()  # Not deleted
+
+        # But symlinks should be checked
+        assert result.symlinks_checked > 0
+
+    def test_multiple_artifacts(self, storage_root: Path) -> None:
+        """Processes multiple artifacts correctly."""
+        create_artifact_with_blobs(
+            storage_root,
+            "project1/app",
+            tagged_hashes={"latest": "hash_a"},
+            untagged_hashes=["old_hash_b"],
+            blob_ages_days={"hash_a": 0, "old_hash_b": 100},
+        )
+        create_artifact_with_blobs(
+            storage_root,
+            "project2/lib",
+            tagged_hashes={"latest": "hash_c"},
+            untagged_hashes=["old_hash_d"],
+            blob_ages_days={"hash_c": 0, "old_hash_d": 100},
+        )
+
+        result, blobs = run_gc(
+            storage_path=storage_root,
+            retention_days=30,
+            dry_run=False,
+        )
+
+        assert result.artifacts_scanned == 2
+        assert result.blobs_deleted == 2
+
+    def test_reconciles_symlinks(self, storage_root: Path) -> None:
+        """Creates missing symlinks during GC."""
+        artifact_dir = create_artifact_with_blobs(
+            storage_root,
+            "test/artifact",
+            tagged_hashes={"latest": "tagged_hash_abc"},
+            untagged_hashes=[],
+        )
+
+        # Symlink should not exist yet
+        symlink = artifact_dir / "latest"
+        assert not symlink.exists()
+
+        result, _ = run_gc(
+            storage_path=storage_root,
+            retention_days=30,
+        )
+
+        assert result.symlinks_fixed > 0
+        assert symlink.is_symlink()
+
+    def test_progress_callback_called(self, storage_root: Path) -> None:
+        """Progress callback is called during scan."""
+        create_artifact_with_blobs(
+            storage_root,
+            "test/artifact",
+            tagged_hashes={"latest": "hash_abc"},
+            untagged_hashes=[],
+        )
+
+        calls = []
+
+        def callback(phase: str, current: int, total: int) -> None:
+            calls.append((phase, current, total))
+
+        run_gc(
+            storage_path=storage_root,
+            retention_days=30,
+            progress_callback=callback,
+        )
+
+        assert len(calls) > 0
+        assert calls[0][0] == "scan"
+        assert calls[0][2] == 1  # Total artifacts
+
+    def test_deletes_metadata_sidecar(self, storage_root: Path) -> None:
+        """Deletes metadata sidecar when deleting blob."""
+        artifact_dir = create_artifact_with_blobs(
+            storage_root,
+            "test/artifact",
+            tagged_hashes={},
+            untagged_hashes=["old_hash_xyz"],
+            blob_ages_days={"old_hash_xyz": 100},
+        )
+
+        blob_file = artifact_dir / "blobs" / "old_hash"
+        metadata_file = artifact_dir / "metadata" / "old_hash.json"
+        assert blob_file.exists()
+        assert metadata_file.exists()
+
+        run_gc(
+            storage_path=storage_root,
+            retention_days=30,
+            dry_run=False,
+        )
+
+        assert not blob_file.exists()
+        assert not metadata_file.exists()
+
+
+class TestBlobToDelete:
+    """Tests for BlobToDelete dataclass."""
+
+    def test_creation(self, tmp_path: Path) -> None:
+        """Can create BlobToDelete instances."""
+        blob_file = tmp_path / "blob"
+        blob_file.write_bytes(b"test")
+
+        blob = BlobToDelete(
+            blob_file=blob_file,
+            artifact_path="test/artifact",
+            blob_hash="abc12345",
+            age_days=100,
+            size=4,
+            metadata_file=None,
+        )
+
+        assert blob.blob_file == blob_file
+        assert blob.artifact_path == "test/artifact"
+        assert blob.blob_hash == "abc12345"
+        assert blob.age_days == 100
+        assert blob.size == 4
+        assert blob.metadata_file is None


### PR DESCRIPTION
## Summary

- Creates a new shared GC implementation in `src/magpie/storage/gc.py` with the core algorithm
- Refactors CLI, CTL, and server GC endpoints to be thin wrappers around `run_gc()`
- Fixes a bug in the server implementation where full hashes were used for tag comparison instead of short (8-char) hashes
- Adds comprehensive unit tests for the shared module

## Changes

**New file: `src/magpie/storage/gc.py`**
- `GCResult` dataclass with all GC statistics
- `BlobToDelete` dataclass for tracking blobs scheduled for deletion
- `SymlinkFixDetail` dataclass for detailed symlink fix reporting
- `run_gc()` core function with progress callback support
- `get_blob_age_days()` helper (previously duplicated in CTL and server)
- `format_size()` helper (previously duplicated in CLI and CTL)

**Updated entry points:**
- `cli/commands/gc.py` - Now imports `format_size` from shared module
- `ctl/commands/gc.py` - Thin wrapper with progress bar handling
- `server/routes/gc.py` - Thin wrapper returning `GCResponse`

## Bug Fixes

The server implementation had a bug where it used full hashes for tag comparison:
```python
# Old (buggy):
tagged_hashes = set(manifest.tags.values())

# New (correct):
tagged_hashes = {h[:8] for h in manifest.tags.values()}
```

This meant blobs were never correctly identified as "tagged" and could be incorrectly garbage collected.

## Test plan

- [x] All existing CTL GC tests pass (30 tests in `test_ctl_init_gc.py`)
- [x] New unit tests for shared module pass (24 tests in `test_gc.py`)
- [x] Total test suite passes (563 tests)
- [x] Ruff check and format pass
- [ ] CI passes

Fixes #69

---
Generated with AI assistance (Claude Code w/ Opus 4.5)