### PR TITLE
feat(auth): Add token name validation to CreateTokenRequest

### DIFF
--- a/src/magpie/server/routes/auth.py
+++ b/src/magpie/server/routes/auth.py
@@ -25,6 +25,8 @@ TOKEN_NAME_PATTERN = r"^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$"  # nosec B105 - not a 
 class CreateTokenRequest(BaseModel):
     """Request model for creating a new token."""
 
+    # NOTE: max_length duplicates the limit in TOKEN_NAME_PATTERN intentionally.
+    # This keeps length validation explicit in the schema and can yield clearer error messages.
     name: str = Field(pattern=TOKEN_NAME_PATTERN, max_length=64)
     scope: str  # "read", "write", or "admin"
 

--- a/src/magpie/server/routes/auth.py
+++ b/src/magpie/server/routes/auth.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Response, status
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from magpie.auth.database import get_connection, list_tokens
 from magpie.auth.models import TokenScope
@@ -15,6 +15,9 @@ from magpie.server.deps import get_token_service, require_admin_scope
 
 router = APIRouter()
 
+# Token name validation pattern: alphanumeric start, then alphanumeric, dots, underscores, hyphens
+# Maximum 64 characters total (1 required start + up to 63 more)
+TOKEN_NAME_PATTERN = r"^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$"  # nosec B105 - not a password, just a token name regex
 
 # Request/Response models for token management
 
@@ -22,7 +25,7 @@ router = APIRouter()
 class CreateTokenRequest(BaseModel):
     """Request model for creating a new token."""
 
-    name: str
+    name: str = Field(pattern=TOKEN_NAME_PATTERN, max_length=64)
     scope: str  # "read", "write", or "admin"
 
 

--- a/src/magpie/server/routes/auth.py
+++ b/src/magpie/server/routes/auth.py
@@ -16,8 +16,8 @@ from magpie.server.deps import get_token_service, require_admin_scope
 router = APIRouter()
 
 # Token name validation pattern: alphanumeric start, then alphanumeric, dots, underscores, hyphens
-# Maximum 64 characters total (1 required start + up to 63 more)
-TOKEN_NAME_PATTERN = r"^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$"  # nosec B105 - not a password, just a token name regex
+# Length limit enforced via Field(max_length=64) for consistency with TAG_NAME_PATTERN style
+TOKEN_NAME_PATTERN = r"^[a-zA-Z0-9][a-zA-Z0-9._-]*$"  # nosec B105 - not a password, just a token name regex
 
 # Request/Response models for token management
 
@@ -25,9 +25,15 @@ TOKEN_NAME_PATTERN = r"^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$"  # nosec B105 - not a 
 class CreateTokenRequest(BaseModel):
     """Request model for creating a new token."""
 
-    # NOTE: max_length duplicates the limit in TOKEN_NAME_PATTERN intentionally.
-    # This keeps length validation explicit in the schema and can yield clearer error messages.
-    name: str = Field(pattern=TOKEN_NAME_PATTERN, max_length=64)
+    name: str = Field(
+        pattern=TOKEN_NAME_PATTERN,
+        max_length=64,
+        description=(
+            "Token name: must start with an alphanumeric character, may contain "
+            "alphanumeric characters, dots (.), underscores (_), or hyphens (-). "
+            "Maximum 64 characters."
+        ),
+    )
     scope: str  # "read", "write", or "admin"
 
 

--- a/tests/integration/test_token_endpoints.py
+++ b/tests/integration/test_token_endpoints.py
@@ -177,6 +177,158 @@ class TestCreateTokenEndpoint:
         assert "already exists" in response.json()["detail"]
 
 
+class TestCreateTokenNameValidation:
+    """Tests for token name validation in POST /api/v1/tokens endpoint."""
+
+    def test_valid_alphanumeric_name(self, client: TestClient, admin_token: str) -> None:
+        """Valid alphanumeric token name is accepted."""
+        response = client.post(
+            "/api/v1/tokens",
+            headers={"Authorization": f"Bearer {admin_token}"},
+            json={"name": "myservice123", "scope": "read"},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["name"] == "myservice123"
+
+    def test_valid_name_with_dots(self, client: TestClient, admin_token: str) -> None:
+        """Token name with dots is accepted."""
+        response = client.post(
+            "/api/v1/tokens",
+            headers={"Authorization": f"Bearer {admin_token}"},
+            json={"name": "my.service.name", "scope": "read"},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["name"] == "my.service.name"
+
+    def test_valid_name_with_underscores(self, client: TestClient, admin_token: str) -> None:
+        """Token name with underscores is accepted."""
+        response = client.post(
+            "/api/v1/tokens",
+            headers={"Authorization": f"Bearer {admin_token}"},
+            json={"name": "my_service_name", "scope": "read"},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["name"] == "my_service_name"
+
+    def test_valid_name_with_hyphens(self, client: TestClient, admin_token: str) -> None:
+        """Token name with hyphens is accepted."""
+        response = client.post(
+            "/api/v1/tokens",
+            headers={"Authorization": f"Bearer {admin_token}"},
+            json={"name": "my-service-name", "scope": "read"},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["name"] == "my-service-name"
+
+    def test_valid_single_character_name(self, client: TestClient, admin_token: str) -> None:
+        """Single alphanumeric character token name is accepted."""
+        response = client.post(
+            "/api/v1/tokens",
+            headers={"Authorization": f"Bearer {admin_token}"},
+            json={"name": "a", "scope": "read"},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["name"] == "a"
+
+    def test_invalid_name_starting_with_hyphen_returns_422(
+        self, client: TestClient, admin_token: str
+    ) -> None:
+        """Token name starting with hyphen returns 422."""
+        response = client.post(
+            "/api/v1/tokens",
+            headers={"Authorization": f"Bearer {admin_token}"},
+            json={"name": "-invalid", "scope": "read"},
+        )
+
+        assert response.status_code == 422
+
+    def test_invalid_name_starting_with_dot_returns_422(
+        self, client: TestClient, admin_token: str
+    ) -> None:
+        """Token name starting with dot returns 422."""
+        response = client.post(
+            "/api/v1/tokens",
+            headers={"Authorization": f"Bearer {admin_token}"},
+            json={"name": ".invalid", "scope": "read"},
+        )
+
+        assert response.status_code == 422
+
+    def test_invalid_name_starting_with_underscore_returns_422(
+        self, client: TestClient, admin_token: str
+    ) -> None:
+        """Token name starting with underscore returns 422."""
+        response = client.post(
+            "/api/v1/tokens",
+            headers={"Authorization": f"Bearer {admin_token}"},
+            json={"name": "_invalid", "scope": "read"},
+        )
+
+        assert response.status_code == 422
+
+    def test_invalid_name_with_spaces_returns_422(
+        self, client: TestClient, admin_token: str
+    ) -> None:
+        """Token name with spaces returns 422."""
+        response = client.post(
+            "/api/v1/tokens",
+            headers={"Authorization": f"Bearer {admin_token}"},
+            json={"name": "invalid name", "scope": "read"},
+        )
+
+        assert response.status_code == 422
+
+    def test_invalid_name_with_special_chars_returns_422(
+        self, client: TestClient, admin_token: str
+    ) -> None:
+        """Token name with special characters returns 422."""
+        response = client.post(
+            "/api/v1/tokens",
+            headers={"Authorization": f"Bearer {admin_token}"},
+            json={"name": "invalid@name!", "scope": "read"},
+        )
+
+        assert response.status_code == 422
+
+    def test_invalid_empty_name_returns_422(self, client: TestClient, admin_token: str) -> None:
+        """Empty token name returns 422."""
+        response = client.post(
+            "/api/v1/tokens",
+            headers={"Authorization": f"Bearer {admin_token}"},
+            json={"name": "", "scope": "read"},
+        )
+
+        assert response.status_code == 422
+
+    def test_invalid_name_too_long_returns_422(self, client: TestClient, admin_token: str) -> None:
+        """Token name exceeding 64 characters returns 422."""
+        long_name = "a" * 65  # 65 characters, exceeds max of 64
+        response = client.post(
+            "/api/v1/tokens",
+            headers={"Authorization": f"Bearer {admin_token}"},
+            json={"name": long_name, "scope": "read"},
+        )
+
+        assert response.status_code == 422
+
+    def test_valid_max_length_name(self, client: TestClient, admin_token: str) -> None:
+        """Token name at max length (64 chars) is accepted."""
+        max_name = "a" * 64  # Exactly 64 characters
+        response = client.post(
+            "/api/v1/tokens",
+            headers={"Authorization": f"Bearer {admin_token}"},
+            json={"name": max_name, "scope": "read"},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["name"] == max_name
+
+
 class TestListTokensEndpoint:
     """Tests for GET /api/v1/tokens endpoint."""
 


### PR DESCRIPTION
## Summary

- Add pattern validation to `CreateTokenRequest.name` field using Pydantic `Field` with regex pattern
- Token names must start with alphanumeric character and contain only alphanumeric, dots, underscores, or hyphens
- Maximum length of 64 characters enforced via `max_length` constraint
- Add comprehensive test suite (13 new tests) covering valid and invalid token name scenarios

## Test plan

- [x] Run `uv run ruff check src/ tests/` - passes
- [x] Run `uv run ruff format src/ tests/` - no changes needed
- [x] Run `uv run pytest tests/unit/ -x` - 620 tests pass
- [x] Run `uv run pytest tests/integration/test_token_endpoints.py -x -v` - 32 tests pass (including 13 new validation tests)

Fixes #100

---
Generated with Claude Code (Opus 4.5)