### PR TITLE
feat(cli): Add --format json support for machine-readable output

### DIFF
--- a/src/magpie/cli/__init__.py
+++ b/src/magpie/cli/__init__.py
@@ -9,6 +9,7 @@ import click
 
 from magpie.cli.client import get_client
 from magpie.cli.config import get_server, get_timeout, get_token
+from magpie.cli.formatting import OutputFormat
 from magpie.config import get_settings
 
 if TYPE_CHECKING:
@@ -56,11 +57,13 @@ class CLIContext:
         token: str,
         debug: bool = False,
         timeout: float = 600.0,
+        output_format: OutputFormat = OutputFormat.HUMAN,
     ) -> None:
         self.server = server
         self.token = token
         self.debug = debug
         self.timeout = timeout
+        self.output_format = output_format
 
     def get_client(self) -> "httpx.Client":
         """Get configured httpx client."""
@@ -93,6 +96,13 @@ pass_context = click.make_pass_decorator(CLIContext)
     default=False,
     help="Enable debug output.",
 )
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice([f.value for f in OutputFormat], case_sensitive=False),
+    default=OutputFormat.HUMAN.value,
+    help="Output format (default: human).",
+)
 @click.pass_context
 def cli(
     ctx: click.Context,
@@ -100,23 +110,27 @@ def cli(
     token: str | None,
     timeout: float | None,
     debug: bool,
+    output_format: str,
 ) -> None:
     """Magpie: Content-addressed artifact storage client."""
     resolved_server = get_server(cli_override=server)
     resolved_token = get_token(cli_override=token)
     resolved_timeout = get_timeout(cli_override=timeout)
+    resolved_format = OutputFormat(output_format)
 
     ctx.obj = CLIContext(
         server=resolved_server,
         token=resolved_token,
         debug=debug,
         timeout=resolved_timeout,
+        output_format=resolved_format,
     )
 
     if debug:
         click.echo(f"Server: {resolved_server}", err=True)
         click.echo(f"Token: {'***' if resolved_token else '(none)'}", err=True)
         click.echo(f"Timeout: {resolved_timeout}s", err=True)
+        click.echo(f"Format: {resolved_format.value}", err=True)
 
 
 @cli.command()

--- a/src/magpie/cli/commands/amend.py
+++ b/src/magpie/cli/commands/amend.py
@@ -7,6 +7,14 @@ import click
 from magpie.cli import CLIContext
 from magpie.cli.commands.parse import ParseError, parse_artifact_ref
 from magpie.cli.errors import handle_http_error
+from magpie.cli.formatting import (
+    CommandResult,
+    ErrorCode,
+    http_status_to_error_code,
+    is_json_output,
+    output_error,
+    output_result,
+)
 
 
 @click.command()
@@ -30,14 +38,25 @@ def amend(ctx: CLIContext, artifact_ref: str, source_uri: str | None) -> None:
         magpie amend builds/app --source-uri https://ci.example.com/builds/123
     """
     if not ctx.server:
+        if is_json_output():
+            output_error(
+                ErrorCode.CONFIG_ERROR, "No server configured. Use --server or set MAGPIE_SERVER."
+            )
         raise click.ClickException("No server configured. Use --server or set MAGPIE_SERVER.")
 
     if source_uri is None:
+        if is_json_output():
+            output_error(
+                ErrorCode.VALIDATION_ERROR,
+                "No metadata updates specified. Use --source-uri to update.",
+            )
         raise click.ClickException("No metadata updates specified. Use --source-uri to update.")
 
     try:
         parsed = parse_artifact_ref(artifact_ref)
     except ParseError as e:
+        if is_json_output():
+            output_error(ErrorCode.VALIDATION_ERROR, str(e))
         raise click.ClickException(str(e))
 
     with ctx.get_client() as client:
@@ -46,9 +65,11 @@ def amend(ctx: CLIContext, artifact_ref: str, source_uri: str | None) -> None:
 
         # Build request body
         body: dict[str, str | None] = {}
+        updated_fields: list[str] = []
         if source_uri is not None:
             # Empty string means clear the field (set to null)
             body["source_uri"] = source_uri if source_uri else None
+            updated_fields.append("source_uri")
 
         response = client.patch(
             f"/api/v1/artifacts/{parsed.path}/{parsed.ref}",
@@ -56,13 +77,35 @@ def amend(ctx: CLIContext, artifact_ref: str, source_uri: str | None) -> None:
         )
 
         if response.status_code == 404:
+            if is_json_output():
+                output_error(ErrorCode.NOT_FOUND, f"Artifact not found: {parsed.path}:{parsed.ref}")
             raise click.ClickException(f"Artifact not found: {parsed.path}:{parsed.ref}")
         if response.status_code != 200:
+            if is_json_output():
+                try:
+                    detail = response.json().get("detail", response.text)
+                except Exception:
+                    detail = response.text
+                output_error(http_status_to_error_code(response.status_code), detail)
             handle_http_error(response, "Amend", ctx.token)
 
         data = response.json()
 
-    # Display updated metadata
+    # JSON output
+    if is_json_output():
+        output_result(
+            CommandResult(
+                data={
+                    "artifact": parsed.path,
+                    "version": data["hash_ref"],
+                    "updated_fields": updated_fields,
+                },
+                human_output="",
+            )
+        )
+        return
+
+    # Human output
     click.echo(f"Updated: {parsed.path}:{data['hash_ref']}")
     click.echo(f"  Source URI: {data.get('source_uri') or '(none)'}")
     click.echo(f"  Tags: {', '.join(data.get('tags', []))}")

--- a/src/magpie/cli/commands/config_cmd.py
+++ b/src/magpie/cli/commands/config_cmd.py
@@ -94,13 +94,17 @@ def config_cmd(
 
     # Validate mutually exclusive options
     if clear and (server or token):
+        msg = "Cannot use --clear with --server or --token."
         if is_json_output():
-            output_error(ErrorCode.VALIDATION_ERROR, "Cannot use --clear with --server or --token.")
-        raise click.ClickException("Cannot use --clear with --server or --token.")
+            output_error(ErrorCode.VALIDATION_ERROR, msg)
+        else:
+            raise click.ClickException(msg)
     if show and (server or token or clear):
+        msg = "Cannot use --show with other options."
         if is_json_output():
-            output_error(ErrorCode.VALIDATION_ERROR, "Cannot use --show with other options.")
-        raise click.ClickException("Cannot use --show with other options.")
+            output_error(ErrorCode.VALIDATION_ERROR, msg)
+        else:
+            raise click.ClickException(msg)
 
     if show:
         _show_config(config_path)

--- a/src/magpie/cli/commands/config_cmd.py
+++ b/src/magpie/cli/commands/config_cmd.py
@@ -9,6 +9,13 @@ import tomli_w
 
 from magpie.cli import config as cli_config
 from magpie.cli.errors import mask_token
+from magpie.cli.formatting import (
+    CommandResult,
+    ErrorCode,
+    is_json_output,
+    output_error,
+    output_result,
+)
 
 
 def _write_config(config_path: Path, server: str | None, token: str | None) -> None:
@@ -87,8 +94,12 @@ def config_cmd(
 
     # Validate mutually exclusive options
     if clear and (server or token):
+        if is_json_output():
+            output_error(ErrorCode.VALIDATION_ERROR, "Cannot use --clear with --server or --token.")
         raise click.ClickException("Cannot use --clear with --server or --token.")
     if show and (server or token or clear):
+        if is_json_output():
+            output_error(ErrorCode.VALIDATION_ERROR, "Cannot use --show with other options.")
         raise click.ClickException("Cannot use --show with other options.")
 
     if show:
@@ -107,7 +118,21 @@ def config_cmd(
     # Set values
     _write_config(config_path, server, token)
 
-    # Show what was set
+    # JSON output
+    if is_json_output():
+        output_result(
+            CommandResult(
+                data={
+                    "server": server,
+                    "token": mask_token(token) if token else None,
+                    "path": str(config_path),
+                },
+                human_output="",
+            )
+        )
+        return
+
+    # Human output - show what was set
     if server:
         click.echo(f"Server set to: {server}")
     if token:
@@ -119,11 +144,44 @@ def config_cmd(
 def _show_config(config_path: Path) -> None:
     """Display current configuration."""
     if not config_path.exists():
+        # JSON output for missing config
+        if is_json_output():
+            output_result(
+                CommandResult(
+                    data={
+                        "server": None,
+                        "token": None,
+                        "timeout": None,
+                        "path": str(config_path),
+                        "exists": False,
+                    },
+                    human_output="",
+                )
+            )
+            return
         click.echo(f"No configuration file found at {config_path}")
         click.echo("Run 'magpie config --server URL --token TOKEN' to create one.")
         return
 
     config = cli_config.load_config(config_path)
+
+    # JSON output
+    if is_json_output():
+        output_result(
+            CommandResult(
+                data={
+                    "server": config.client.server,
+                    "token": mask_token(config.client.token) if config.client.token else None,
+                    "timeout": config.client.timeout,
+                    "path": str(config_path),
+                    "exists": True,
+                },
+                human_output="",
+            )
+        )
+        return
+
+    # Human output
     click.echo(f"Configuration file: {config_path}")
     click.echo()
 
@@ -141,11 +199,23 @@ def _show_config(config_path: Path) -> None:
 def _clear_config(config_path: Path) -> None:
     """Remove configuration file."""
     if not config_path.exists():
+        # JSON output for missing config
+        if is_json_output():
+            output_result(
+                CommandResult(
+                    data={
+                        "path": str(config_path),
+                        "cleared": False,
+                        "existed": False,
+                    },
+                    human_output="",
+                )
+            )
+            return
         click.echo(f"No configuration file found at {config_path}")
         return
 
     config_path.unlink()
-    click.echo(f"Configuration cleared: {config_path}")
 
     # Remove parent directory if empty
     try:
@@ -153,3 +223,20 @@ def _clear_config(config_path: Path) -> None:
     except OSError:
         # Directory not empty or other error, ignore
         pass
+
+    # JSON output
+    if is_json_output():
+        output_result(
+            CommandResult(
+                data={
+                    "path": str(config_path),
+                    "cleared": True,
+                    "existed": True,
+                },
+                human_output="",
+            )
+        )
+        return
+
+    # Human output
+    click.echo(f"Configuration cleared: {config_path}")

--- a/src/magpie/cli/commands/flush_tag.py
+++ b/src/magpie/cli/commands/flush_tag.py
@@ -60,11 +60,11 @@ def flush_tag(ctx: CLIContext, tag_name: str, dry_run: bool, yes: bool, force: b
         magpie flush-tag latest --force --yes
     """
     if not ctx.server:
+        msg = "No server configured. Use --server or set MAGPIE_SERVER."
         if is_json_output():
-            output_error(
-                ErrorCode.CONFIG_ERROR, "No server configured. Use --server or set MAGPIE_SERVER."
-            )
-        raise click.ClickException("No server configured. Use --server or set MAGPIE_SERVER.")
+            output_error(ErrorCode.CONFIG_ERROR, msg)
+        else:
+            raise click.ClickException(msg)
 
     # Refuse to flush protected tags without --force
     if tag_name.lower() in PROTECTED_TAGS and not force:
@@ -74,7 +74,8 @@ def flush_tag(ctx: CLIContext, tag_name: str, dry_run: bool, yes: bool, force: b
         )
         if is_json_output():
             output_error(ErrorCode.VALIDATION_ERROR, msg)
-        raise click.ClickException(msg)
+        else:
+            raise click.ClickException(msg)
 
     # In JSON mode, require --yes to skip confirmation (no interactive prompts)
     if is_json_output() and not dry_run and not yes:
@@ -112,7 +113,8 @@ def flush_tag(ctx: CLIContext, tag_name: str, dry_run: bool, yes: bool, force: b
                 except Exception:
                     detail = response.text
                 output_error(http_status_to_error_code(response.status_code), detail)
-            handle_http_error(response, "Flush", ctx.token)
+            else:
+                handle_http_error(response, "Flush", ctx.token)
         if response.status_code not in (200,):
             if is_json_output():
                 try:
@@ -120,7 +122,8 @@ def flush_tag(ctx: CLIContext, tag_name: str, dry_run: bool, yes: bool, force: b
                 except Exception:
                     detail = response.text
                 output_error(http_status_to_error_code(response.status_code), detail)
-            handle_http_error(response, "Flush", ctx.token)
+            else:
+                handle_http_error(response, "Flush", ctx.token)
 
         data = response.json()
         affected_count = data.get("count", 0)

--- a/src/magpie/cli/commands/flush_tag.py
+++ b/src/magpie/cli/commands/flush_tag.py
@@ -6,6 +6,14 @@ import click
 
 from magpie.cli import CLIContext
 from magpie.cli.errors import handle_http_error
+from magpie.cli.formatting import (
+    CommandResult,
+    ErrorCode,
+    http_status_to_error_code,
+    is_json_output,
+    output_error,
+    output_result,
+)
 
 # Tags that require --force to flush due to their common importance
 PROTECTED_TAGS = frozenset({"latest", "stable", "production", "prod", "release"})
@@ -52,13 +60,26 @@ def flush_tag(ctx: CLIContext, tag_name: str, dry_run: bool, yes: bool, force: b
         magpie flush-tag latest --force --yes
     """
     if not ctx.server:
+        if is_json_output():
+            output_error(
+                ErrorCode.CONFIG_ERROR, "No server configured. Use --server or set MAGPIE_SERVER."
+            )
         raise click.ClickException("No server configured. Use --server or set MAGPIE_SERVER.")
 
     # Refuse to flush protected tags without --force
     if tag_name.lower() in PROTECTED_TAGS and not force:
-        raise click.ClickException(
+        msg = (
             f"Tag '{tag_name}' is protected. Use --force to confirm you want to remove "
             f"this tag from ALL artifacts. Protected tags: {', '.join(sorted(PROTECTED_TAGS))}"
+        )
+        if is_json_output():
+            output_error(ErrorCode.VALIDATION_ERROR, msg)
+        raise click.ClickException(msg)
+
+    # In JSON mode, require --yes to skip confirmation (no interactive prompts)
+    if is_json_output() and not dry_run and not yes:
+        output_error(
+            ErrorCode.VALIDATION_ERROR, "In JSON mode, use --yes to confirm destructive operations."
         )
 
     # Confirm before proceeding (unless --yes or --dry-run)
@@ -85,14 +106,42 @@ def flush_tag(ctx: CLIContext, tag_name: str, dry_run: bool, yes: bool, force: b
         )
 
         if response.status_code == 400:
+            if is_json_output():
+                try:
+                    detail = response.json().get("detail", response.text)
+                except Exception:
+                    detail = response.text
+                output_error(http_status_to_error_code(response.status_code), detail)
             handle_http_error(response, "Flush", ctx.token)
         if response.status_code not in (200,):
+            if is_json_output():
+                try:
+                    detail = response.json().get("detail", response.text)
+                except Exception:
+                    detail = response.text
+                output_error(http_status_to_error_code(response.status_code), detail)
             handle_http_error(response, "Flush", ctx.token)
 
         data = response.json()
         affected_count = data.get("count", 0)
         affected_artifacts = data.get("affected_artifacts", [])
 
+    # JSON output
+    if is_json_output():
+        output_result(
+            CommandResult(
+                data={
+                    "tag": tag_name,
+                    "dry_run": dry_run,
+                    "artifacts_affected": affected_count,
+                    "artifacts": affected_artifacts,
+                },
+                human_output="",
+            )
+        )
+        return
+
+    # Human output
     if dry_run:
         click.echo(f"Would remove tag '{tag_name}' from {affected_count} artifact(s)")
     else:

--- a/src/magpie/cli/commands/gc.py
+++ b/src/magpie/cli/commands/gc.py
@@ -6,6 +6,14 @@ import click
 
 from magpie.cli import CLIContext
 from magpie.cli.errors import handle_http_error, mask_token
+from magpie.cli.formatting import (
+    CommandResult,
+    ErrorCode,
+    http_status_to_error_code,
+    is_json_output,
+    output_error,
+    output_result,
+)
 from magpie.storage.gc import format_size
 
 
@@ -34,9 +42,18 @@ def gc(ctx: CLIContext, dry_run: bool) -> None:
         magpie gc
     """
     if not ctx.server:
+        if is_json_output():
+            output_error(
+                ErrorCode.CONFIG_ERROR, "No server configured. Use --server or set MAGPIE_SERVER."
+            )
         raise click.ClickException("No server configured. Use --server or set MAGPIE_SERVER.")
 
     if not ctx.token:
+        if is_json_output():
+            output_error(
+                ErrorCode.CONFIG_ERROR,
+                "No token configured. Use --token or set MAGPIE_TOKEN. Admin token required.",
+            )
         raise click.ClickException(
             "No token configured. Use --token or set MAGPIE_TOKEN. Admin token required."
         )
@@ -54,16 +71,46 @@ def gc(ctx: CLIContext, dry_run: bool) -> None:
 
         if response.status_code == 401:
             msg = f"Authentication failed. Check your token (token: {mask_token(ctx.token)})"
+            if is_json_output():
+                output_error(ErrorCode.UNAUTHORIZED, msg)
             raise click.ClickException(msg)
         if response.status_code == 403:
             msg = f"Admin token required for garbage collection (token: {mask_token(ctx.token)})"
+            if is_json_output():
+                output_error(ErrorCode.FORBIDDEN, msg)
             raise click.ClickException(msg)
         if response.status_code not in (200,):
+            if is_json_output():
+                try:
+                    detail = response.json().get("detail", response.text)
+                except Exception:
+                    detail = response.text
+                output_error(http_status_to_error_code(response.status_code), detail)
             handle_http_error(response, "GC", ctx.token)
 
         data = response.json()
 
-    # Display results
+    # JSON output
+    if is_json_output():
+        output_result(
+            CommandResult(
+                data={
+                    "dry_run": dry_run,
+                    "blobs_removed": data["blobs_deleted"],
+                    "bytes_reclaimed": data["space_reclaimed_bytes"],
+                    "errors": [],  # Server-side GC currently doesn't report individual errors
+                    "artifacts_scanned": data.get("artifacts_scanned", 0),
+                    "blobs_found": data.get("blobs_found", 0),
+                    "symlinks_checked": data.get("symlinks_checked", 0),
+                    "symlinks_fixed": data.get("symlinks_fixed", 0),
+                    "items_removed": data.get("items_removed", 0),
+                },
+                human_output="",
+            )
+        )
+        return
+
+    # Human output
     if dry_run:
         click.echo("GC Preview (dry run):")
     else:

--- a/src/magpie/cli/commands/gc.py
+++ b/src/magpie/cli/commands/gc.py
@@ -42,21 +42,18 @@ def gc(ctx: CLIContext, dry_run: bool) -> None:
         magpie gc
     """
     if not ctx.server:
+        msg = "No server configured. Use --server or set MAGPIE_SERVER."
         if is_json_output():
-            output_error(
-                ErrorCode.CONFIG_ERROR, "No server configured. Use --server or set MAGPIE_SERVER."
-            )
-        raise click.ClickException("No server configured. Use --server or set MAGPIE_SERVER.")
+            output_error(ErrorCode.CONFIG_ERROR, msg)
+        else:
+            raise click.ClickException(msg)
 
     if not ctx.token:
+        msg = "No token configured. Use --token or set MAGPIE_TOKEN. Admin token required."
         if is_json_output():
-            output_error(
-                ErrorCode.CONFIG_ERROR,
-                "No token configured. Use --token or set MAGPIE_TOKEN. Admin token required.",
-            )
-        raise click.ClickException(
-            "No token configured. Use --token or set MAGPIE_TOKEN. Admin token required."
-        )
+            output_error(ErrorCode.CONFIG_ERROR, msg)
+        else:
+            raise click.ClickException(msg)
 
     with ctx.get_client() as client:
         if ctx.debug:
@@ -73,12 +70,14 @@ def gc(ctx: CLIContext, dry_run: bool) -> None:
             msg = f"Authentication failed. Check your token (token: {mask_token(ctx.token)})"
             if is_json_output():
                 output_error(ErrorCode.UNAUTHORIZED, msg)
-            raise click.ClickException(msg)
+            else:
+                raise click.ClickException(msg)
         if response.status_code == 403:
             msg = f"Admin token required for garbage collection (token: {mask_token(ctx.token)})"
             if is_json_output():
                 output_error(ErrorCode.FORBIDDEN, msg)
-            raise click.ClickException(msg)
+            else:
+                raise click.ClickException(msg)
         if response.status_code not in (200,):
             if is_json_output():
                 try:
@@ -86,7 +85,8 @@ def gc(ctx: CLIContext, dry_run: bool) -> None:
                 except Exception:
                     detail = response.text
                 output_error(http_status_to_error_code(response.status_code), detail)
-            handle_http_error(response, "GC", ctx.token)
+            else:
+                handle_http_error(response, "GC", ctx.token)
 
         data = response.json()
 

--- a/src/magpie/cli/commands/get.py
+++ b/src/magpie/cli/commands/get.py
@@ -56,18 +56,19 @@ def get(
         magpie get builds/app --no-verify
     """
     if not ctx.server:
+        msg = "No server configured. Use --server or set MAGPIE_SERVER."
         if is_json_output():
-            output_error(
-                ErrorCode.CONFIG_ERROR, "No server configured. Use --server or set MAGPIE_SERVER."
-            )
-        raise click.ClickException("No server configured. Use --server or set MAGPIE_SERVER.")
+            output_error(ErrorCode.CONFIG_ERROR, msg)
+        else:
+            raise click.ClickException(msg)
 
     try:
         parsed = parse_artifact_ref(artifact_ref)
     except ParseError as e:
         if is_json_output():
             output_error(ErrorCode.VALIDATION_ERROR, str(e))
-        raise click.ClickException(str(e))
+        else:
+            raise click.ClickException(str(e))
 
     with ctx.get_client() as client:
         # Fetch metadata to get hash and size for verification/progress
@@ -77,9 +78,11 @@ def get(
         info_response = client.get(f"/api/v1/artifacts/{parsed.path}/{parsed.ref}/info")
 
         if info_response.status_code == 404:
+            msg = f"Artifact not found: {parsed.path}:{parsed.ref}"
             if is_json_output():
-                output_error(ErrorCode.NOT_FOUND, f"Artifact not found: {parsed.path}:{parsed.ref}")
-            raise click.ClickException(f"Artifact not found: {parsed.path}:{parsed.ref}")
+                output_error(ErrorCode.NOT_FOUND, msg)
+            else:
+                raise click.ClickException(msg)
         if info_response.status_code != 200:
             if is_json_output():
                 try:
@@ -87,7 +90,8 @@ def get(
                 except Exception:
                     detail = info_response.text
                 output_error(http_status_to_error_code(info_response.status_code), detail)
-            handle_http_error(info_response, "Metadata", ctx.token)
+            else:
+                handle_http_error(info_response, "Metadata", ctx.token)
 
         info = info_response.json()
         expected_hash = info["hash"]
@@ -160,9 +164,11 @@ def get(
         chunks: list[bytes] = []
         with client.stream("GET", download_url) as response:
             if response.status_code == 404:
+                msg = f"Artifact blob not found: {hash_ref}"
                 if is_json_output():
-                    output_error(ErrorCode.NOT_FOUND, f"Artifact blob not found: {hash_ref}")
-                raise click.ClickException(f"Artifact blob not found: {hash_ref}")
+                    output_error(ErrorCode.NOT_FOUND, msg)
+                else:
+                    raise click.ClickException(msg)
             if response.status_code != 200:
                 # Read response body for error message
                 response.read()
@@ -172,7 +178,8 @@ def get(
                     except Exception:
                         detail = response.text
                     output_error(http_status_to_error_code(response.status_code), detail)
-                handle_http_error(response, "Download", ctx.token)
+                else:
+                    handle_http_error(response, "Download", ctx.token)
 
             # Get content length from header if available (may be more accurate)
             content_length = response.headers.get("content-length")

--- a/src/magpie/cli/commands/get.py
+++ b/src/magpie/cli/commands/get.py
@@ -10,6 +10,14 @@ import click
 from magpie.cli import CLIContext
 from magpie.cli.commands.parse import ParseError, parse_artifact_ref
 from magpie.cli.errors import handle_http_error
+from magpie.cli.formatting import (
+    CommandResult,
+    ErrorCode,
+    http_status_to_error_code,
+    is_json_output,
+    output_error,
+    output_result,
+)
 from magpie.cli.progress import transfer_progress
 from magpie.storage.hash import compute_hash
 
@@ -48,11 +56,17 @@ def get(
         magpie get builds/app --no-verify
     """
     if not ctx.server:
+        if is_json_output():
+            output_error(
+                ErrorCode.CONFIG_ERROR, "No server configured. Use --server or set MAGPIE_SERVER."
+            )
         raise click.ClickException("No server configured. Use --server or set MAGPIE_SERVER.")
 
     try:
         parsed = parse_artifact_ref(artifact_ref)
     except ParseError as e:
+        if is_json_output():
+            output_error(ErrorCode.VALIDATION_ERROR, str(e))
         raise click.ClickException(str(e))
 
     with ctx.get_client() as client:
@@ -63,8 +77,16 @@ def get(
         info_response = client.get(f"/api/v1/artifacts/{parsed.path}/{parsed.ref}/info")
 
         if info_response.status_code == 404:
+            if is_json_output():
+                output_error(ErrorCode.NOT_FOUND, f"Artifact not found: {parsed.path}:{parsed.ref}")
             raise click.ClickException(f"Artifact not found: {parsed.path}:{parsed.ref}")
         if info_response.status_code != 200:
+            if is_json_output():
+                try:
+                    detail = info_response.json().get("detail", info_response.text)
+                except Exception:
+                    detail = info_response.text
+                output_error(http_status_to_error_code(info_response.status_code), detail)
             handle_http_error(info_response, "Metadata", ctx.token)
 
         info = info_response.json()
@@ -89,11 +111,30 @@ def get(
             # Use compute_hash for streaming hash computation (handles large files)
             local_hash = compute_hash(output)
             if local_hash == expected_hash and not force:
+                if is_json_output():
+                    output_result(
+                        CommandResult(
+                            data={
+                                "path": str(output.absolute()),
+                                "hash": expected_hash,
+                                "size": output.stat().st_size,
+                                "verified": True,
+                                "skipped": True,
+                            },
+                            human_output="",
+                        )
+                    )
+                    return
                 click.echo(f"File already exists with matching hash: {output}")
                 return
 
             # File exists but has different hash - require --force
             if not force:
+                if is_json_output():
+                    output_error(
+                        ErrorCode.CONFLICT,
+                        f"Output file already exists: {output}. Use --force to overwrite.",
+                    )
                 raise click.ClickException(
                     f"Output file already exists: {output}\n"
                     "Use --force to overwrite existing files."
@@ -112,14 +153,25 @@ def get(
         if ctx.debug:
             click.echo(f"Downloading from {download_url}...", err=True)
 
+        # Suppress progress output in JSON mode
+        quiet_mode = quiet or is_json_output()
+
         # Use streaming download with progress
         chunks: list[bytes] = []
         with client.stream("GET", download_url) as response:
             if response.status_code == 404:
+                if is_json_output():
+                    output_error(ErrorCode.NOT_FOUND, f"Artifact blob not found: {hash_ref}")
                 raise click.ClickException(f"Artifact blob not found: {hash_ref}")
             if response.status_code != 200:
                 # Read response body for error message
                 response.read()
+                if is_json_output():
+                    try:
+                        detail = response.json().get("detail", response.text)
+                    except Exception:
+                        detail = response.text
+                    output_error(http_status_to_error_code(response.status_code), detail)
                 handle_http_error(response, "Download", ctx.token)
 
             # Get content length from header if available (may be more accurate)
@@ -127,7 +179,10 @@ def get(
             if content_length:
                 file_size = int(content_length)
 
-            with transfer_progress("Downloading", file_size, quiet=quiet) as (progress, task_id):
+            with transfer_progress("Downloading", file_size, quiet=quiet_mode) as (
+                progress,
+                task_id,
+            ):
                 for chunk in response.iter_bytes():
                     chunks.append(chunk)
                     if progress is not None and task_id is not None:
@@ -136,16 +191,39 @@ def get(
         content = b"".join(chunks)
 
     # Verify hash unless --no-verify
+    verified = False
     if not no_verify:
         actual_hash = hashlib.sha256(content).hexdigest()
         if actual_hash != expected_hash:
+            if is_json_output():
+                output_error(
+                    ErrorCode.VALIDATION_ERROR,
+                    f"Hash mismatch! Expected {expected_hash}, got {actual_hash}.",
+                )
             raise click.ClickException(
                 f"Hash mismatch! Expected {expected_hash}, got {actual_hash}. "
                 "File may be corrupted. Use --no-verify to skip verification."
             )
+        verified = True
         if ctx.debug:
             click.echo("Hash verified.", err=True)
 
     # Write file
     output.write_bytes(content)
+
+    # Output result
+    if is_json_output():
+        output_result(
+            CommandResult(
+                data={
+                    "path": str(output.absolute()),
+                    "hash": expected_hash,
+                    "size": len(content),
+                    "verified": verified,
+                },
+                human_output="",
+            )
+        )
+        return
+
     click.echo(f"Downloaded: {output}")

--- a/src/magpie/cli/commands/info.py
+++ b/src/magpie/cli/commands/info.py
@@ -7,6 +7,14 @@ import click
 from magpie.cli import CLIContext
 from magpie.cli.commands.parse import ParseError, parse_artifact_ref
 from magpie.cli.errors import handle_http_error
+from magpie.cli.formatting import (
+    CommandResult,
+    ErrorCode,
+    http_status_to_error_code,
+    is_json_output,
+    output_error,
+    output_result,
+)
 
 
 @click.command()
@@ -27,11 +35,17 @@ def info(ctx: CLIContext, artifact_ref: str) -> None:
         magpie info builds/app
     """
     if not ctx.server:
+        if is_json_output():
+            output_error(
+                ErrorCode.CONFIG_ERROR, "No server configured. Use --server or set MAGPIE_SERVER."
+            )
         raise click.ClickException("No server configured. Use --server or set MAGPIE_SERVER.")
 
     try:
         parsed = parse_artifact_ref(artifact_ref)
     except ParseError as e:
+        if is_json_output():
+            output_error(ErrorCode.VALIDATION_ERROR, str(e))
         raise click.ClickException(str(e))
 
     with ctx.get_client() as client:
@@ -41,13 +55,40 @@ def info(ctx: CLIContext, artifact_ref: str) -> None:
         response = client.get(f"/api/v1/artifacts/{parsed.path}/{parsed.ref}/info")
 
         if response.status_code == 404:
+            if is_json_output():
+                output_error(ErrorCode.NOT_FOUND, f"Artifact not found: {parsed.path}:{parsed.ref}")
             raise click.ClickException(f"Artifact not found: {parsed.path}:{parsed.ref}")
         if response.status_code != 200:
+            if is_json_output():
+                try:
+                    detail = response.json().get("detail", response.text)
+                except Exception:
+                    detail = response.text
+                output_error(http_status_to_error_code(response.status_code), detail)
             handle_http_error(response, "Info", ctx.token)
 
         data = response.json()
 
-    # Display detailed metadata
+    # JSON output
+    if is_json_output():
+        output_result(
+            CommandResult(
+                data={
+                    "artifact": parsed.path,
+                    "version": data["hash_ref"],
+                    "hash": data["hash"],
+                    "size": data.get("size"),
+                    "tags": data.get("tags", []),
+                    "source_uri": data.get("source_uri"),
+                    "created": data.get("uploaded_at"),
+                    "uploaded_by": data.get("uploaded_by"),
+                },
+                human_output="",
+            )
+        )
+        return
+
+    # Human output
     click.echo(f"Hash:        {data['hash']}")
     click.echo(f"Hash Ref:    {data['hash_ref']}")
     click.echo(f"Uploaded By: {data.get('uploaded_by', 'unknown')}")

--- a/src/magpie/cli/commands/info.py
+++ b/src/magpie/cli/commands/info.py
@@ -35,18 +35,19 @@ def info(ctx: CLIContext, artifact_ref: str) -> None:
         magpie info builds/app
     """
     if not ctx.server:
+        msg = "No server configured. Use --server or set MAGPIE_SERVER."
         if is_json_output():
-            output_error(
-                ErrorCode.CONFIG_ERROR, "No server configured. Use --server or set MAGPIE_SERVER."
-            )
-        raise click.ClickException("No server configured. Use --server or set MAGPIE_SERVER.")
+            output_error(ErrorCode.CONFIG_ERROR, msg)
+        else:
+            raise click.ClickException(msg)
 
     try:
         parsed = parse_artifact_ref(artifact_ref)
     except ParseError as e:
         if is_json_output():
             output_error(ErrorCode.VALIDATION_ERROR, str(e))
-        raise click.ClickException(str(e))
+        else:
+            raise click.ClickException(str(e))
 
     with ctx.get_client() as client:
         if ctx.debug:
@@ -55,9 +56,11 @@ def info(ctx: CLIContext, artifact_ref: str) -> None:
         response = client.get(f"/api/v1/artifacts/{parsed.path}/{parsed.ref}/info")
 
         if response.status_code == 404:
+            msg = f"Artifact not found: {parsed.path}:{parsed.ref}"
             if is_json_output():
-                output_error(ErrorCode.NOT_FOUND, f"Artifact not found: {parsed.path}:{parsed.ref}")
-            raise click.ClickException(f"Artifact not found: {parsed.path}:{parsed.ref}")
+                output_error(ErrorCode.NOT_FOUND, msg)
+            else:
+                raise click.ClickException(msg)
         if response.status_code != 200:
             if is_json_output():
                 try:
@@ -65,7 +68,8 @@ def info(ctx: CLIContext, artifact_ref: str) -> None:
                 except Exception:
                     detail = response.text
                 output_error(http_status_to_error_code(response.status_code), detail)
-            handle_http_error(response, "Info", ctx.token)
+            else:
+                handle_http_error(response, "Info", ctx.token)
 
         data = response.json()
 

--- a/src/magpie/cli/commands/ls.py
+++ b/src/magpie/cli/commands/ls.py
@@ -12,6 +12,14 @@ if TYPE_CHECKING:
 from magpie.cli import CLIContext
 from magpie.cli.commands.parse import ParseError, parse_artifact_path
 from magpie.cli.errors import handle_http_error
+from magpie.cli.formatting import (
+    CommandResult,
+    ErrorCode,
+    http_status_to_error_code,
+    is_json_output,
+    output_error,
+    output_result,
+)
 
 
 @click.command(name="ls")
@@ -35,6 +43,10 @@ def ls(ctx: CLIContext, artifact_path: str | None) -> None:
         magpie ls /test/myartifact   # Leading slash is normalized
     """
     if not ctx.server:
+        if is_json_output():
+            output_error(
+                ErrorCode.CONFIG_ERROR, "No server configured. Use --server or set MAGPIE_SERVER."
+            )
         raise click.ClickException("No server configured. Use --server or set MAGPIE_SERVER.")
 
     with ctx.get_client() as client:
@@ -47,6 +59,8 @@ def ls(ctx: CLIContext, artifact_path: str | None) -> None:
         try:
             normalized_path = parse_artifact_path(artifact_path)
         except ParseError as e:
+            if is_json_output():
+                output_error(ErrorCode.VALIDATION_ERROR, str(e))
             raise click.ClickException(str(e))
 
         if ctx.debug:
@@ -60,7 +74,26 @@ def ls(ctx: CLIContext, artifact_path: str | None) -> None:
             versions = data.get("versions", [])
 
             if versions:
-                # Found versions - display them in table format
+                # Found versions - display them
+                if is_json_output():
+                    output_result(
+                        CommandResult(
+                            data={
+                                "artifact": normalized_path,
+                                "versions": [
+                                    {
+                                        "version": v["hash_ref"],
+                                        "hash": v.get("hash", ""),
+                                        "tags": v.get("tags", []),
+                                        "created": v.get("uploaded_at", ""),
+                                    }
+                                    for v in versions
+                                ],
+                            },
+                            human_output="",
+                        )
+                    )
+                    return
                 _display_versions_table(versions)
                 return
             # No versions but path exists - fall through to prefix listing
@@ -86,11 +119,31 @@ def _list_paths(ctx: CLIContext, client: "httpx.Client", prefix: str) -> None:
     response = client.get("/api/v1/artifacts", params={"prefix": prefix})
 
     if response.status_code != 200:
+        if is_json_output():
+            try:
+                detail = response.json().get("detail", response.text)
+            except Exception:
+                detail = response.text
+            output_error(http_status_to_error_code(response.status_code), detail)
         handle_http_error(response, "List", ctx.token)
 
     data = response.json()
     paths = data.get("paths", [])
 
+    # JSON output
+    if is_json_output():
+        output_result(
+            CommandResult(
+                data={
+                    "prefix": prefix,
+                    "paths": paths,
+                },
+                human_output="",
+            )
+        )
+        return
+
+    # Human output
     if not paths:
         if prefix:
             click.echo(f"No artifacts found matching: {prefix}")

--- a/src/magpie/cli/commands/ls.py
+++ b/src/magpie/cli/commands/ls.py
@@ -43,11 +43,11 @@ def ls(ctx: CLIContext, artifact_path: str | None) -> None:
         magpie ls /test/myartifact   # Leading slash is normalized
     """
     if not ctx.server:
+        msg = "No server configured. Use --server or set MAGPIE_SERVER."
         if is_json_output():
-            output_error(
-                ErrorCode.CONFIG_ERROR, "No server configured. Use --server or set MAGPIE_SERVER."
-            )
-        raise click.ClickException("No server configured. Use --server or set MAGPIE_SERVER.")
+            output_error(ErrorCode.CONFIG_ERROR, msg)
+        else:
+            raise click.ClickException(msg)
 
     with ctx.get_client() as client:
         # Case 1: No path provided - list all artifact paths
@@ -61,7 +61,8 @@ def ls(ctx: CLIContext, artifact_path: str | None) -> None:
         except ParseError as e:
             if is_json_output():
                 output_error(ErrorCode.VALIDATION_ERROR, str(e))
-            raise click.ClickException(str(e))
+            else:
+                raise click.ClickException(str(e))
 
         if ctx.debug:
             click.echo(f"Listing for path: {normalized_path}...", err=True)
@@ -125,7 +126,8 @@ def _list_paths(ctx: CLIContext, client: "httpx.Client", prefix: str) -> None:
             except Exception:
                 detail = response.text
             output_error(http_status_to_error_code(response.status_code), detail)
-        handle_http_error(response, "List", ctx.token)
+        else:
+            handle_http_error(response, "List", ctx.token)
 
     data = response.json()
     paths = data.get("paths", [])

--- a/src/magpie/cli/commands/push.py
+++ b/src/magpie/cli/commands/push.py
@@ -125,11 +125,11 @@ def push(
         magpie push build.zip --to builds/app --source-uri git://repo@v1.0
     """
     if not ctx.server:
+        msg = "No server configured. Use --server or set MAGPIE_SERVER."
         if is_json_output():
-            output_error(
-                ErrorCode.CONFIG_ERROR, "No server configured. Use --server or set MAGPIE_SERVER."
-            )
-        raise click.ClickException("No server configured. Use --server or set MAGPIE_SERVER.")
+            output_error(ErrorCode.CONFIG_ERROR, msg)
+        else:
+            raise click.ClickException(msg)
 
     # Normalize artifact path
     try:
@@ -137,7 +137,8 @@ def push(
     except InvalidArtifactPathError as e:
         if is_json_output():
             output_error(ErrorCode.VALIDATION_ERROR, str(e))
-        raise click.ClickException(str(e))
+        else:
+            raise click.ClickException(str(e))
 
     # Build query params
     params: dict[str, str] = {}
@@ -187,7 +188,8 @@ def push(
                     except Exception:
                         detail = response.text
                     output_error(http_status_to_error_code(response.status_code), detail)
-                handle_http_error(response, "Upload", ctx.token)
+                else:
+                    handle_http_error(response, "Upload", ctx.token)
 
             data = response.json()
 

--- a/src/magpie/cli/commands/push.py
+++ b/src/magpie/cli/commands/push.py
@@ -12,6 +12,14 @@ if TYPE_CHECKING:
 
 from magpie.cli import CLIContext
 from magpie.cli.errors import handle_http_error
+from magpie.cli.formatting import (
+    CommandResult,
+    ErrorCode,
+    http_status_to_error_code,
+    is_json_output,
+    output_error,
+    output_result,
+)
 from magpie.cli.progress import transfer_progress
 from magpie.storage.exceptions import InvalidArtifactPathError
 from magpie.storage.paths import normalize_artifact_path
@@ -117,12 +125,18 @@ def push(
         magpie push build.zip --to builds/app --source-uri git://repo@v1.0
     """
     if not ctx.server:
+        if is_json_output():
+            output_error(
+                ErrorCode.CONFIG_ERROR, "No server configured. Use --server or set MAGPIE_SERVER."
+            )
         raise click.ClickException("No server configured. Use --server or set MAGPIE_SERVER.")
 
     # Normalize artifact path
     try:
         artifact_path = normalize_artifact_path(artifact_path)
     except InvalidArtifactPathError as e:
+        if is_json_output():
+            output_error(ErrorCode.VALIDATION_ERROR, str(e))
         raise click.ClickException(str(e))
 
     # Build query params
@@ -137,8 +151,11 @@ def push(
     if ctx.debug:
         click.echo(f"Uploading {file} ({file_size} bytes) to {artifact_path}...", err=True)
 
+    # Suppress progress output in JSON mode
+    quiet_mode = quiet or is_json_output()
+
     # Upload file with progress
-    with transfer_progress("Uploading", file_size, quiet=quiet) as (progress, task_id):
+    with transfer_progress("Uploading", file_size, quiet=quiet_mode) as (progress, task_id):
         with ctx.get_client() as client:
             with file.open("rb") as f:
                 # Container for processing task ID (mutable to allow callback to store it)
@@ -164,11 +181,43 @@ def push(
                     progress.update(processing_task[0], visible=False)
 
             if response.status_code != 200:
+                if is_json_output():
+                    try:
+                        detail = response.json().get("detail", response.text)
+                    except Exception:
+                        detail = response.text
+                    output_error(http_status_to_error_code(response.status_code), detail)
                 handle_http_error(response, "Upload", ctx.token)
 
             data = response.json()
 
-    # Display results
+    # Determine download URL
+    if not no_latest:
+        download_url = f"{ctx.server}/artifacts/{artifact_path}/latest"
+        tags = ["latest"]
+    else:
+        download_url = f"{ctx.server}{data['download_url']}"
+        tags = []
+
+    # JSON output
+    if is_json_output():
+        output_result(
+            CommandResult(
+                data={
+                    "artifact": artifact_path,
+                    "version": data["hash_ref"],
+                    "hash": data["hash"],
+                    "size": file_size,
+                    "tags": tags,
+                    "url": download_url,
+                    "is_duplicate": data.get("is_duplicate", False),
+                },
+                human_output="",  # Not used for JSON
+            )
+        )
+        return
+
+    # Human output
     if data.get("is_duplicate"):
         click.echo(f"Duplicate: {data['hash']}")
     else:
@@ -178,10 +227,10 @@ def push(
     if not no_latest:
         click.echo("Tagged:   latest")
         # Use /latest in download URL instead of hash ref
-        download_url = f"/artifacts/{artifact_path}/latest"
+        display_download_url = f"/artifacts/{artifact_path}/latest"
     else:
-        download_url = data["download_url"]
-    click.echo(f"Download: {ctx.server}{download_url}")
+        display_download_url = data["download_url"]
+    click.echo(f"Download: {ctx.server}{display_download_url}")
 
     if not source_uri:
         click.echo()

--- a/src/magpie/cli/commands/tag.py
+++ b/src/magpie/cli/commands/tag.py
@@ -7,6 +7,14 @@ import click
 from magpie.cli import CLIContext
 from magpie.cli.commands.parse import ParseError, parse_artifact_ref
 from magpie.cli.errors import handle_http_error
+from magpie.cli.formatting import (
+    CommandResult,
+    ErrorCode,
+    http_status_to_error_code,
+    is_json_output,
+    output_error,
+    output_result,
+)
 
 
 @click.command()
@@ -28,11 +36,17 @@ def tag(ctx: CLIContext, artifact_ref: str, tag_name: str) -> None:
         magpie tag builds/app --as release-1.0
     """
     if not ctx.server:
+        if is_json_output():
+            output_error(
+                ErrorCode.CONFIG_ERROR, "No server configured. Use --server or set MAGPIE_SERVER."
+            )
         raise click.ClickException("No server configured. Use --server or set MAGPIE_SERVER.")
 
     try:
         parsed = parse_artifact_ref(artifact_ref)
     except ParseError as e:
+        if is_json_output():
+            output_error(ErrorCode.VALIDATION_ERROR, str(e))
         raise click.ClickException(str(e))
 
     with ctx.get_client() as client:
@@ -45,11 +59,34 @@ def tag(ctx: CLIContext, artifact_ref: str, tag_name: str) -> None:
         )
 
         if response.status_code == 404:
+            if is_json_output():
+                output_error(ErrorCode.NOT_FOUND, f"Artifact not found: {parsed.path}:{parsed.ref}")
             raise click.ClickException(f"Artifact not found: {parsed.path}:{parsed.ref}")
         if response.status_code != 200:
+            if is_json_output():
+                try:
+                    detail = response.json().get("detail", response.text)
+                except Exception:
+                    detail = response.text
+                output_error(http_status_to_error_code(response.status_code), detail)
             handle_http_error(response, "Tag", ctx.token)
 
         data = response.json()
 
+    # JSON output
+    if is_json_output():
+        output_result(
+            CommandResult(
+                data={
+                    "artifact": parsed.path,
+                    "version": data["hash_ref"],
+                    "tag": tag_name,
+                },
+                human_output="",
+            )
+        )
+        return
+
+    # Human output
     click.echo(f"Tagged {data['hash_ref']} as '{tag_name}'")
     click.echo(f"All tags: {', '.join(data.get('tags', []))}")

--- a/src/magpie/cli/commands/tag.py
+++ b/src/magpie/cli/commands/tag.py
@@ -36,18 +36,19 @@ def tag(ctx: CLIContext, artifact_ref: str, tag_name: str) -> None:
         magpie tag builds/app --as release-1.0
     """
     if not ctx.server:
+        msg = "No server configured. Use --server or set MAGPIE_SERVER."
         if is_json_output():
-            output_error(
-                ErrorCode.CONFIG_ERROR, "No server configured. Use --server or set MAGPIE_SERVER."
-            )
-        raise click.ClickException("No server configured. Use --server or set MAGPIE_SERVER.")
+            output_error(ErrorCode.CONFIG_ERROR, msg)
+        else:
+            raise click.ClickException(msg)
 
     try:
         parsed = parse_artifact_ref(artifact_ref)
     except ParseError as e:
         if is_json_output():
             output_error(ErrorCode.VALIDATION_ERROR, str(e))
-        raise click.ClickException(str(e))
+        else:
+            raise click.ClickException(str(e))
 
     with ctx.get_client() as client:
         if ctx.debug:
@@ -59,9 +60,11 @@ def tag(ctx: CLIContext, artifact_ref: str, tag_name: str) -> None:
         )
 
         if response.status_code == 404:
+            msg = f"Artifact not found: {parsed.path}:{parsed.ref}"
             if is_json_output():
-                output_error(ErrorCode.NOT_FOUND, f"Artifact not found: {parsed.path}:{parsed.ref}")
-            raise click.ClickException(f"Artifact not found: {parsed.path}:{parsed.ref}")
+                output_error(ErrorCode.NOT_FOUND, msg)
+            else:
+                raise click.ClickException(msg)
         if response.status_code != 200:
             if is_json_output():
                 try:
@@ -69,7 +72,8 @@ def tag(ctx: CLIContext, artifact_ref: str, tag_name: str) -> None:
                 except Exception:
                     detail = response.text
                 output_error(http_status_to_error_code(response.status_code), detail)
-            handle_http_error(response, "Tag", ctx.token)
+            else:
+                handle_http_error(response, "Tag", ctx.token)
 
         data = response.json()
 

--- a/src/magpie/cli/commands/untag.py
+++ b/src/magpie/cli/commands/untag.py
@@ -36,11 +36,11 @@ def untag(ctx: CLIContext, artifact_path: str, tag_name: str) -> None:
         magpie untag builds/app old-release
     """
     if not ctx.server:
+        msg = "No server configured. Use --server or set MAGPIE_SERVER."
         if is_json_output():
-            output_error(
-                ErrorCode.CONFIG_ERROR, "No server configured. Use --server or set MAGPIE_SERVER."
-            )
-        raise click.ClickException("No server configured. Use --server or set MAGPIE_SERVER.")
+            output_error(ErrorCode.CONFIG_ERROR, msg)
+        else:
+            raise click.ClickException(msg)
 
     # Normalize artifact path
     try:
@@ -48,7 +48,8 @@ def untag(ctx: CLIContext, artifact_path: str, tag_name: str) -> None:
     except InvalidArtifactPathError as e:
         if is_json_output():
             output_error(ErrorCode.VALIDATION_ERROR, str(e))
-        raise click.ClickException(str(e))
+        else:
+            raise click.ClickException(str(e))
 
     with ctx.get_client() as client:
         if ctx.debug:
@@ -59,9 +60,11 @@ def untag(ctx: CLIContext, artifact_path: str, tag_name: str) -> None:
         )
 
         if response.status_code == 404:
+            msg = f"Tag not found: {artifact_path}:{tag_name}"
             if is_json_output():
-                output_error(ErrorCode.NOT_FOUND, f"Tag not found: {artifact_path}:{tag_name}")
-            raise click.ClickException(f"Tag not found: {artifact_path}:{tag_name}")
+                output_error(ErrorCode.NOT_FOUND, msg)
+            else:
+                raise click.ClickException(msg)
         if response.status_code != 204:
             if is_json_output():
                 try:
@@ -69,7 +72,8 @@ def untag(ctx: CLIContext, artifact_path: str, tag_name: str) -> None:
                 except Exception:
                     detail = response.text
                 output_error(http_status_to_error_code(response.status_code), detail)
-            handle_http_error(response, "Untag", ctx.token)
+            else:
+                handle_http_error(response, "Untag", ctx.token)
 
     # JSON output
     if is_json_output():

--- a/src/magpie/cli/commands/untag.py
+++ b/src/magpie/cli/commands/untag.py
@@ -6,6 +6,14 @@ import click
 
 from magpie.cli import CLIContext
 from magpie.cli.errors import handle_http_error
+from magpie.cli.formatting import (
+    CommandResult,
+    ErrorCode,
+    http_status_to_error_code,
+    is_json_output,
+    output_error,
+    output_result,
+)
 from magpie.storage.exceptions import InvalidArtifactPathError
 from magpie.storage.paths import normalize_artifact_path
 
@@ -28,12 +36,18 @@ def untag(ctx: CLIContext, artifact_path: str, tag_name: str) -> None:
         magpie untag builds/app old-release
     """
     if not ctx.server:
+        if is_json_output():
+            output_error(
+                ErrorCode.CONFIG_ERROR, "No server configured. Use --server or set MAGPIE_SERVER."
+            )
         raise click.ClickException("No server configured. Use --server or set MAGPIE_SERVER.")
 
     # Normalize artifact path
     try:
         artifact_path = normalize_artifact_path(artifact_path)
     except InvalidArtifactPathError as e:
+        if is_json_output():
+            output_error(ErrorCode.VALIDATION_ERROR, str(e))
         raise click.ClickException(str(e))
 
     with ctx.get_client() as client:
@@ -45,8 +59,31 @@ def untag(ctx: CLIContext, artifact_path: str, tag_name: str) -> None:
         )
 
         if response.status_code == 404:
+            if is_json_output():
+                output_error(ErrorCode.NOT_FOUND, f"Tag not found: {artifact_path}:{tag_name}")
             raise click.ClickException(f"Tag not found: {artifact_path}:{tag_name}")
         if response.status_code != 204:
+            if is_json_output():
+                try:
+                    detail = response.json().get("detail", response.text)
+                except Exception:
+                    detail = response.text
+                output_error(http_status_to_error_code(response.status_code), detail)
             handle_http_error(response, "Untag", ctx.token)
 
+    # JSON output
+    if is_json_output():
+        output_result(
+            CommandResult(
+                data={
+                    "artifact": artifact_path,
+                    "tag": tag_name,
+                    "removed": True,
+                },
+                human_output="",
+            )
+        )
+        return
+
+    # Human output
     click.echo(f"Removed tag '{tag_name}' from {artifact_path}")

--- a/src/magpie/cli/commands/url.py
+++ b/src/magpie/cli/commands/url.py
@@ -37,18 +37,19 @@ def url(ctx: CLIContext, artifact_ref: str) -> None:
         wget $(magpie url builds/app:v1.0)
     """
     if not ctx.server:
+        msg = "No server configured. Use --server or set MAGPIE_SERVER."
         if is_json_output():
-            output_error(
-                ErrorCode.CONFIG_ERROR, "No server configured. Use --server or set MAGPIE_SERVER."
-            )
-        raise click.ClickException("No server configured. Use --server or set MAGPIE_SERVER.")
+            output_error(ErrorCode.CONFIG_ERROR, msg)
+        else:
+            raise click.ClickException(msg)
 
     try:
         parsed = parse_artifact_ref(artifact_ref)
     except ParseError as e:
         if is_json_output():
             output_error(ErrorCode.VALIDATION_ERROR, str(e))
-        raise click.ClickException(str(e))
+        else:
+            raise click.ClickException(str(e))
 
     with ctx.get_client() as client:
         if ctx.debug:
@@ -58,9 +59,11 @@ def url(ctx: CLIContext, artifact_ref: str) -> None:
         response = client.get(f"/api/v1/artifacts/{parsed.path}/{parsed.ref}/info")
 
         if response.status_code == 404:
+            msg = f"Artifact not found: {parsed.path}:{parsed.ref}"
             if is_json_output():
-                output_error(ErrorCode.NOT_FOUND, f"Artifact not found: {parsed.path}:{parsed.ref}")
-            raise click.ClickException(f"Artifact not found: {parsed.path}:{parsed.ref}")
+                output_error(ErrorCode.NOT_FOUND, msg)
+            else:
+                raise click.ClickException(msg)
         if response.status_code != 200:
             if is_json_output():
                 try:
@@ -68,7 +71,8 @@ def url(ctx: CLIContext, artifact_ref: str) -> None:
                 except Exception:
                     detail = response.text
                 output_error(http_status_to_error_code(response.status_code), detail)
-            handle_http_error(response, "URL resolution")
+            else:
+                handle_http_error(response, "URL resolution")
 
         data = response.json()
         hash_ref = data["hash_ref"]

--- a/src/magpie/cli/commands/url.py
+++ b/src/magpie/cli/commands/url.py
@@ -7,6 +7,14 @@ import click
 from magpie.cli import CLIContext
 from magpie.cli.commands.parse import ParseError, parse_artifact_ref
 from magpie.cli.errors import handle_http_error
+from magpie.cli.formatting import (
+    CommandResult,
+    ErrorCode,
+    http_status_to_error_code,
+    is_json_output,
+    output_error,
+    output_result,
+)
 
 
 @click.command()
@@ -29,11 +37,17 @@ def url(ctx: CLIContext, artifact_ref: str) -> None:
         wget $(magpie url builds/app:v1.0)
     """
     if not ctx.server:
+        if is_json_output():
+            output_error(
+                ErrorCode.CONFIG_ERROR, "No server configured. Use --server or set MAGPIE_SERVER."
+            )
         raise click.ClickException("No server configured. Use --server or set MAGPIE_SERVER.")
 
     try:
         parsed = parse_artifact_ref(artifact_ref)
     except ParseError as e:
+        if is_json_output():
+            output_error(ErrorCode.VALIDATION_ERROR, str(e))
         raise click.ClickException(str(e))
 
     with ctx.get_client() as client:
@@ -44,15 +58,22 @@ def url(ctx: CLIContext, artifact_ref: str) -> None:
         response = client.get(f"/api/v1/artifacts/{parsed.path}/{parsed.ref}/info")
 
         if response.status_code == 404:
+            if is_json_output():
+                output_error(ErrorCode.NOT_FOUND, f"Artifact not found: {parsed.path}:{parsed.ref}")
             raise click.ClickException(f"Artifact not found: {parsed.path}:{parsed.ref}")
         if response.status_code != 200:
+            if is_json_output():
+                try:
+                    detail = response.json().get("detail", response.text)
+                except Exception:
+                    detail = response.text
+                output_error(http_status_to_error_code(response.status_code), detail)
             handle_http_error(response, "URL resolution")
 
         data = response.json()
         hash_ref = data["hash_ref"]
 
-    # Output bare URL (no newline issues - click.echo adds one)
-    # Hash refs use blobs/ subdirectory, tags are symlinks at root
+    # Build URL - Hash refs use blobs/ subdirectory, tags are symlinks at root
     if parsed.ref.startswith("@"):
         # User requested hash directly - use blobs path
         blob_name = hash_ref.lstrip("@")
@@ -60,4 +81,16 @@ def url(ctx: CLIContext, artifact_ref: str) -> None:
     else:
         # User requested tag - use tag symlink path
         download_url = f"{ctx.server}/artifacts/{parsed.path}/{parsed.ref}"
+
+    # JSON output
+    if is_json_output():
+        output_result(
+            CommandResult(
+                data={"url": download_url},
+                human_output="",
+            )
+        )
+        return
+
+    # Human output - bare URL for scripting
     click.echo(download_url)

--- a/src/magpie/cli/formatting.py
+++ b/src/magpie/cli/formatting.py
@@ -1,0 +1,224 @@
+"""CLI output formatting utilities for JSON and human-readable output.
+
+This module provides a unified output formatting system that supports multiple
+output formats (human-readable, JSON) across all CLI commands.
+
+Usage:
+    from magpie.cli.formatting import format_option, output_result, output_error, CommandResult
+
+    @cli.command()
+    @format_option
+    def my_command():
+        try:
+            # Do work...
+            output_result(CommandResult(
+                data={"key": "value"},
+                human_output="Human readable output"
+            ))
+        except SomeError as e:
+            output_error("ERROR_CODE", str(e))
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+from functools import wraps
+from typing import TYPE_CHECKING, Any, Callable, TypeVar
+
+import click
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+F = TypeVar("F", bound=Callable[..., object])
+
+
+class OutputFormat(str, Enum):
+    """Supported output formats."""
+
+    HUMAN = "human"
+    JSON = "json"
+    # Future: TABLE = "table", XML = "xml"
+
+
+def format_option(func: F) -> F:
+    """Decorator that adds --format option to a command.
+
+    Stores the selected format in the Click context for use by output_result
+    and output_error.
+
+    Usage:
+        @cli.command()
+        @format_option
+        def my_command():
+            ...
+    """
+
+    @click.option(
+        "--format",
+        "output_format",
+        type=click.Choice([f.value for f in OutputFormat], case_sensitive=False),
+        default=OutputFormat.HUMAN.value,
+        help="Output format (default: human)",
+    )
+    @wraps(func)
+    def wrapper(*args: object, output_format: str, **kwargs: object) -> object:
+        ctx = click.get_current_context()
+        ctx.ensure_object(dict)
+        ctx.obj["output_format"] = OutputFormat(output_format)
+        return func(*args, **kwargs)
+
+    return wrapper  # type: ignore[return-value]
+
+
+def get_output_format() -> OutputFormat:
+    """Get the current output format from Click context.
+
+    Looks for output_format attribute on the context object (CLIContext or CTLContext).
+
+    Returns:
+        The current output format, defaulting to HUMAN if not set.
+    """
+    ctx = click.get_current_context(silent=True)
+    if ctx is None or ctx.obj is None:
+        return OutputFormat.HUMAN
+
+    # Check if ctx.obj has output_format attribute (CLIContext or CTLContext)
+    if hasattr(ctx.obj, "output_format"):
+        return ctx.obj.output_format
+
+    # Fall back to dict-style access for format_option decorator usage
+    if isinstance(ctx.obj, dict):
+        return ctx.obj.get("output_format", OutputFormat.HUMAN)
+
+    return OutputFormat.HUMAN
+
+
+def is_json_output() -> bool:
+    """Check if JSON output format is currently active.
+
+    Returns:
+        True if JSON output is enabled, False otherwise.
+    """
+    return get_output_format() == OutputFormat.JSON
+
+
+@dataclass
+class CommandResult:
+    """Standardized command result container.
+
+    Attributes:
+        data: Structured data for JSON output. Should be JSON-serializable.
+        human_output: Pre-formatted human-readable string for terminal display.
+    """
+
+    data: Any
+    human_output: str
+
+
+def _json_serializer(obj: object) -> str:
+    """Custom JSON serializer for non-standard types.
+
+    Args:
+        obj: Object to serialize.
+
+    Returns:
+        String representation of the object.
+
+    Raises:
+        TypeError: If object is not serializable.
+    """
+    if isinstance(obj, datetime):
+        return obj.isoformat()
+    if hasattr(obj, "__dict__"):
+        return str(obj)
+    raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")
+
+
+def output_result(result: CommandResult) -> None:
+    """Output command result in the appropriate format.
+
+    For JSON format, wraps data in the standard envelope:
+        {"status": "ok", "data": ...}
+
+    For human format, outputs the pre-formatted string directly.
+
+    Args:
+        result: CommandResult containing both structured data and human output.
+    """
+    output_format = get_output_format()
+
+    if output_format == OutputFormat.JSON:
+        envelope = {"status": "ok", "data": result.data}
+        click.echo(json.dumps(envelope, indent=2, default=_json_serializer))
+    else:
+        click.echo(result.human_output)
+
+
+def output_error(code: str, message: str, exit_code: int = 1) -> None:
+    """Output error in the appropriate format and exit.
+
+    For JSON format, outputs to stderr:
+        {"status": "error", "error": {"code": "...", "message": "..."}}
+
+    For human format, outputs "Error: {message}" to stderr.
+
+    Args:
+        code: Error code (e.g., "NOT_FOUND", "UNAUTHORIZED").
+        message: Human-readable error message.
+        exit_code: Exit code to use (default: 1).
+
+    Note:
+        This function always exits the program.
+    """
+    output_format = get_output_format()
+
+    if output_format == OutputFormat.JSON:
+        envelope = {"status": "error", "error": {"code": code, "message": message}}
+        click.echo(json.dumps(envelope, indent=2), err=True)
+    else:
+        click.echo(f"Error: {message}", err=True)
+
+    sys.exit(exit_code)
+
+
+# Standard error codes for consistency across commands
+class ErrorCode:
+    """Standard error codes for JSON output."""
+
+    NOT_FOUND = "NOT_FOUND"
+    UNAUTHORIZED = "UNAUTHORIZED"
+    FORBIDDEN = "FORBIDDEN"
+    CONFLICT = "CONFLICT"
+    VALIDATION_ERROR = "VALIDATION_ERROR"
+    SERVER_ERROR = "SERVER_ERROR"
+    NETWORK_ERROR = "NETWORK_ERROR"
+    IO_ERROR = "IO_ERROR"
+    CONFIG_ERROR = "CONFIG_ERROR"
+
+
+def http_status_to_error_code(status_code: int) -> str:
+    """Map HTTP status code to standard error code.
+
+    Args:
+        status_code: HTTP response status code.
+
+    Returns:
+        Corresponding error code string.
+    """
+    mapping: Mapping[int, str] = {
+        400: ErrorCode.VALIDATION_ERROR,
+        401: ErrorCode.UNAUTHORIZED,
+        403: ErrorCode.FORBIDDEN,
+        404: ErrorCode.NOT_FOUND,
+        409: ErrorCode.CONFLICT,
+    }
+    if status_code in mapping:
+        return mapping[status_code]
+    if status_code >= 500:
+        return ErrorCode.SERVER_ERROR
+    return ErrorCode.VALIDATION_ERROR

--- a/src/magpie/ctl/__init__.py
+++ b/src/magpie/ctl/__init__.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 
 import click
 
+from magpie.cli.formatting import OutputFormat
 from magpie.config import get_settings
 
 if TYPE_CHECKING:
@@ -19,8 +20,13 @@ if TYPE_CHECKING:
 class CTLContext:
     """Context object passed to ctl commands."""
 
-    def __init__(self, debug: bool = False) -> None:
+    def __init__(
+        self,
+        debug: bool = False,
+        output_format: OutputFormat = OutputFormat.HUMAN,
+    ) -> None:
         self.debug = debug
+        self.output_format = output_format
         self._settings: "MagpieSettings | None" = None
 
     @property
@@ -41,15 +47,24 @@ pass_context = click.make_pass_decorator(CTLContext)
     default=False,
     help="Enable debug output.",
 )
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice([f.value for f in OutputFormat], case_sensitive=False),
+    default=OutputFormat.HUMAN.value,
+    help="Output format (default: human).",
+)
 @click.pass_context
-def cli(ctx: click.Context, debug: bool) -> None:
+def cli(ctx: click.Context, debug: bool, output_format: str) -> None:
     """Magpie server administration."""
-    ctx.obj = CTLContext(debug=debug)
+    resolved_format = OutputFormat(output_format)
+    ctx.obj = CTLContext(debug=debug, output_format=resolved_format)
 
     if debug:
         settings = get_settings()
         click.echo(f"Storage path: {settings.storage_path}", err=True)
         click.echo(f"Database path: {settings.database_path}", err=True)
+        click.echo(f"Format: {resolved_format.value}", err=True)
 
 
 @cli.command()

--- a/src/magpie/ctl/commands/gc.py
+++ b/src/magpie/ctl/commands/gc.py
@@ -6,6 +6,13 @@ from pathlib import Path
 
 import click
 
+from magpie.cli.formatting import (
+    CommandResult,
+    ErrorCode,
+    is_json_output,
+    output_error,
+    output_result,
+)
 from magpie.cli.progress import count_progress
 from magpie.ctl import CTLContext
 from magpie.storage.gc import BlobToDelete, GCResult, format_size, run_gc
@@ -77,11 +84,16 @@ def gc(
     )
 
     if not storage_path.exists():
+        if is_json_output():
+            output_error(ErrorCode.IO_ERROR, f"Storage path does not exist: {storage_path}")
         raise click.ClickException(f"Storage path does not exist: {storage_path}")
 
     if ctx.debug:
         click.echo(f"Storage path: {storage_path}", err=True)
         click.echo(f"Retention days: {retention_days}", err=True)
+
+    # Suppress progress output in JSON mode
+    quiet_mode = quiet or is_json_output()
 
     # Run GC with progress display using a two-phase approach
     # Phase 1: Scan (with progress bar)
@@ -91,11 +103,31 @@ def gc(
         retention_days=retention_days,
         dry_run=dry_run,
         reconcile_only=reconcile_only,
-        quiet=quiet,
+        quiet=quiet_mode,
         debug=ctx.debug,
     )
 
-    # Print dry-run deletion preview
+    # JSON output
+    if is_json_output():
+        output_result(
+            CommandResult(
+                data={
+                    "dry_run": dry_run,
+                    "blobs_removed": result.blobs_deleted,
+                    "bytes_reclaimed": result.space_reclaimed_bytes,
+                    "errors": [],  # Collect errors if any
+                    "artifacts_scanned": result.artifacts_scanned,
+                    "blobs_found": result.blobs_found,
+                    "symlinks_checked": result.symlinks_checked,
+                    "symlinks_fixed": result.symlinks_fixed,
+                    "items_removed": result.items_removed,
+                },
+                human_output="",
+            )
+        )
+        return
+
+    # Human output - Print dry-run deletion preview
     if dry_run and not reconcile_only and blobs_to_delete:
         for blob in blobs_to_delete:
             click.echo(

--- a/src/magpie/ctl/commands/gc.py
+++ b/src/magpie/ctl/commands/gc.py
@@ -84,9 +84,11 @@ def gc(
     )
 
     if not storage_path.exists():
+        msg = f"Storage path does not exist: {storage_path}"
         if is_json_output():
-            output_error(ErrorCode.IO_ERROR, f"Storage path does not exist: {storage_path}")
-        raise click.ClickException(f"Storage path does not exist: {storage_path}")
+            output_error(ErrorCode.IO_ERROR, msg)
+        else:
+            raise click.ClickException(msg)
 
     if ctx.debug:
         click.echo(f"Storage path: {storage_path}", err=True)

--- a/src/magpie/ctl/commands/init.py
+++ b/src/magpie/ctl/commands/init.py
@@ -7,6 +7,11 @@ import click
 from magpie.auth.database import init_database
 from magpie.auth.models import TokenScope
 from magpie.auth.service import TokenService
+from magpie.cli.formatting import (
+    CommandResult,
+    is_json_output,
+    output_result,
+)
 from magpie.ctl import CTLContext
 
 ADMIN_TOKEN_NAME = "admin"  # nosec B105 - not a password, just a token name
@@ -48,44 +53,65 @@ def init(ctx: CTLContext, reset_admin_token: bool) -> None:
         click.echo(f"Creating temp directory: {settings.temp_path}", err=True)
     settings.temp_path.mkdir(parents=True, exist_ok=True)
 
-    click.echo(f"Storage initialized at: {settings.storage_path}")
+    if not is_json_output():
+        click.echo(f"Storage initialized at: {settings.storage_path}")
 
     # Initialize database
     if ctx.debug:
         click.echo(f"Initializing database: {settings.database_path}", err=True)
     init_database(settings.database_path)
-    click.echo(f"Database initialized at: {settings.database_path}")
+    if not is_json_output():
+        click.echo(f"Database initialized at: {settings.database_path}")
 
     # Create or reset admin token
     token_service = TokenService(settings)
+    plaintext_token: str | None = None
+    token_already_exists = False
 
     if reset_admin_token:
         # Revoke existing admin token first
         if ctx.debug:
             click.echo(f"Revoking existing admin token: {ADMIN_TOKEN_NAME}", err=True)
         revoked = token_service.revoke_token(ADMIN_TOKEN_NAME)
-        if revoked:
+        if revoked and not is_json_output():
             click.echo(f"Revoked existing admin token: {ADMIN_TOKEN_NAME}")
-        else:
+        elif not revoked and not is_json_output():
             click.echo("No existing admin token found to revoke")
 
         # Create new admin token
         plaintext_token = token_service.create_token(ADMIN_TOKEN_NAME, TokenScope.ADMIN)
-        click.echo("")
-        click.echo("=" * 60)
-        click.echo("NEW ADMIN TOKEN (store securely, only shown once!):")
-        click.echo(plaintext_token)
-        click.echo("=" * 60)
+        if not is_json_output():
+            click.echo("")
+            click.echo("=" * 60)
+            click.echo("NEW ADMIN TOKEN (store securely, only shown once!):")
+            click.echo(plaintext_token)
+            click.echo("=" * 60)
     else:
         # Try to create admin token (may fail if already exists)
         try:
             plaintext_token = token_service.create_token(ADMIN_TOKEN_NAME, TokenScope.ADMIN)
-            click.echo("")
-            click.echo("=" * 60)
-            click.echo("ADMIN TOKEN (store securely, only shown once!):")
-            click.echo(plaintext_token)
-            click.echo("=" * 60)
+            if not is_json_output():
+                click.echo("")
+                click.echo("=" * 60)
+                click.echo("ADMIN TOKEN (store securely, only shown once!):")
+                click.echo(plaintext_token)
+                click.echo("=" * 60)
         except ValueError:
             # Token already exists
-            click.echo("")
-            click.echo("Admin token already exists. Use --reset-admin-token to regenerate.")
+            token_already_exists = True
+            if not is_json_output():
+                click.echo("")
+                click.echo("Admin token already exists. Use --reset-admin-token to regenerate.")
+
+    # JSON output
+    if is_json_output():
+        output_result(
+            CommandResult(
+                data={
+                    "admin_token": plaintext_token,
+                    "storage_path": str(settings.storage_path),
+                    "token_already_existed": token_already_exists,
+                },
+                human_output="",
+            )
+        )

--- a/src/magpie/ctl/commands/token.py
+++ b/src/magpie/ctl/commands/token.py
@@ -61,7 +61,8 @@ def token_create(ctx: CTLContext, name: str, scope: str) -> None:
     except ValueError as e:
         if is_json_output():
             output_error(ErrorCode.CONFLICT, str(e))
-        raise click.ClickException(str(e))
+        else:
+            raise click.ClickException(str(e))
 
     # JSON output
     if is_json_output():
@@ -191,6 +192,8 @@ def token_revoke(ctx: CTLContext, name: str) -> None:
         # Human output
         click.echo(f"Token '{name}' has been revoked.")
     else:
+        msg = f"Token not found: {name}"
         if is_json_output():
-            output_error(ErrorCode.NOT_FOUND, f"Token not found: {name}")
-        raise click.ClickException(f"Token not found: {name}")
+            output_error(ErrorCode.NOT_FOUND, msg)
+        else:
+            raise click.ClickException(msg)

--- a/src/magpie/ctl/commands/token.py
+++ b/src/magpie/ctl/commands/token.py
@@ -7,6 +7,13 @@ import click
 from magpie.auth.database import get_connection, list_tokens
 from magpie.auth.models import TokenScope
 from magpie.auth.service import TokenService
+from magpie.cli.formatting import (
+    CommandResult,
+    ErrorCode,
+    is_json_output,
+    output_error,
+    output_result,
+)
 from magpie.ctl import CTLContext
 
 
@@ -52,8 +59,25 @@ def token_create(ctx: CTLContext, name: str, scope: str) -> None:
     try:
         plaintext_token = token_service.create_token(name, token_scope)
     except ValueError as e:
+        if is_json_output():
+            output_error(ErrorCode.CONFLICT, str(e))
         raise click.ClickException(str(e))
 
+    # JSON output
+    if is_json_output():
+        output_result(
+            CommandResult(
+                data={
+                    "token": plaintext_token,
+                    "name": name,
+                    "scope": scope.lower(),
+                },
+                human_output="",
+            )
+        )
+        return
+
+    # Human output
     click.echo("")
     click.echo("=" * 60)
     click.echo(f"TOKEN CREATED: {name} (scope: {scope})")
@@ -86,6 +110,27 @@ def token_list(ctx: CTLContext) -> None:
     finally:
         conn.close()
 
+    # JSON output
+    if is_json_output():
+        output_result(
+            CommandResult(
+                data={
+                    "tokens": [
+                        {
+                            "name": tok.name,
+                            "scope": tok.scope.value,
+                            "created": tok.created_at.isoformat(),
+                            "enabled": tok.enabled,
+                        }
+                        for tok in tokens
+                    ],
+                },
+                human_output="",
+            )
+        )
+        return
+
+    # Human output
     if not tokens:
         click.echo("No tokens found.")
         return
@@ -131,6 +176,21 @@ def token_revoke(ctx: CTLContext, name: str) -> None:
     revoked = token_service.revoke_token(name)
 
     if revoked:
+        # JSON output
+        if is_json_output():
+            output_result(
+                CommandResult(
+                    data={
+                        "name": name,
+                        "revoked": True,
+                    },
+                    human_output="",
+                )
+            )
+            return
+        # Human output
         click.echo(f"Token '{name}' has been revoked.")
     else:
+        if is_json_output():
+            output_error(ErrorCode.NOT_FOUND, f"Token not found: {name}")
         raise click.ClickException(f"Token not found: {name}")

--- a/tests/unit/test_cli_formatting.py
+++ b/tests/unit/test_cli_formatting.py
@@ -1,0 +1,405 @@
+"""Unit tests for CLI formatting module."""
+
+from __future__ import annotations
+
+import json
+
+import click
+from click.testing import CliRunner
+
+from magpie.cli.formatting import (
+    CommandResult,
+    ErrorCode,
+    OutputFormat,
+    format_option,
+    get_output_format,
+    http_status_to_error_code,
+    is_json_output,
+    output_error,
+    output_result,
+)
+
+
+class TestOutputFormat:
+    """Tests for OutputFormat enum."""
+
+    def test_output_format_values(self) -> None:
+        """Test enum values are strings."""
+        assert OutputFormat.HUMAN.value == "human"
+        assert OutputFormat.JSON.value == "json"
+
+    def test_output_format_str_subclass(self) -> None:
+        """Test OutputFormat is a string enum."""
+        assert isinstance(OutputFormat.HUMAN, str)
+        assert OutputFormat.HUMAN == "human"
+
+
+class TestCommandResult:
+    """Tests for CommandResult dataclass."""
+
+    def test_command_result_creation(self) -> None:
+        """Test basic CommandResult creation."""
+        result = CommandResult(
+            data={"key": "value"},
+            human_output="Human readable text",
+        )
+        assert result.data == {"key": "value"}
+        assert result.human_output == "Human readable text"
+
+    def test_command_result_with_list_data(self) -> None:
+        """Test CommandResult with list data."""
+        result = CommandResult(
+            data={"items": [1, 2, 3]},
+            human_output="Items: 1, 2, 3",
+        )
+        assert result.data["items"] == [1, 2, 3]
+
+    def test_command_result_with_nested_data(self) -> None:
+        """Test CommandResult with nested data structures."""
+        result = CommandResult(
+            data={
+                "artifact": "test/path",
+                "versions": [
+                    {"version": "@abc123", "tags": ["latest"]},
+                    {"version": "@def456", "tags": ["stable"]},
+                ],
+            },
+            human_output="test output",
+        )
+        assert len(result.data["versions"]) == 2
+        assert result.data["versions"][0]["tags"] == ["latest"]
+
+
+class TestFormatOption:
+    """Tests for format_option decorator."""
+
+    def test_format_option_adds_option(self) -> None:
+        """Test that format_option decorator adds --format option."""
+
+        @click.command()
+        @format_option
+        def test_cmd() -> None:
+            pass
+
+        runner = CliRunner()
+        result = runner.invoke(test_cmd, ["--help"])
+        assert "--format" in result.output
+        assert "human" in result.output
+        assert "json" in result.output
+
+    def test_format_option_default_human(self) -> None:
+        """Test that format defaults to human."""
+
+        @click.command()
+        @format_option
+        def test_cmd() -> None:
+            ctx = click.get_current_context()
+            fmt = ctx.obj.get("output_format")
+            click.echo(f"Format: {fmt.value}")
+
+        runner = CliRunner()
+        result = runner.invoke(test_cmd)
+        assert result.exit_code == 0
+        assert "Format: human" in result.output
+
+    def test_format_option_accepts_json(self) -> None:
+        """Test that --format json sets JSON format."""
+
+        @click.command()
+        @format_option
+        def test_cmd() -> None:
+            ctx = click.get_current_context()
+            fmt = ctx.obj.get("output_format")
+            click.echo(f"Format: {fmt.value}")
+
+        runner = CliRunner()
+        result = runner.invoke(test_cmd, ["--format", "json"])
+        assert result.exit_code == 0
+        assert "Format: json" in result.output
+
+    def test_format_option_case_insensitive(self) -> None:
+        """Test that --format option is case insensitive."""
+
+        @click.command()
+        @format_option
+        def test_cmd() -> None:
+            ctx = click.get_current_context()
+            fmt = ctx.obj.get("output_format")
+            click.echo(f"Format: {fmt.value}")
+
+        runner = CliRunner()
+        result = runner.invoke(test_cmd, ["--format", "JSON"])
+        assert result.exit_code == 0
+        assert "Format: json" in result.output
+
+    def test_format_option_invalid_value(self) -> None:
+        """Test that invalid format value is rejected."""
+
+        @click.command()
+        @format_option
+        def test_cmd() -> None:
+            pass
+
+        runner = CliRunner()
+        result = runner.invoke(test_cmd, ["--format", "invalid"])
+        assert result.exit_code != 0
+        assert "Invalid value" in result.output or "invalid" in result.output.lower()
+
+
+class TestGetOutputFormat:
+    """Tests for get_output_format function."""
+
+    def test_get_output_format_no_context(self) -> None:
+        """Test default when no context available."""
+        assert get_output_format() == OutputFormat.HUMAN
+
+    def test_get_output_format_from_dict(self) -> None:
+        """Test getting format from dict context."""
+
+        @click.command()
+        @click.pass_context
+        def test_cmd(ctx: click.Context) -> None:
+            ctx.ensure_object(dict)
+            ctx.obj["output_format"] = OutputFormat.JSON
+            fmt = get_output_format()
+            click.echo(f"Format: {fmt.value}")
+
+        runner = CliRunner()
+        result = runner.invoke(test_cmd)
+        assert "Format: json" in result.output
+
+    def test_get_output_format_from_object(self) -> None:
+        """Test getting format from object with output_format attribute."""
+
+        class MockContext:
+            output_format = OutputFormat.JSON
+
+        @click.command()
+        @click.pass_context
+        def test_cmd(ctx: click.Context) -> None:
+            ctx.obj = MockContext()
+            fmt = get_output_format()
+            click.echo(f"Format: {fmt.value}")
+
+        runner = CliRunner()
+        result = runner.invoke(test_cmd)
+        assert "Format: json" in result.output
+
+
+class TestIsJsonOutput:
+    """Tests for is_json_output function."""
+
+    def test_is_json_output_false_by_default(self) -> None:
+        """Test that is_json_output returns False by default."""
+        assert is_json_output() is False
+
+    def test_is_json_output_true_when_json(self) -> None:
+        """Test that is_json_output returns True when JSON format."""
+
+        @click.command()
+        @format_option
+        def test_cmd() -> None:
+            result = is_json_output()
+            click.echo(f"JSON: {result}")
+
+        runner = CliRunner()
+        result = runner.invoke(test_cmd, ["--format", "json"])
+        assert "JSON: True" in result.output
+
+    def test_is_json_output_false_when_human(self) -> None:
+        """Test that is_json_output returns False when human format."""
+
+        @click.command()
+        @format_option
+        def test_cmd() -> None:
+            result = is_json_output()
+            click.echo(f"JSON: {result}")
+
+        runner = CliRunner()
+        result = runner.invoke(test_cmd, ["--format", "human"])
+        assert "JSON: False" in result.output
+
+
+class TestOutputResult:
+    """Tests for output_result function."""
+
+    def test_output_result_human_format(self) -> None:
+        """Test output_result in human format."""
+
+        @click.command()
+        @format_option
+        def test_cmd() -> None:
+            output_result(
+                CommandResult(
+                    data={"key": "value"},
+                    human_output="Human readable output",
+                )
+            )
+
+        runner = CliRunner()
+        result = runner.invoke(test_cmd, ["--format", "human"])
+        assert result.exit_code == 0
+        assert result.output.strip() == "Human readable output"
+
+    def test_output_result_json_format(self) -> None:
+        """Test output_result in JSON format."""
+
+        @click.command()
+        @format_option
+        def test_cmd() -> None:
+            output_result(
+                CommandResult(
+                    data={"key": "value"},
+                    human_output="Human readable output",
+                )
+            )
+
+        runner = CliRunner()
+        result = runner.invoke(test_cmd, ["--format", "json"])
+        assert result.exit_code == 0
+
+        # Parse the JSON output
+        output = json.loads(result.output)
+        assert output["status"] == "ok"
+        assert output["data"] == {"key": "value"}
+
+    def test_output_result_json_format_with_nested_data(self) -> None:
+        """Test output_result JSON with nested data structures."""
+
+        @click.command()
+        @format_option
+        def test_cmd() -> None:
+            output_result(
+                CommandResult(
+                    data={
+                        "artifact": "test/path",
+                        "versions": [
+                            {"version": "@abc123", "tags": ["latest"]},
+                        ],
+                    },
+                    human_output="",
+                )
+            )
+
+        runner = CliRunner()
+        result = runner.invoke(test_cmd, ["--format", "json"])
+        output = json.loads(result.output)
+        assert output["status"] == "ok"
+        assert output["data"]["artifact"] == "test/path"
+        assert len(output["data"]["versions"]) == 1
+
+
+class TestOutputError:
+    """Tests for output_error function."""
+
+    def test_output_error_human_format(self) -> None:
+        """Test output_error in human format - exit code is non-zero."""
+
+        @click.command()
+        @format_option
+        def test_cmd() -> None:
+            output_error(ErrorCode.NOT_FOUND, "Resource not found")
+
+        runner = CliRunner()
+        result = runner.invoke(test_cmd, ["--format", "human"])
+        assert result.exit_code == 1
+        # In Click 8.x+, stderr and stdout are mixed by default
+        # Just check the error message appears
+        assert "Error: Resource not found" in result.output
+
+    def test_output_error_json_format(self) -> None:
+        """Test output_error in JSON format - outputs JSON envelope."""
+
+        @click.command()
+        @format_option
+        def test_cmd() -> None:
+            output_error(ErrorCode.NOT_FOUND, "Resource not found")
+
+        runner = CliRunner()
+        result = runner.invoke(test_cmd, ["--format", "json"])
+        assert result.exit_code == 1
+
+        # Parse the JSON error output (mixed into output in Click 8.x+)
+        output = json.loads(result.output)
+        assert output["status"] == "error"
+        assert output["error"]["code"] == "NOT_FOUND"
+        assert output["error"]["message"] == "Resource not found"
+
+    def test_output_error_custom_exit_code(self) -> None:
+        """Test output_error with custom exit code."""
+
+        @click.command()
+        @format_option
+        def test_cmd() -> None:
+            output_error(ErrorCode.VALIDATION_ERROR, "Invalid input", exit_code=2)
+
+        runner = CliRunner()
+        result = runner.invoke(test_cmd, ["--format", "human"])
+        assert result.exit_code == 2
+
+    def test_output_error_json_envelope_structure(self) -> None:
+        """Test that JSON error has correct envelope structure."""
+
+        @click.command()
+        @format_option
+        def test_cmd() -> None:
+            output_error(ErrorCode.SERVER_ERROR, "Server failed")
+
+        runner = CliRunner()
+        result = runner.invoke(test_cmd, ["--format", "json"])
+        output = json.loads(result.output)
+        assert "status" in output
+        assert output["status"] == "error"
+        assert "error" in output
+        assert "code" in output["error"]
+        assert "message" in output["error"]
+
+
+class TestErrorCode:
+    """Tests for ErrorCode constants."""
+
+    def test_error_code_values(self) -> None:
+        """Test all error codes have expected values."""
+        assert ErrorCode.NOT_FOUND == "NOT_FOUND"
+        assert ErrorCode.UNAUTHORIZED == "UNAUTHORIZED"
+        assert ErrorCode.FORBIDDEN == "FORBIDDEN"
+        assert ErrorCode.CONFLICT == "CONFLICT"
+        assert ErrorCode.VALIDATION_ERROR == "VALIDATION_ERROR"
+        assert ErrorCode.SERVER_ERROR == "SERVER_ERROR"
+        assert ErrorCode.NETWORK_ERROR == "NETWORK_ERROR"
+        assert ErrorCode.IO_ERROR == "IO_ERROR"
+        assert ErrorCode.CONFIG_ERROR == "CONFIG_ERROR"
+
+
+class TestHttpStatusToErrorCode:
+    """Tests for http_status_to_error_code function."""
+
+    def test_maps_400_to_validation_error(self) -> None:
+        """Test 400 maps to VALIDATION_ERROR."""
+        assert http_status_to_error_code(400) == ErrorCode.VALIDATION_ERROR
+
+    def test_maps_401_to_unauthorized(self) -> None:
+        """Test 401 maps to UNAUTHORIZED."""
+        assert http_status_to_error_code(401) == ErrorCode.UNAUTHORIZED
+
+    def test_maps_403_to_forbidden(self) -> None:
+        """Test 403 maps to FORBIDDEN."""
+        assert http_status_to_error_code(403) == ErrorCode.FORBIDDEN
+
+    def test_maps_404_to_not_found(self) -> None:
+        """Test 404 maps to NOT_FOUND."""
+        assert http_status_to_error_code(404) == ErrorCode.NOT_FOUND
+
+    def test_maps_409_to_conflict(self) -> None:
+        """Test 409 maps to CONFLICT."""
+        assert http_status_to_error_code(409) == ErrorCode.CONFLICT
+
+    def test_maps_5xx_to_server_error(self) -> None:
+        """Test 5xx status codes map to SERVER_ERROR."""
+        assert http_status_to_error_code(500) == ErrorCode.SERVER_ERROR
+        assert http_status_to_error_code(502) == ErrorCode.SERVER_ERROR
+        assert http_status_to_error_code(503) == ErrorCode.SERVER_ERROR
+
+    def test_maps_unknown_to_validation_error(self) -> None:
+        """Test unknown status codes map to VALIDATION_ERROR."""
+        assert http_status_to_error_code(418) == ErrorCode.VALIDATION_ERROR


### PR DESCRIPTION
## Summary
- Add new `src/magpie/cli/formatting.py` module with shared formatting utilities
- Add global `--format` option to `magpie` and `magpie-ctl` command groups
- Update all commands to support JSON output with consistent envelope structure
- Add comprehensive unit tests for the formatting module

## Changes

### New formatting module
- `OutputFormat` enum with `human` (default) and `json` values
- `CommandResult` dataclass for structured command results
- `format_option` decorator for adding `--format` option to commands
- `output_result()` and `output_error()` helpers for consistent output
- `ErrorCode` constants and `http_status_to_error_code()` mapping

### Updated magpie commands
- `push`, `get`, `ls`, `info`, `url`, `tag`, `untag`, `amend`, `gc`, `flush-tag`, `config`

### Updated magpie-ctl commands
- `init`, `token create`, `token list`, `token revoke`, `gc`

### JSON envelope format
Success response:
```json
{"status": "ok", "data": {...}}
```

Error response (to stderr):
```json
{"status": "error", "error": {"code": "NOT_FOUND", "message": "..."}}
```

## Usage
```bash
# Human output (default)
magpie ls myartifact

# JSON output
magpie --format json ls myartifact
magpie-ctl --format json token list

# JSON errors go to stderr with non-zero exit
magpie --format json get nonexistent 2>error.json
```

## Test plan
- [x] Unit tests for formatting module (31 tests)
- [x] All existing unit tests pass (599 tests)
- [x] ruff check passes
- [x] ruff format applied

Closes #16

(AI-generated via Claude Code w/ Opus 4.5)