### PR TITLE
security: Add tag name validation to prevent path traversal

### DIFF
--- a/src/magpie/server/routes/artifacts.py
+++ b/src/magpie/server/routes/artifacts.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+import re
 from datetime import datetime
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, Response, status
-from pydantic import BaseModel
+from fastapi import APIRouter, Depends, HTTPException, Path, Response, status
+from pydantic import BaseModel, field_validator
 
 from magpie.server.deps import get_storage_service, require_write_scope
 from magpie.storage.exceptions import ArtifactNotFoundError, InvalidArtifactPathError
@@ -14,6 +15,11 @@ from magpie.storage.paths import normalize_artifact_path
 from magpie.storage.service import StorageService
 
 router = APIRouter()
+
+# Tag name validation pattern: alphanumeric start, then alphanumeric, dots, underscores, hyphens
+# Must match the pattern in tags.py for consistency
+TAG_NAME_PATTERN = r"^[a-zA-Z0-9][a-zA-Z0-9._-]*$"
+_TAG_NAME_RE = re.compile(TAG_NAME_PATTERN)
 
 
 def _normalize_path(path: str) -> str:
@@ -69,6 +75,24 @@ class CreateTagRequest(BaseModel):
     """Request model for creating a tag."""
 
     tag_name: str  # Name for the new tag
+
+    @field_validator("tag_name")
+    @classmethod
+    def validate_tag_name(cls, v: str) -> str:
+        """Validate tag name matches allowed pattern.
+
+        Tag names must start with an alphanumeric character and contain only
+        alphanumeric characters, dots, underscores, and hyphens.
+
+        Raises:
+            ValueError: If tag name is invalid.
+        """
+        if not _TAG_NAME_RE.match(v):
+            raise ValueError(
+                "Tag name must start with alphanumeric and contain only "
+                "alphanumeric, dots, underscores, or hyphens"
+            )
+        return v
 
 
 class TagResponse(BaseModel):
@@ -183,7 +207,7 @@ async def create_tag(
 )
 async def remove_tag(
     path: str,
-    tag_name: str,
+    tag_name: Annotated[str, Path(pattern=TAG_NAME_PATTERN, max_length=128)],
     storage_service: Annotated[StorageService, Depends(get_storage_service)],
     _write_scope_check: Annotated[None, Depends(require_write_scope)] = None,
 ) -> Response:

--- a/tests/integration/test_tag_endpoints.py
+++ b/tests/integration/test_tag_endpoints.py
@@ -243,3 +243,123 @@ class TestTagResponseIncludesTags:
 
         expected_fields = {"artifact_path", "tag_name", "hash_ref", "tags"}
         assert expected_fields == set(data.keys())
+
+
+class TestCreateTagValidation:
+    """Tests for tag name validation on create_tag endpoint."""
+
+    def test_create_tag_rejects_path_traversal(self, client: TestClient) -> None:
+        """Create tag rejects tag names with path traversal."""
+        artifact_path = "tag-validation/traversal"
+        upload_artifact(client, artifact_path, b"validation test content")
+
+        response = client.post(
+            f"/api/v1/artifacts/{artifact_path}/latest/tags",
+            json={"tag_name": "../../../evil"},
+        )
+
+        assert response.status_code == 422
+
+    def test_create_tag_rejects_leading_dot(self, client: TestClient) -> None:
+        """Create tag rejects tag names starting with a dot."""
+        artifact_path = "tag-validation/leading-dot"
+        upload_artifact(client, artifact_path, b"validation test content")
+
+        response = client.post(
+            f"/api/v1/artifacts/{artifact_path}/latest/tags",
+            json={"tag_name": ".hidden"},
+        )
+
+        assert response.status_code == 422
+
+    def test_create_tag_rejects_leading_hyphen(self, client: TestClient) -> None:
+        """Create tag rejects tag names starting with a hyphen."""
+        artifact_path = "tag-validation/leading-hyphen"
+        upload_artifact(client, artifact_path, b"validation test content")
+
+        response = client.post(
+            f"/api/v1/artifacts/{artifact_path}/latest/tags",
+            json={"tag_name": "-invalid"},
+        )
+
+        assert response.status_code == 422
+
+    def test_create_tag_rejects_slashes(self, client: TestClient) -> None:
+        """Create tag rejects tag names with slashes."""
+        artifact_path = "tag-validation/slashes"
+        upload_artifact(client, artifact_path, b"validation test content")
+
+        response = client.post(
+            f"/api/v1/artifacts/{artifact_path}/latest/tags",
+            json={"tag_name": "path/to/tag"},
+        )
+
+        assert response.status_code == 422
+
+    def test_create_tag_accepts_valid_names(self, client: TestClient) -> None:
+        """Create tag accepts various valid tag name formats."""
+        artifact_path = "tag-validation/valid-names"
+        upload_artifact(client, artifact_path, b"validation test content")
+
+        valid_names = [
+            "v1.0.0",
+            "release-2024",
+            "my_tag",
+            "Tag123",
+            "a",
+            "1tag",
+        ]
+
+        for tag_name in valid_names:
+            response = client.post(
+                f"/api/v1/artifacts/{artifact_path}/latest/tags",
+                json={"tag_name": tag_name},
+            )
+            assert response.status_code == 200, f"Tag name '{tag_name}' should be valid"
+
+
+class TestRemoveTagValidation:
+    """Tests for tag name validation on remove_tag endpoint."""
+
+    def test_remove_tag_rejects_leading_dot(self, client: TestClient) -> None:
+        """Remove tag rejects tag names starting with a dot."""
+        artifact_path = "tag-validation/remove-leading-dot"
+        upload_artifact(client, artifact_path, b"validation test content")
+
+        response = client.delete(f"/api/v1/artifacts/{artifact_path}/tags/.hidden")
+
+        assert response.status_code == 422
+
+    def test_remove_tag_rejects_leading_hyphen(self, client: TestClient) -> None:
+        """Remove tag rejects tag names starting with a hyphen."""
+        artifact_path = "tag-validation/remove-leading-hyphen"
+        upload_artifact(client, artifact_path, b"validation test content")
+
+        response = client.delete(f"/api/v1/artifacts/{artifact_path}/tags/-invalid")
+
+        assert response.status_code == 422
+
+    def test_remove_tag_rejects_leading_underscore(self, client: TestClient) -> None:
+        """Remove tag rejects tag names starting with an underscore."""
+        artifact_path = "tag-validation/remove-leading-underscore"
+        upload_artifact(client, artifact_path, b"validation test content")
+
+        response = client.delete(f"/api/v1/artifacts/{artifact_path}/tags/_invalid")
+
+        assert response.status_code == 422
+
+    def test_remove_tag_accepts_valid_name(self, client: TestClient) -> None:
+        """Remove tag allows valid tag names."""
+        artifact_path = "tag-validation/remove-valid"
+        upload_data = upload_artifact(client, artifact_path, b"validation test content")
+
+        # Create a tag to remove
+        client.post(
+            f"/api/v1/artifacts/{artifact_path}/{upload_data['hash_ref']}/tags",
+            json={"tag_name": "valid-tag"},
+        )
+
+        # Removing should succeed (204 if found, but we care about validation passing)
+        response = client.delete(f"/api/v1/artifacts/{artifact_path}/tags/valid-tag")
+
+        assert response.status_code == 204


### PR DESCRIPTION
## Summary

- Add validation to `CreateTagRequest.tag_name` using a Pydantic field validator
- Add validation to `remove_tag`'s `tag_name` path parameter using FastAPI's `Path` annotation with a regex pattern
- Both use the same pattern as `flush_tag` in `tags.py` for consistency:
  - Must start with alphanumeric character
  - Can only contain alphanumeric, dots, underscores, and hyphens

This prevents path traversal attacks like `../../../evil` from being used as tag names.

Closes #99

## Test plan

- [x] Added integration tests for `CreateTagRequest` validation (rejects path traversal, leading dot, leading hyphen, slashes; accepts valid names)
- [x] Added integration tests for `remove_tag` validation (rejects leading dot, leading hyphen, leading underscore; accepts valid names)
- [x] All existing unit tests pass (620 tests)
- [x] All existing integration tests pass
- [x] Linting passes with ruff

Generated with Claude Code (Opus 4.5)