### PR TITLE
security: Add source_uri length validation

### DIFF
--- a/src/magpie/server/routes/artifacts.py
+++ b/src/magpie/server/routes/artifacts.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Response, status
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, Field, field_validator
 
 from magpie.server.deps import get_storage_service, require_write_scope
 from magpie.storage.exceptions import ArtifactNotFoundError, InvalidArtifactPathError
@@ -107,7 +107,9 @@ class TagResponse(BaseModel):
 class AmendMetadataRequest(BaseModel):
     """Request model for amending artifact metadata."""
 
-    source_uri: str | None = None  # New source URI (None to leave unchanged)
+    source_uri: str | None = Field(
+        default=None, max_length=2048
+    )  # New source URI (None to leave unchanged)
 
 
 class ArtifactPathsResponse(BaseModel):

--- a/src/magpie/server/routes/upload.py
+++ b/src/magpie/server/routes/upload.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, Header, HTTPException, UploadFile, status
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, UploadFile, status
 from pydantic import BaseModel
 
 from magpie.server.deps import get_storage_service, require_write_scope
@@ -34,7 +34,7 @@ async def upload_artifact(
     file: UploadFile,
     storage_service: Annotated[StorageService, Depends(get_storage_service)],
     _write_scope_check: Annotated[None, Depends(require_write_scope)] = None,
-    source_uri: str | None = None,
+    source_uri: Annotated[str | None, Query(max_length=2048)] = None,
     uploaded_by: str = "anonymous",
     x_magpie_user: Annotated[str | None, Header(alias="X-Magpie-User")] = None,
 ) -> UploadResponse:

--- a/tests/integration/test_source_uri_validation.py
+++ b/tests/integration/test_source_uri_validation.py
@@ -1,0 +1,185 @@
+"""Unit tests for source_uri length validation."""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from magpie.config import MagpieSettings
+from magpie.server.app import app
+from magpie.server.deps import get_storage_service
+from magpie.storage.service import StorageService
+
+
+@pytest.fixture
+def test_config(tmp_path: Path) -> MagpieSettings:
+    """Create test configuration with temporary paths."""
+    config = MagpieSettings(storage_path=tmp_path)
+    config.temp_path.mkdir(parents=True, exist_ok=True)
+    return config
+
+
+@pytest.fixture
+def test_storage_service(test_config: MagpieSettings) -> StorageService:
+    """Create a StorageService instance for testing."""
+    return StorageService(test_config)
+
+
+@pytest.fixture
+def client(test_storage_service: StorageService) -> TestClient:
+    """Create test client with overridden storage service dependency."""
+
+    def override_storage_service() -> StorageService:
+        return test_storage_service
+
+    app.dependency_overrides[get_storage_service] = override_storage_service
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+def _upload_artifact(
+    client: TestClient, path: str, content: bytes, source_uri: str | None = None
+) -> dict:
+    """Helper to upload an artifact and return the response data."""
+    files = {"file": ("artifact.bin", io.BytesIO(content), "application/octet-stream")}
+    params = {"uploaded_by": "test-user"}
+    if source_uri:
+        params["source_uri"] = source_uri
+
+    response = client.post(f"/api/v1/upload/{path}", files=files, params=params)
+    assert response.status_code == 200
+    return response.json()
+
+
+class TestSourceUriValidationUpload:
+    """Tests for source_uri length validation in upload endpoint."""
+
+    def test_upload_with_valid_source_uri(self, client: TestClient) -> None:
+        """Upload with a valid source_uri succeeds."""
+        content = b"valid source uri test"
+        files = {"file": ("artifact.bin", io.BytesIO(content), "application/octet-stream")}
+        valid_uri = "https://example.com/path/to/resource"
+
+        response = client.post(
+            "/api/v1/upload/source-uri/valid",
+            files=files,
+            params={"source_uri": valid_uri},
+        )
+
+        assert response.status_code == 200
+
+    def test_upload_with_max_length_source_uri(self, client: TestClient) -> None:
+        """Upload with source_uri at exactly 2048 chars succeeds."""
+        content = b"max length source uri test"
+        files = {"file": ("artifact.bin", io.BytesIO(content), "application/octet-stream")}
+        # Create a URI that is exactly 2048 characters
+        base_uri = "https://example.com/"
+        padding = "x" * (2048 - len(base_uri))
+        max_uri = base_uri + padding
+        assert len(max_uri) == 2048
+
+        response = client.post(
+            "/api/v1/upload/source-uri/maxlen",
+            files=files,
+            params={"source_uri": max_uri},
+        )
+
+        assert response.status_code == 200
+
+    def test_upload_with_too_long_source_uri(self, client: TestClient) -> None:
+        """Upload with source_uri exceeding 2048 chars is rejected."""
+        content = b"too long source uri test"
+        files = {"file": ("artifact.bin", io.BytesIO(content), "application/octet-stream")}
+        # Create a URI that exceeds 2048 characters
+        too_long_uri = "https://example.com/" + "x" * 2040
+
+        response = client.post(
+            "/api/v1/upload/source-uri/toolong",
+            files=files,
+            params={"source_uri": too_long_uri},
+        )
+
+        assert response.status_code == 422  # Validation error
+
+    def test_upload_without_source_uri(self, client: TestClient) -> None:
+        """Upload without source_uri succeeds (optional field)."""
+        content = b"no source uri test"
+        files = {"file": ("artifact.bin", io.BytesIO(content), "application/octet-stream")}
+
+        response = client.post(
+            "/api/v1/upload/source-uri/none",
+            files=files,
+        )
+
+        assert response.status_code == 200
+
+
+class TestSourceUriValidationAmend:
+    """Tests for source_uri length validation in amend endpoint."""
+
+    def test_amend_with_valid_source_uri(self, client: TestClient) -> None:
+        """Amend with a valid source_uri succeeds."""
+        _upload_artifact(client, "amend-uri/valid", b"test content")
+        valid_uri = "https://example.com/updated/path"
+
+        response = client.patch(
+            "/api/v1/artifacts/amend-uri/valid/latest",
+            json={"source_uri": valid_uri},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["source_uri"] == valid_uri
+
+    def test_amend_with_max_length_source_uri(self, client: TestClient) -> None:
+        """Amend with source_uri at exactly 2048 chars succeeds."""
+        _upload_artifact(client, "amend-uri/maxlen", b"test content")
+        # Create a URI that is exactly 2048 characters
+        base_uri = "https://example.com/"
+        padding = "x" * (2048 - len(base_uri))
+        max_uri = base_uri + padding
+        assert len(max_uri) == 2048
+
+        response = client.patch(
+            "/api/v1/artifacts/amend-uri/maxlen/latest",
+            json={"source_uri": max_uri},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["source_uri"] == max_uri
+
+    def test_amend_with_too_long_source_uri(self, client: TestClient) -> None:
+        """Amend with source_uri exceeding 2048 chars is rejected."""
+        _upload_artifact(client, "amend-uri/toolong", b"test content")
+        # Create a URI that exceeds 2048 characters
+        too_long_uri = "https://example.com/" + "x" * 2040
+
+        response = client.patch(
+            "/api/v1/artifacts/amend-uri/toolong/latest",
+            json={"source_uri": too_long_uri},
+        )
+
+        assert response.status_code == 422  # Validation error
+
+    def test_amend_with_null_source_uri(self, client: TestClient) -> None:
+        """Amend with null source_uri succeeds (to preserve value)."""
+        _upload_artifact(
+            client,
+            "amend-uri/null",
+            b"test content",
+            source_uri="https://original.com",
+        )
+
+        response = client.patch(
+            "/api/v1/artifacts/amend-uri/null/latest",
+            json={"source_uri": None},
+        )
+
+        assert response.status_code == 200
+        # Should preserve original value
+        data = response.json()
+        assert data["source_uri"] == "https://original.com"

--- a/tests/integration/test_source_uri_validation.py
+++ b/tests/integration/test_source_uri_validation.py
@@ -1,4 +1,4 @@
-"""Unit tests for source_uri length validation."""
+"""Integration tests for source_uri length validation."""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary
- Adds `max_length=2048` validation to `source_uri` field in upload endpoint (via `Query`)
- Adds `max_length=2048` validation to `source_uri` field in `AmendMetadataRequest` model (via `Field`)
- Adds integration tests for source_uri length validation

## Motivation
This prevents potential DoS attacks via extremely long source_uri values.

Closes #101

## Test plan
- [x] Run `uv run ruff check src/ tests/` - passes
- [x] Run `uv run ruff format src/ tests/` - formatted
- [x] Run `uv run pytest tests/unit/ -x` - 620 passed
- [x] Run `uv run pytest tests/integration/test_source_uri_validation.py -v` - 8 passed
- [ ] CI checks pass

---
Generated with Claude Code (Opus 4.5)