### PR TITLE
docs: Add .env.example documenting all environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,8 @@
 #
 # Copy this file to .env and customize as needed.
 # Variables are read by both docker-compose and the Magpie application.
+#
+# Note: This file was generated with AI assistance (Claude Code w/ Opus 4.5).
 
 # =============================================================================
 # Docker Compose / Deployment Settings
@@ -76,7 +78,7 @@
 # =============================================================================
 # CLI Client Configuration
 # =============================================================================
-# These are typically set in your shell environment or ~/.config/magpie/config.toml,
+# These are typically set in your shell environment or ~/.magpie/config.toml,
 # not in this file. Included here for reference.
 
 # Magpie server URL for CLI operations

--- a/.env.example
+++ b/.env.example
@@ -1,12 +1,13 @@
 # Magpie Artifact Storage - Environment Configuration Example
 #
 # Copy this file to .env and customize as needed.
-# Variables are read by both docker-compose and the Magpie application.
+# This .env file is used by docker-compose, entrypoint.sh, and the Magpie application.
+# Different variables are consumed by different components; see section headers for scope.
 #
 # Note: This file was generated with AI assistance (Claude Code w/ Opus 4.5).
 
 # =============================================================================
-# Docker Compose / Deployment Settings
+# Docker Compose Settings (used by docker-compose.yml only, not the application)
 # =============================================================================
 
 # Host directory for artifact storage (mounted into containers)
@@ -22,7 +23,7 @@
 # MAGPIE_HTTPS_PORT=8443
 
 # =============================================================================
-# Container Runtime Settings
+# Container Runtime Settings (used by entrypoint.sh only, not the application)
 # =============================================================================
 
 # User ID to run the Magpie process as (overrides auto-detection from volume ownership)
@@ -78,8 +79,10 @@
 # =============================================================================
 # CLI Client Configuration
 # =============================================================================
-# These are typically set in your shell environment or ~/.magpie/config.toml,
-# not in this file. Included here for reference.
+# These are typically set in your shell environment or ~/.magpie/config.toml.
+# Note: MAGPIE_TIMEOUT is intentionally NOT read from config.toml (only env var
+# or CLI flag) to prevent global config from silently affecting network behavior.
+# Only MAGPIE_SERVER and MAGPIE_TOKEN can be set in config.toml.
 
 # Magpie server URL for CLI operations
 # MAGPIE_SERVER=https://magpie.example.com

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,91 @@
+# Magpie Artifact Storage - Environment Configuration Example
+#
+# Copy this file to .env and customize as needed.
+# Variables are read by both docker-compose and the Magpie application.
+
+# =============================================================================
+# Docker Compose / Deployment Settings
+# =============================================================================
+
+# Host directory for artifact storage (mounted into containers)
+# Default: ./data/artifacts
+# MAGPIE_DATA_DIR=/data/artifacts
+
+# External HTTP port (Caddy reverse proxy)
+# Default: 8080
+# MAGPIE_HTTP_PORT=8080
+
+# External HTTPS port (Caddy reverse proxy, auto-TLS in production)
+# Default: 8443
+# MAGPIE_HTTPS_PORT=8443
+
+# =============================================================================
+# Container Runtime Settings
+# =============================================================================
+
+# User ID to run the Magpie process as (overrides auto-detection from volume ownership)
+# Default: auto-detected from /data/artifacts ownership, or 1000
+# MAGPIE_UID=1000
+
+# Group ID to run the Magpie process as (overrides auto-detection from volume ownership)
+# Default: auto-detected from /data/artifacts ownership, or 1000
+# MAGPIE_GID=1000
+
+# =============================================================================
+# Server Configuration
+# =============================================================================
+
+# Root directory for artifact storage (inside container)
+# Default: /data/artifacts
+# MAGPIE_STORAGE_PATH=/data/artifacts
+
+# Path for temporary files during uploads
+# Default: derived from MAGPIE_STORAGE_PATH (storage_path/.tmp)
+# MAGPIE_TEMP_PATH=/data/artifacts/.tmp
+
+# Path to SQLite database file
+# Default: derived from MAGPIE_STORAGE_PATH (storage_path/.magpie.db)
+# MAGPIE_DATABASE_PATH=/data/artifacts/.magpie.db
+
+# Days before untagged blobs are eligible for garbage collection
+# Default: 90
+# MAGPIE_RETENTION_DAYS=90
+
+# Enable debug mode (verbose logging, detailed error responses)
+# Default: false
+# MAGPIE_DEBUG=false
+
+# =============================================================================
+# Observability (Optional)
+# =============================================================================
+
+# Sentry DSN for error tracking (leave empty to disable)
+# MAGPIE_SENTRY_DSN=
+
+# Enable OpenTelemetry tracing
+# Default: false
+# MAGPIE_OTEL_ENABLED=false
+
+# OpenTelemetry collector endpoint (required if OTEL enabled)
+# MAGPIE_OTEL_ENDPOINT=http://localhost:4317
+
+# Service name for OpenTelemetry traces
+# Default: magpie
+# MAGPIE_OTEL_SERVICE_NAME=magpie
+
+# =============================================================================
+# CLI Client Configuration
+# =============================================================================
+# These are typically set in your shell environment or ~/.config/magpie/config.toml,
+# not in this file. Included here for reference.
+
+# Magpie server URL for CLI operations
+# MAGPIE_SERVER=https://magpie.example.com
+
+# Authentication token for CLI operations
+# Generated via: magpie-ctl token create --role write
+# MAGPIE_TOKEN=mgp_your_token_here
+
+# CLI request timeout (seconds or duration like "5m", "1h30m")
+# Default: 600 (10 minutes)
+# MAGPIE_TIMEOUT=600


### PR DESCRIPTION
## Summary

- Creates comprehensive `.env.example` file documenting all `MAGPIE_*` environment variables
- Organizes variables into logical sections: deployment, container runtime, server config, observability, and CLI
- Includes comments explaining each variable's purpose and default value

## Test plan

- [ ] Verify file is properly formatted and readable
- [ ] Confirm all documented variables match actual usage in codebase
- [ ] Ensure defaults match what's in `config.py`, `docker-compose.yml`, and `entrypoint.sh`

Closes #108

---
Generated with Claude Code (Opus 4.5)