### PR TITLE
feat(docker): Add magpie-ctl wrapper for smart privilege handling

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -79,8 +79,14 @@ fi
 # The flock subshell holds the lock for the entire duration of the init check.
 # Using -w 30 to timeout after 30 seconds instead of blocking indefinitely.
 (
-    if ! flock -x -w 30 200; then
-        echo "Error: Failed to acquire database init lock on $DB_LOCK_FILE (timeout or flock unavailable)" >&2
+    flock_status=0
+    flock -x -w 30 200 || flock_status=$?
+    if [ "$flock_status" -ne 0 ]; then
+        if [ "$flock_status" -eq 1 ]; then
+            echo "Error: Failed to acquire database init lock on $DB_LOCK_FILE within 30 seconds (another process may be initializing the database)" >&2
+        else
+            echo "Error: flock failed with exit code $flock_status while trying to lock $DB_LOCK_FILE (is flock available and working?)" >&2
+        fi
         exit 1
     fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -92,10 +92,20 @@ fi
 
     if [ ! -f "$DB_PATH" ]; then
         echo "Database not found at $DB_PATH, running magpie-ctl init..."
+        init_status=0
         if [ "$RUN_UID" = "0" ]; then
-            /app/.venv/bin/python -m magpie.ctl init
+            /app/.venv/bin/python -m magpie.ctl init || init_status=$?
         else
-            gosu "$RUN_UID:$RUN_GID" /app/.venv/bin/python -m magpie.ctl init
+            gosu "$RUN_UID:$RUN_GID" /app/.venv/bin/python -m magpie.ctl init || init_status=$?
+        fi
+        if [ "$init_status" -ne 0 ]; then
+            echo "Error: magpie-ctl init failed with exit code $init_status" >&2
+            # Remove potentially incomplete database file to allow retry on next start
+            if [ -f "$DB_PATH" ]; then
+                echo "Removing incomplete database file at $DB_PATH" >&2
+                rm -f "$DB_PATH"
+            fi
+            exit 1
         fi
     fi
 ) 200>"$DB_LOCK_FILE"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -38,10 +38,10 @@ chmod 644 /run/magpie-user
 # Auto-initialize database if it doesn't exist
 # This runs before starting the main service
 # Uses a lock file (held via flock on FD 200) to prevent race conditions when multiple
-# containers share /data/artifacts. The lock is only held for the duration of the subshell
-# below (database check and init) and is automatically released when FD 200 closes at
-# subshell exit. The lock file itself persists on disk as an empty, harmless marker;
-# concurrent entrypoints will block on the lock and serialize correctly rather than deadlocking.
+# containers share /data/artifacts. The lock is held for the entire subshell duration
+# (both the existence check and the init command) and released when the subshell exits.
+# The lock file persists on disk as an empty marker; concurrent entrypoints serialize
+# correctly. A 30-second timeout prevents indefinite blocking.
 
 # Determine the storage path for the lock file. We need a directory that exists and is
 # writable. Check MAGPIE_STORAGE_PATH first, then fall back to /data/artifacts, then /data.
@@ -64,17 +64,15 @@ else
     DB_PATH="${MAGPIE_STORAGE_PATH:-/data/artifacts}/.magpie.db"
 fi
 
-# Acquire the lock before checking/initializing the database
-# We separate the flock step from the init step to provide clear error messages
-if ! flock -x 200 2>/dev/null; then
-    echo "Error: Failed to acquire database init lock on $DB_LOCK_FILE (file system error or flock unavailable)" >&2
-    exit 1
-fi 200>"$DB_LOCK_FILE"
-
-# Now check and initialize the database (lock is held on FD 200)
-# The subshell closes FD 200 (releasing the lock) after the init completes.
-# If the subshell exits non-zero, set -e propagates the failure to the main script.
+# Acquire the lock and check/initialize the database atomically
+# The flock subshell holds the lock for the entire duration of the init check.
+# Using -w 30 to timeout after 30 seconds instead of blocking indefinitely.
 (
+    if ! flock -x -w 30 200; then
+        echo "Error: Failed to acquire database init lock on $DB_LOCK_FILE (timeout or flock unavailable)" >&2
+        exit 1
+    fi
+
     if [ ! -f "$DB_PATH" ]; then
         echo "Database not found at $DB_PATH, running magpie-ctl init..."
         if [ "$RUN_UID" = "0" ]; then
@@ -83,7 +81,7 @@ fi 200>"$DB_LOCK_FILE"
             gosu "$RUN_UID:$RUN_GID" /app/.venv/bin/python -m magpie.ctl init
         fi
     fi
-) 200>&-
+) 200>"$DB_LOCK_FILE"
 
 # Run as root if UID is 0 (no privilege drop needed)
 if [ "$RUN_UID" = "0" ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -58,10 +58,21 @@ fi
 DB_LOCK_FILE="${LOCK_DIR}/.magpie-init.lock"
 
 # Determine database path: MAGPIE_DATABASE_PATH takes precedence, otherwise derive from validated LOCK_DIR
+# NOTE: When MAGPIE_DATABASE_PATH points outside LOCK_DIR, the lock file and database
+# reside in different locations. This lock is designed for single-container use (preventing
+# race conditions between the entrypoint and concurrent docker exec invocations). If you
+# override MAGPIE_DATABASE_PATH in a multi-container deployment, you are responsible for
+# your own coordination to avoid concurrent database initialization.
 if [ -n "$MAGPIE_DATABASE_PATH" ]; then
     DB_PATH="$MAGPIE_DATABASE_PATH"
 else
     DB_PATH="${LOCK_DIR}/.magpie.db"
+fi
+
+# Verify gosu is available before we need it (only required when not running as root)
+if [ "$RUN_UID" != "0" ] && ! command -v gosu >/dev/null 2>&1; then
+    echo "Error: gosu is required to drop privileges but was not found in PATH" >&2
+    exit 1
 fi
 
 # Acquire the lock and check/initialize the database atomically

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -37,15 +37,17 @@ chmod 644 /run/magpie-user
 
 # Auto-initialize database if it doesn't exist
 # This runs before starting the main service
-# Uses a lock file to prevent race conditions when multiple containers share /data
-# Note: The lock file persists on disk; this is intentional and harmless (flock releases
-# the lock automatically when the file descriptor closes, and the empty file has no effect)
-DB_LOCK_FILE=/data/.magpie-init.lock
+# Uses a lock file (held via flock on FD 200) to prevent race conditions when multiple
+# containers share /data/artifacts. The lock is only held for the duration of the subshell
+# below (database check and init) and is automatically released when FD 200 closes at
+# subshell exit. The lock file itself persists on disk as an empty, harmless marker;
+# concurrent entrypoints will block on the lock and serialize correctly rather than deadlocking.
+DB_LOCK_FILE="${MAGPIE_STORAGE_PATH:-/data/artifacts}/.magpie-init.lock"
 
 (
     flock -x 200
 
-    if [ ! -f /data/magpie.db ]; then
+    if [ ! -f "${MAGPIE_STORAGE_PATH:-/data/artifacts}/.magpie.db" ]; then
         echo "Database not found, running magpie-ctl init..."
         INIT_STATUS=0
         if [ "$RUN_UID" = "0" ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -42,13 +42,39 @@ chmod 644 /run/magpie-user
 # below (database check and init) and is automatically released when FD 200 closes at
 # subshell exit. The lock file itself persists on disk as an empty, harmless marker;
 # concurrent entrypoints will block on the lock and serialize correctly rather than deadlocking.
-DB_LOCK_FILE="${MAGPIE_STORAGE_PATH:-/data/artifacts}/.magpie-init.lock"
 
+# Determine the storage path for the lock file. We need a directory that exists and is
+# writable. Check MAGPIE_STORAGE_PATH first, then fall back to /data/artifacts, then /data.
+if [ -n "$MAGPIE_STORAGE_PATH" ] && [ -d "$MAGPIE_STORAGE_PATH" ]; then
+    LOCK_DIR="$MAGPIE_STORAGE_PATH"
+elif [ -d /data/artifacts ]; then
+    LOCK_DIR=/data/artifacts
+elif [ -d /data ]; then
+    LOCK_DIR=/data
+else
+    echo "Error: No valid storage directory found for lock file (tried MAGPIE_STORAGE_PATH, /data/artifacts, /data)" >&2
+    exit 1
+fi
+DB_LOCK_FILE="${LOCK_DIR}/.magpie-init.lock"
+
+# Determine database path: MAGPIE_DATABASE_PATH takes precedence, otherwise derive from storage
+if [ -n "$MAGPIE_DATABASE_PATH" ]; then
+    DB_PATH="$MAGPIE_DATABASE_PATH"
+else
+    DB_PATH="${MAGPIE_STORAGE_PATH:-/data/artifacts}/.magpie.db"
+fi
+
+# Acquire the lock before checking/initializing the database
+# We separate the flock step from the init step to provide clear error messages
+if ! flock -x 200 2>/dev/null; then
+    echo "Error: Failed to acquire database init lock on $DB_LOCK_FILE (file system error or flock unavailable)" >&2
+    exit 1
+fi 200>"$DB_LOCK_FILE"
+
+# Now check and initialize the database (lock is held on FD 200)
 (
-    flock -x 200
-
-    if [ ! -f "${MAGPIE_STORAGE_PATH:-/data/artifacts}/.magpie.db" ]; then
-        echo "Database not found, running magpie-ctl init..."
+    if [ ! -f "$DB_PATH" ]; then
+        echo "Database not found at $DB_PATH, running magpie-ctl init..."
         INIT_STATUS=0
         if [ "$RUN_UID" = "0" ]; then
             /app/.venv/bin/python -m magpie.ctl init || INIT_STATUS=$?
@@ -61,13 +87,12 @@ DB_LOCK_FILE="${MAGPIE_STORAGE_PATH:-/data/artifacts}/.magpie-init.lock"
             exit "$INIT_STATUS"
         fi
     fi
-) 200>"$DB_LOCK_FILE"
-INIT_LOCK_STATUS=$?
+) 200>&-
+INIT_STATUS=$?
 
-# The subshell exits with the init status; re-check and propagate to main script
-# (set -e doesn't automatically propagate subshell exit codes)
-if [ "$INIT_LOCK_STATUS" -ne 0 ]; then
-    exit "$INIT_LOCK_STATUS"
+# Propagate init failure to main script (set -e doesn't automatically propagate subshell exit codes)
+if [ "$INIT_STATUS" -ne 0 ]; then
+    exit "$INIT_STATUS"
 fi
 
 # Run as root if UID is 0 (no privilege drop needed)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -38,6 +38,8 @@ chmod 644 /run/magpie-user
 # Auto-initialize database if it doesn't exist
 # This runs before starting the main service
 # Uses a lock file to prevent race conditions when multiple containers share /data
+# Note: The lock file persists on disk; this is intentional and harmless (flock releases
+# the lock automatically when the file descriptor closes, and the empty file has no effect)
 DB_LOCK_FILE=/data/.magpie-init.lock
 
 (
@@ -45,15 +47,12 @@ DB_LOCK_FILE=/data/.magpie-init.lock
 
     if [ ! -f /data/magpie.db ]; then
         echo "Database not found, running magpie-ctl init..."
-        set +e
+        INIT_STATUS=0
         if [ "$RUN_UID" = "0" ]; then
-            /app/.venv/bin/python -m magpie.ctl init
-            INIT_STATUS=$?
+            /app/.venv/bin/python -m magpie.ctl init || INIT_STATUS=$?
         else
-            gosu "$RUN_UID:$RUN_GID" /app/.venv/bin/python -m magpie.ctl init
-            INIT_STATUS=$?
+            gosu "$RUN_UID:$RUN_GID" /app/.venv/bin/python -m magpie.ctl init || INIT_STATUS=$?
         fi
-        set -e
 
         if [ "$INIT_STATUS" -ne 0 ]; then
             echo "Error: magpie-ctl init failed with exit code $INIT_STATUS" >&2
@@ -61,6 +60,13 @@ DB_LOCK_FILE=/data/.magpie-init.lock
         fi
     fi
 ) 200>"$DB_LOCK_FILE"
+INIT_LOCK_STATUS=$?
+
+# The subshell exits with the init status; re-check and propagate to main script
+# (set -e doesn't automatically propagate subshell exit codes)
+if [ "$INIT_LOCK_STATUS" -ne 0 ]; then
+    exit "$INIT_LOCK_STATUS"
+fi
 
 # Run as root if UID is 0 (no privilege drop needed)
 if [ "$RUN_UID" = "0" ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -35,6 +35,17 @@ mkdir -p /run
 echo "$RUN_UID:$RUN_GID" > /run/magpie-user
 chmod 644 /run/magpie-user
 
+# Auto-initialize database if it doesn't exist
+# This runs before starting the main service
+if [ ! -f /data/magpie.db ]; then
+    echo "Database not found, running magpie-ctl init..."
+    if [ "$RUN_UID" = "0" ]; then
+        /app/.venv/bin/python -m magpie.ctl init
+    else
+        gosu "$RUN_UID:$RUN_GID" /app/.venv/bin/python -m magpie.ctl init
+    fi
+fi
+
 # Run as root if UID is 0 (no privilege drop needed)
 if [ "$RUN_UID" = "0" ]; then
     exec "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -57,11 +57,11 @@ else
 fi
 DB_LOCK_FILE="${LOCK_DIR}/.magpie-init.lock"
 
-# Determine database path: MAGPIE_DATABASE_PATH takes precedence, otherwise derive from storage
+# Determine database path: MAGPIE_DATABASE_PATH takes precedence, otherwise derive from validated LOCK_DIR
 if [ -n "$MAGPIE_DATABASE_PATH" ]; then
     DB_PATH="$MAGPIE_DATABASE_PATH"
 else
-    DB_PATH="${MAGPIE_STORAGE_PATH:-/data/artifacts}/.magpie.db"
+    DB_PATH="${LOCK_DIR}/.magpie.db"
 fi
 
 # Acquire the lock and check/initialize the database atomically

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -37,14 +37,30 @@ chmod 644 /run/magpie-user
 
 # Auto-initialize database if it doesn't exist
 # This runs before starting the main service
-if [ ! -f /data/magpie.db ]; then
-    echo "Database not found, running magpie-ctl init..."
-    if [ "$RUN_UID" = "0" ]; then
-        /app/.venv/bin/python -m magpie.ctl init
-    else
-        gosu "$RUN_UID:$RUN_GID" /app/.venv/bin/python -m magpie.ctl init
+# Uses a lock file to prevent race conditions when multiple containers share /data
+DB_LOCK_FILE=/data/.magpie-init.lock
+
+(
+    flock -x 200
+
+    if [ ! -f /data/magpie.db ]; then
+        echo "Database not found, running magpie-ctl init..."
+        set +e
+        if [ "$RUN_UID" = "0" ]; then
+            /app/.venv/bin/python -m magpie.ctl init
+            INIT_STATUS=$?
+        else
+            gosu "$RUN_UID:$RUN_GID" /app/.venv/bin/python -m magpie.ctl init
+            INIT_STATUS=$?
+        fi
+        set -e
+
+        if [ "$INIT_STATUS" -ne 0 ]; then
+            echo "Error: magpie-ctl init failed with exit code $INIT_STATUS" >&2
+            exit "$INIT_STATUS"
+        fi
     fi
-fi
+) 200>"$DB_LOCK_FILE"
 
 # Run as root if UID is 0 (no privilege drop needed)
 if [ "$RUN_UID" = "0" ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -72,28 +72,18 @@ if ! flock -x 200 2>/dev/null; then
 fi 200>"$DB_LOCK_FILE"
 
 # Now check and initialize the database (lock is held on FD 200)
+# The subshell closes FD 200 (releasing the lock) after the init completes.
+# If the subshell exits non-zero, set -e propagates the failure to the main script.
 (
     if [ ! -f "$DB_PATH" ]; then
         echo "Database not found at $DB_PATH, running magpie-ctl init..."
-        INIT_STATUS=0
         if [ "$RUN_UID" = "0" ]; then
-            /app/.venv/bin/python -m magpie.ctl init || INIT_STATUS=$?
+            /app/.venv/bin/python -m magpie.ctl init
         else
-            gosu "$RUN_UID:$RUN_GID" /app/.venv/bin/python -m magpie.ctl init || INIT_STATUS=$?
-        fi
-
-        if [ "$INIT_STATUS" -ne 0 ]; then
-            echo "Error: magpie-ctl init failed with exit code $INIT_STATUS" >&2
-            exit "$INIT_STATUS"
+            gosu "$RUN_UID:$RUN_GID" /app/.venv/bin/python -m magpie.ctl init
         fi
     fi
 ) 200>&-
-INIT_STATUS=$?
-
-# Propagate init failure to main script (set -e doesn't automatically propagate subshell exit codes)
-if [ "$INIT_STATUS" -ne 0 ]; then
-    exit "$INIT_STATUS"
-fi
 
 # Run as root if UID is 0 (no privilege drop needed)
 if [ "$RUN_UID" = "0" ]; then

--- a/magpie-ctl-wrapper.sh
+++ b/magpie-ctl-wrapper.sh
@@ -1,14 +1,29 @@
 #!/bin/bash
-# Wrapper for magpie-ctl that ensures it runs with the same user as the main app
-# This is needed when invoking magpie-ctl via docker exec, which bypasses the entrypoint
+# Unified wrapper for magpie-ctl that handles privilege management
+#
+# This wrapper detects whether it needs to drop privileges:
+# - If already running as the correct user (UID matches), exec directly
+# - If running as root, use gosu to drop privileges
+# - Fallback to direct exec if /run/magpie-user doesn't exist
+#
+# This enables magpie-ctl to work correctly whether invoked:
+# - From within the running container (same user)
+# - Via docker exec (typically as root)
+# - From cron or other contexts
 
 set -e
 
-if [ -f /run/magpie-user ] && command -v gosu >/dev/null 2>&1; then
-    # Read the UID:GID that the entrypoint determined
-    USER_INFO=$(cat /run/magpie-user)
-    exec gosu "$USER_INFO" /app/.venv/bin/magpie-ctl "$@"
-else
-    # Fallback: run directly (happens if container started without entrypoint or gosu not available)
-    exec /app/.venv/bin/magpie-ctl "$@"
+REAL_CTL="/app/.venv/bin/python -m magpie.ctl"
+
+if [ -f /run/magpie-user ]; then
+    EXPECTED_UID=$(cut -d: -f1 /run/magpie-user)
+    CURRENT_UID=$(id -u)
+
+    if [ "$CURRENT_UID" = "$EXPECTED_UID" ]; then
+        exec $REAL_CTL "$@"
+    elif [ "$CURRENT_UID" = "0" ]; then
+        exec gosu "$(cat /run/magpie-user)" $REAL_CTL "$@"
+    fi
 fi
+
+exec $REAL_CTL "$@"

--- a/magpie-ctl-wrapper.sh
+++ b/magpie-ctl-wrapper.sh
@@ -13,17 +13,23 @@
 
 set -e
 
-REAL_CTL="/app/.venv/bin/python -m magpie.ctl"
+# Use array to avoid word splitting issues with multi-word command
+REAL_CTL=(/app/.venv/bin/python -m magpie.ctl)
 
 if [ -f /run/magpie-user ]; then
     EXPECTED_UID=$(cut -d: -f1 /run/magpie-user)
     CURRENT_UID=$(id -u)
 
     if [ "$CURRENT_UID" = "$EXPECTED_UID" ]; then
-        exec $REAL_CTL "$@"
+        exec "${REAL_CTL[@]}" "$@"
     elif [ "$CURRENT_UID" = "0" ]; then
-        exec gosu "$(cat /run/magpie-user)" $REAL_CTL "$@"
+        if command -v gosu >/dev/null 2>&1; then
+            exec gosu "$(cat /run/magpie-user)" "${REAL_CTL[@]}" "$@"
+        else
+            echo "magpie-ctl-wrapper: gosu is required to drop privileges from root but was not found in PATH" >&2
+            exit 1
+        fi
     fi
 fi
 
-exec $REAL_CTL "$@"
+exec "${REAL_CTL[@]}" "$@"

--- a/magpie-ctl-wrapper.sh
+++ b/magpie-ctl-wrapper.sh
@@ -34,6 +34,11 @@ if [ -f /run/magpie-user ]; then
         exit 1
     fi
 
+    # Normalize UID/GID by stripping leading zeros to ensure consistent comparison
+    # (e.g., "007" becomes "7" to match `id -u` output)
+    EXPECTED_UID=$((10#$EXPECTED_UID))
+    EXPECTED_GID=$((10#$EXPECTED_GID))
+
     CURRENT_UID=$(id -u)
 
     if [ "$CURRENT_UID" = "$EXPECTED_UID" ]; then
@@ -43,6 +48,7 @@ if [ -f /run/magpie-user ]; then
             exec gosu "$EXPECTED_UID:$EXPECTED_GID" "${REAL_CTL[@]}" "$@"
         else
             echo "magpie-ctl-wrapper: gosu is required to drop privileges from root but was not found in PATH" >&2
+            echo "magpie-ctl-wrapper: ensure gosu is installed in the container image (e.g., 'apt-get install gosu')" >&2
             exit 1
         fi
     fi

--- a/magpie-ctl-wrapper.sh
+++ b/magpie-ctl-wrapper.sh
@@ -41,8 +41,10 @@ if [ -f /run/magpie-user ]; then
     # the container where we control the user context. Fall through to the
     # final exec below, which will run as the current (unexpected) user.
     echo "magpie-ctl-wrapper: warning: running as UID $CURRENT_UID (expected $EXPECTED_UID or 0)" >&2
+    echo "magpie-ctl-wrapper: warning: this may cause permission errors accessing the database or storage paths" >&2
 fi
 
 # Fallback: run directly if /run/magpie-user doesn't exist (container started
 # without entrypoint) or if we're in an unexpected UID state (see warning above).
+# Note: In the unexpected UID case, the command may fail with permission errors.
 exec "${REAL_CTL[@]}" "$@"

--- a/magpie-ctl-wrapper.sh
+++ b/magpie-ctl-wrapper.sh
@@ -20,6 +20,12 @@ if [ -f /run/magpie-user ]; then
     EXPECTED_UID=$(cut -d: -f1 /run/magpie-user)
     CURRENT_UID=$(id -u)
 
+    # Validate that EXPECTED_UID is non-empty and numeric
+    if [ -z "$EXPECTED_UID" ] || ! [[ "$EXPECTED_UID" =~ ^[0-9]+$ ]]; then
+        echo "magpie-ctl-wrapper: invalid UID in /run/magpie-user: '$EXPECTED_UID'" >&2
+        exit 1
+    fi
+
     if [ "$CURRENT_UID" = "$EXPECTED_UID" ]; then
         exec "${REAL_CTL[@]}" "$@"
     elif [ "$CURRENT_UID" = "0" ]; then
@@ -30,6 +36,13 @@ if [ -f /run/magpie-user ]; then
             exit 1
         fi
     fi
+    # If we reach here, the current UID is neither the expected UID nor root.
+    # This is an unexpected state - the wrapper should only be invoked inside
+    # the container where we control the user context. Fall through to the
+    # final exec below, which will run as the current (unexpected) user.
+    echo "magpie-ctl-wrapper: warning: running as UID $CURRENT_UID (expected $EXPECTED_UID or 0)" >&2
 fi
 
+# Fallback: run directly if /run/magpie-user doesn't exist (container started
+# without entrypoint) or if we're in an unexpected UID state (see warning above).
 exec "${REAL_CTL[@]}" "$@"

--- a/magpie-ctl-wrapper.sh
+++ b/magpie-ctl-wrapper.sh
@@ -17,8 +17,10 @@ set -e
 REAL_CTL=(/app/.venv/bin/python -m magpie.ctl)
 
 if [ -f /run/magpie-user ]; then
-    EXPECTED_UID=$(cut -d: -f1 /run/magpie-user)
-    CURRENT_UID=$(id -u)
+    # Extract and validate both UID and GID from /run/magpie-user (format: UID:GID)
+    MAGPIE_USER_CONTENT=$(cat /run/magpie-user)
+    EXPECTED_UID=$(echo "$MAGPIE_USER_CONTENT" | cut -d: -f1)
+    EXPECTED_GID=$(echo "$MAGPIE_USER_CONTENT" | cut -d: -f2)
 
     # Validate that EXPECTED_UID is non-empty and numeric
     if [ -z "$EXPECTED_UID" ] || ! [[ "$EXPECTED_UID" =~ ^[0-9]+$ ]]; then
@@ -26,11 +28,19 @@ if [ -f /run/magpie-user ]; then
         exit 1
     fi
 
+    # Validate that EXPECTED_GID is non-empty and numeric
+    if [ -z "$EXPECTED_GID" ] || ! [[ "$EXPECTED_GID" =~ ^[0-9]+$ ]]; then
+        echo "magpie-ctl-wrapper: invalid GID in /run/magpie-user: '$EXPECTED_GID'" >&2
+        exit 1
+    fi
+
+    CURRENT_UID=$(id -u)
+
     if [ "$CURRENT_UID" = "$EXPECTED_UID" ]; then
         exec "${REAL_CTL[@]}" "$@"
     elif [ "$CURRENT_UID" = "0" ]; then
         if command -v gosu >/dev/null 2>&1; then
-            exec gosu "$(cat /run/magpie-user)" "${REAL_CTL[@]}" "$@"
+            exec gosu "$EXPECTED_UID:$EXPECTED_GID" "${REAL_CTL[@]}" "$@"
         else
             echo "magpie-ctl-wrapper: gosu is required to drop privileges from root but was not found in PATH" >&2
             exit 1

--- a/magpie-ctl-wrapper.sh
+++ b/magpie-ctl-wrapper.sh
@@ -4,7 +4,7 @@
 # This wrapper detects whether it needs to drop privileges:
 # - If already running as the correct user (UID matches), exec directly
 # - If running as root, use gosu to drop privileges
-# - Fallback to direct exec if /run/magpie-user doesn't exist
+# - Fallback to direct exec if /run/magpie-user doesn't exist or UID is neither expected nor root
 #
 # This enables magpie-ctl to work correctly whether invoked:
 # - From within the running container (same user)
@@ -13,7 +13,7 @@
 
 set -e
 
-# Use array to avoid word splitting issues with multi-word command
+# Use an array so the command and its arguments are kept as separate elements
 REAL_CTL=(/app/.venv/bin/python -m magpie.ctl)
 
 if [ -f /run/magpie-user ]; then


### PR DESCRIPTION
## Summary

This PR adds a unified `magpie-ctl-wrapper.sh` script that intelligently handles privilege management for `magpie-ctl` commands, whether invoked from within the running container or via `docker exec`.

- **Smart UID detection**: The wrapper checks `/run/magpie-user` (written by entrypoint) to determine the expected user
- **Automatic privilege drop**: When invoked as root (typical for `docker exec`), uses `gosu` to drop to the correct user
- **Direct execution**: When already running as the expected user, executes directly without overhead
- **Graceful degradation**: Warns but continues if invoked as an unexpected UID

Additionally, the entrypoint now auto-initializes the database on first start with proper locking to prevent race conditions when multiple containers share storage.

## Key Design Decisions

1. **Fail-open for UID mismatch**: The wrapper warns but allows execution if running as an unexpected UID. This is intentional - better to try and fail with a clear permission error than refuse to run at all.

2. **Lock file in storage directory**: The init lock file is placed in the storage directory (not `/run`) so it works correctly when multiple containers share the same storage volume.

3. **30-second flock timeout**: Prevents indefinite blocking if something goes wrong with the lock. Most init operations complete in under a second.

4. **FD 200 for flock**: Standard convention that avoids conflicts with stdin/stdout/stderr and common redirects.

## Testing Done

- Shell scripts pass `shellcheck` with no warnings
- Python linting (`ruff check`) passes
- Python formatting (`ruff format --check`) passes
- All 543 unit tests pass
- Manual testing of privilege drop scenarios

## Review Findings Addressed

This is a fresh PR after PR #73 was closed. Key fix from post-close review:

- **Fixed flock/subshell pattern**: The previous code had a bug where the lock was released before the subshell ran the database check. The flock is now inside the subshell so the lock is held for the entire init operation.

Closes #72

---
(AI-generated via Claude Code w/ Opus 4.5)