### PR TITLE
Add production Caddyfile with HTTPS/TLS configuration

### DIFF
--- a/Caddyfile.prod
+++ b/Caddyfile.prod
@@ -1,0 +1,264 @@
+# Magpie Artifact Storage - Production Caddy Configuration
+#
+# =============================================================================
+# PRODUCTION DEPLOYMENT NOTES
+# =============================================================================
+#
+# This configuration provides:
+# - TLS encryption (automatic via Let's Encrypt or manual certs)
+# - Security headers (HSTS, X-Content-Type-Options, X-Frame-Options, etc.)
+# - Rate limiting on authentication endpoints
+# - Access logging
+#
+# Environment variable configuration:
+#   MAGPIE_DOMAIN - The domain name for the service (default: magpie.example.com)
+#
+# TLS options:
+#   1. Automatic TLS via Let's Encrypt (default)
+#   2. Manual certificates: Set MAGPIE_TLS_CERT and MAGPIE_TLS_KEY paths
+#
+# =============================================================================
+# AUTHENTICATION FLOW (forward_auth)
+# =============================================================================
+#
+# Protected routes use Caddy's forward_auth to validate Bearer tokens:
+#
+# 1. Client sends request with "Authorization: Bearer <token>" header
+# 2. Caddy makes subrequest to /api/v1/auth/validate with the same headers
+# 3. Auth endpoint validates token and returns:
+#    - 200 OK with X-Magpie-User and X-Magpie-Scope headers (valid token)
+#    - 401 Unauthorized (invalid/missing token)
+# 4. If auth returns 200, Caddy copies identity headers to upstream request
+# 5. If auth returns 401, Caddy returns 401 to client (request blocked)
+#
+# =============================================================================
+# ROUTE PROTECTION SUMMARY
+# =============================================================================
+#
+# PROTECTED ROUTES (require valid Bearer token):
+#   - POST   /api/v1/upload/*              - Artifact uploads
+#   - POST   /api/v1/artifacts/*/tags      - Create/update tags
+#   - DELETE /api/v1/artifacts/*/tags/*    - Remove tags
+#   - POST   /api/v1/tags/*/flush          - Flush tags globally
+#   - GET    /api/v1/tokens                - List tokens (admin)
+#   - POST   /api/v1/tokens                - Create tokens (admin)
+#   - DELETE /api/v1/tokens/*              - Revoke tokens (admin)
+#   - POST   /api/v1/gc                    - Garbage collection (admin)
+#
+# PUBLIC ROUTES (no authentication required):
+#   - GET    /api/v1/artifacts/*           - List artifacts, get info
+#   - GET    /api/v1/auth/validate         - Auth validation endpoint
+#   - GET    /health                       - Health check
+#   - GET    /artifacts/*                  - Static file downloads + directory browsing
+#
+# =============================================================================
+# HEADER PROPAGATION
+# =============================================================================
+#
+# On successful authentication, these headers are copied to upstream:
+#   - X-Magpie-User:  Token name (identifies the authenticated client)
+#   - X-Magpie-Scope: Permission level (read, write, or admin)
+#
+# The FastAPI backend can use these headers for authorization decisions.
+#
+# =============================================================================
+
+# Global options block
+{
+	# Enable access logging to stdout (captured by container runtime)
+	log {
+		output stdout
+		format json
+		level INFO
+	}
+
+	# Admin API disabled for security (enable only if needed for debugging)
+	admin off
+}
+
+# Site block - uses environment variable for domain, with fallback
+{$MAGPIE_DOMAIN:magpie.example.com} {
+	# =========================================================================
+	# TLS CONFIGURATION
+	# =========================================================================
+	#
+	# Option 1: Automatic TLS via Let's Encrypt (default)
+	# Just ensure the domain resolves to this server and port 443 is accessible.
+	#
+	# Option 2: Manual certificates - uncomment and set paths:
+	# tls /path/to/cert.pem /path/to/key.pem
+	#
+	# Option 3: Internal CA - for internal deployments:
+	# tls internal
+	#
+	# For flexibility, check for environment variables:
+	tls {$MAGPIE_TLS_CERT:} {$MAGPIE_TLS_KEY:}
+
+	# =========================================================================
+	# SECURITY HEADERS
+	# =========================================================================
+
+	header {
+		# HSTS - Enforce HTTPS for all future requests (2 year max-age)
+		Strict-Transport-Security "max-age=63072000; includeSubDomains; preload"
+
+		# Prevent MIME type sniffing
+		X-Content-Type-Options "nosniff"
+
+		# Clickjacking protection - deny framing entirely
+		X-Frame-Options "DENY"
+
+		# XSS protection (legacy, but still useful for older browsers)
+		X-XSS-Protection "1; mode=block"
+
+		# Referrer policy - only send origin for cross-origin requests
+		Referrer-Policy "strict-origin-when-cross-origin"
+
+		# Content Security Policy - restrict resource loading
+		# Adjust as needed for your frontend requirements
+		Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
+
+		# Remove server identification headers
+		-Server
+	}
+
+	# =========================================================================
+	# RATE LIMITING
+	# =========================================================================
+	#
+	# Rate limit authentication-related endpoints to prevent brute force attacks.
+	# Limits: 10 requests per second per client IP
+
+	@auth_endpoints {
+		path /api/v1/auth/*
+		path /api/v1/tokens*
+	}
+	rate_limit @auth_endpoints {
+		zone auth_zone {
+			key {remote_host}
+			events 10
+			window 1s
+		}
+	}
+
+	# =========================================================================
+	# ACCESS LOGGING
+	# =========================================================================
+
+	log {
+		output stdout
+		format json {
+			time_format iso8601
+		}
+	}
+
+	# =========================================================================
+	# PUBLIC ROUTES - No authentication required
+	# =========================================================================
+
+	# Health check endpoint - used by container orchestration
+	handle /health {
+		reverse_proxy magpie:8000
+	}
+
+	# Auth validation endpoint - must be public (used by forward_auth itself)
+	handle /api/v1/auth/validate {
+		reverse_proxy magpie:8000
+	}
+
+	# Artifact read operations (GET only) - public access
+	# Matches: GET /api/v1/artifacts/{path}, GET /api/v1/artifacts/{path}/{ref}/info
+	# Note: POST/DELETE to /artifacts/*/tags* are handled by protected routes below
+	@artifacts_read {
+		method GET
+		path_regexp read ^/api/v1/artifacts/.+
+	}
+	handle @artifacts_read {
+		reverse_proxy magpie:8000
+	}
+
+	# Static artifact downloads - served directly by Caddy for performance
+	# Files accessed via /artifacts/{artifact_path}/{ref} symlinks
+	# Directory browsing enabled for discovery and debugging
+	handle /artifacts/* {
+		root * /data
+		file_server browse
+	}
+
+	# =========================================================================
+	# PROTECTED ROUTES - Require valid Bearer token via forward_auth
+	# =========================================================================
+
+	# Upload endpoint - requires write or admin scope
+	handle /api/v1/upload/* {
+		forward_auth magpie:8000 {
+			uri /api/v1/auth/validate
+			copy_headers X-Magpie-User X-Magpie-Scope
+		}
+		reverse_proxy magpie:8000
+	}
+
+	# Artifact metadata amendment - requires write or admin scope
+	# Matches: PATCH /api/v1/artifacts/{path}/{ref}
+	@artifacts_amend {
+		method PATCH
+		path_regexp amend ^/api/v1/artifacts/.+
+	}
+	handle @artifacts_amend {
+		forward_auth magpie:8000 {
+			uri /api/v1/auth/validate
+			copy_headers X-Magpie-User X-Magpie-Scope
+		}
+		reverse_proxy magpie:8000
+	}
+
+	# Tag mutation endpoints - requires write or admin scope
+	# Matches: POST /api/v1/artifacts/{path}/{ref}/tags
+	#          DELETE /api/v1/artifacts/{path}/tags/{tag_name}
+	@artifacts_tags {
+		path_regexp tags ^/api/v1/artifacts/.+/tags
+	}
+	handle @artifacts_tags {
+		forward_auth magpie:8000 {
+			uri /api/v1/auth/validate
+			copy_headers X-Magpie-User X-Magpie-Scope
+		}
+		reverse_proxy magpie:8000
+	}
+
+	# Flush tag endpoint - requires admin scope
+	handle /api/v1/tags/* {
+		forward_auth magpie:8000 {
+			uri /api/v1/auth/validate
+			copy_headers X-Magpie-User X-Magpie-Scope
+		}
+		reverse_proxy magpie:8000
+	}
+
+	# Token management endpoints - requires admin scope
+	handle /api/v1/tokens* {
+		forward_auth magpie:8000 {
+			uri /api/v1/auth/validate
+			copy_headers X-Magpie-User X-Magpie-Scope
+		}
+		reverse_proxy magpie:8000
+	}
+
+	# GC endpoint - requires admin scope
+	handle /api/v1/gc {
+		forward_auth magpie:8000 {
+			uri /api/v1/auth/validate
+			copy_headers X-Magpie-User X-Magpie-Scope
+		}
+		reverse_proxy magpie:8000
+	}
+
+	# =========================================================================
+	# FALLBACK
+	# =========================================================================
+
+	# Return 404 for unmatched routes
+	handle {
+		respond "Not Found" 404
+	}
+}

--- a/Caddyfile.prod
+++ b/Caddyfile.prod
@@ -96,7 +96,10 @@
 
 	header {
 		# HSTS - Enforce HTTPS for all future requests (2 year max-age)
-		Strict-Transport-Security "max-age=63072000; includeSubDomains; preload"
+		# NOTE: The "preload" directive is omitted because it requires active
+		# submission to hstspreload.org. Add "preload" only after submitting
+		# your domain to the HSTS preload list.
+		Strict-Transport-Security "max-age=63072000; includeSubDomains"
 
 		# Prevent MIME type sniffing
 		X-Content-Type-Options "nosniff"
@@ -166,6 +169,11 @@
 	# Static artifact downloads - served directly by Caddy for performance
 	# Files accessed via /artifacts/{artifact_path}/{ref} symlinks
 	# Directory browsing enabled for discovery and debugging
+	#
+	# SECURITY NOTE: Directory browsing exposes the artifact structure (paths,
+	# refs, filenames) to anyone who can access this endpoint. This is intentional
+	# for Magpie's use case (artifact discovery). If you need to restrict
+	# browsing, remove the "browse" argument from file_server below.
 	handle /artifacts/* {
 		root * /data
 		file_server browse
@@ -214,6 +222,12 @@
 
 	# Flush tag endpoint - requires admin scope
 	# Matches: POST /api/v1/tags/{tag_name}/flush
+	#
+	# NOTE: This route is more specific than the dev Caddyfile which uses
+	# /api/v1/tags/* to catch all tag operations. In production, we explicitly
+	# match only POST /api/v1/tags/*/flush since that is the only tag endpoint
+	# that exists outside of artifact-scoped routes. The dev config is broader
+	# to simplify local testing.
 	@tags_flush {
 		method POST
 		path /api/v1/tags/*/flush

--- a/Caddyfile.prod
+++ b/Caddyfile.prod
@@ -72,7 +72,13 @@
 		level INFO
 	}
 
-	# Admin API disabled for security (enable only if needed for debugging)
+	# Admin API disabled for production security.
+	# For debugging, prefer:
+	#   - Reviewing Caddy's access/error logs (output to stdout, captured by Docker)
+	#   - Validating config before deployment: `caddy validate --config /etc/caddy/Caddyfile`
+	#   - Testing in a non-production environment
+	# If you must enable the admin API temporarily, restrict access to localhost
+	# and disable it again before returning to production.
 	admin off
 }
 
@@ -95,11 +101,13 @@
 	# =========================================================================
 
 	header {
-		# HSTS - Enforce HTTPS for all future requests (2 year max-age)
-		# NOTE: The "preload" directive is omitted because it requires active
-		# submission to hstspreload.org. Add "preload" only after submitting
+		# HSTS - Enforce HTTPS for all future requests (30-day max-age for initial deployment)
+		# NOTE: Starting with 30 days allows recovery if TLS is misconfigured. After
+		# confirming TLS works correctly, increase to 2 years (63072000) for production.
+		# The "preload" directive is omitted because it requires active submission to
+		# hstspreload.org. Add "preload" only after increasing max-age and submitting
 		# your domain to the HSTS preload list.
-		Strict-Transport-Security "max-age=63072000; includeSubDomains"
+		Strict-Transport-Security "max-age=2592000; includeSubDomains"
 
 		# Prevent MIME type sniffing
 		X-Content-Type-Options "nosniff"
@@ -174,8 +182,14 @@
 	# refs, filenames) to anyone who can access this endpoint. This is intentional
 	# for Magpie's use case (artifact discovery). If you need to restrict
 	# browsing, remove the "browse" argument from file_server below.
+	#
+	# PATH TRAVERSAL PROTECTION: The root directive points to /data/artifacts
+	# (not /data) to prevent traversal attacks from accessing Caddy's internal
+	# state directories (ACME keys, TLS certificates) that are stored elsewhere
+	# under /data. Caddy normalizes ".." segments, so the explicit subdirectory
+	# root ensures only artifact files are accessible.
 	handle /artifacts/* {
-		root * /data
+		root * /data/artifacts
 		file_server browse
 	}
 

--- a/Caddyfile.prod
+++ b/Caddyfile.prod
@@ -182,14 +182,8 @@
 	# refs, filenames) to anyone who can access this endpoint. This is intentional
 	# for Magpie's use case (artifact discovery). If you need to restrict
 	# browsing, remove the "browse" argument from file_server below.
-	#
-	# PATH TRAVERSAL PROTECTION: The root directive points to /data/artifacts
-	# (not /data) to prevent traversal attacks from accessing Caddy's internal
-	# state directories (ACME keys, TLS certificates) that are stored elsewhere
-	# under /data. Caddy normalizes ".." segments, so the explicit subdirectory
-	# root ensures only artifact files are accessible.
 	handle /artifacts/* {
-		root * /data/artifacts
+		root * /data
 		file_server browse
 	}
 

--- a/Caddyfile.prod
+++ b/Caddyfile.prod
@@ -10,7 +10,7 @@
 # - Access logging
 #
 # Environment variable configuration:
-#   MAGPIE_DOMAIN - The domain name for the service (default: magpie.example.com)
+#   MAGPIE_DOMAIN - The domain name for the service (REQUIRED - no default)
 #
 # TLS options:
 #   1. Automatic TLS via Let's Encrypt (default)
@@ -76,8 +76,9 @@
 	admin off
 }
 
-# Site block - uses environment variable for domain, with fallback
-{$MAGPIE_DOMAIN:magpie.example.com} {
+# Site block - uses environment variable for domain (required)
+# WARNING: MAGPIE_DOMAIN must be set - Let's Encrypt will fail without a valid domain
+{$MAGPIE_DOMAIN} {
 	# =========================================================================
 	# TLS CONFIGURATION
 	# =========================================================================
@@ -110,8 +111,8 @@
 		Referrer-Policy "strict-origin-when-cross-origin"
 
 		# Content Security Policy - restrict resource loading
-		# Adjust as needed for your frontend requirements
-		Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
+		# API-only service: strict policy with no data URIs
+		Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self'; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
 
 		# Remove server identification headers
 		-Server
@@ -212,7 +213,12 @@
 	}
 
 	# Flush tag endpoint - requires admin scope
-	handle /api/v1/tags/* {
+	# Matches: POST /api/v1/tags/{tag_name}/flush
+	@tags_flush {
+		method POST
+		path /api/v1/tags/*/flush
+	}
+	handle @tags_flush {
 		forward_auth magpie:8000 {
 			uri /api/v1/auth/validate
 			copy_headers X-Magpie-User X-Magpie-Scope

--- a/Caddyfile.prod
+++ b/Caddyfile.prod
@@ -7,7 +7,6 @@
 # This configuration provides:
 # - TLS encryption (automatic via Let's Encrypt or manual certs)
 # - Security headers (HSTS, X-Content-Type-Options, X-Frame-Options, etc.)
-# - Rate limiting on authentication endpoints
 # - Access logging
 #
 # Environment variable configuration:
@@ -15,7 +14,8 @@
 #
 # TLS options:
 #   1. Automatic TLS via Let's Encrypt (default)
-#   2. Manual certificates: Set MAGPIE_TLS_CERT and MAGPIE_TLS_KEY paths
+#   2. Manual certificates: Edit the TLS block to specify cert/key paths
+#   3. Internal CA: Edit the TLS block to use 'tls internal'
 #
 # =============================================================================
 # AUTHENTICATION FLOW (forward_auth)
@@ -82,17 +82,12 @@
 	# TLS CONFIGURATION
 	# =========================================================================
 	#
-	# Option 1: Automatic TLS via Let's Encrypt (default)
-	# Just ensure the domain resolves to this server and port 443 is accessible.
-	#
-	# Option 2: Manual certificates - uncomment and set paths:
+	# TLS is automatic via Let's Encrypt by default.
+	# For manual certificates, uncomment and configure:
 	# tls /path/to/cert.pem /path/to/key.pem
 	#
-	# Option 3: Internal CA - for internal deployments:
+	# For internal CA (self-signed):
 	# tls internal
-	#
-	# For flexibility, check for environment variables:
-	tls {$MAGPIE_TLS_CERT:} {$MAGPIE_TLS_KEY:}
 
 	# =========================================================================
 	# SECURITY HEADERS
@@ -116,41 +111,30 @@
 
 		# Content Security Policy - restrict resource loading
 		# Adjust as needed for your frontend requirements
-		Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
+		Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
 
 		# Remove server identification headers
 		-Server
 	}
 
 	# =========================================================================
-	# RATE LIMITING
+	# RATE LIMITING NOTE
 	# =========================================================================
+	# Caddy's standard build does not include rate limiting. For production,
+	# implement rate limiting at the infrastructure layer (load balancer, WAF)
+	# or use a custom Caddy build with the rate-limit plugin.
+	# See issue #129 for implementation options.
 	#
-	# Rate limit authentication-related endpoints to prevent brute force attacks.
-	# Limits: 10 requests per second per client IP
-
+	# Auth endpoints that should be rate-limited:
 	@auth_endpoints {
 		path /api/v1/auth/*
 		path /api/v1/tokens*
-	}
-	rate_limit @auth_endpoints {
-		zone auth_zone {
-			key {remote_host}
-			events 10
-			window 1s
-		}
 	}
 
 	# =========================================================================
 	# ACCESS LOGGING
 	# =========================================================================
-
-	log {
-		output stdout
-		format json {
-			time_format iso8601
-		}
-	}
+	# Site-specific logging is handled by the global log block above.
 
 	# =========================================================================
 	# PUBLIC ROUTES - No authentication required

--- a/Caddyfile.prod
+++ b/Caddyfile.prod
@@ -125,7 +125,8 @@
 	# or use a custom Caddy build with the rate-limit plugin.
 	# See issue #129 for implementation options.
 	#
-	# Auth endpoints that should be rate-limited:
+	# Auth endpoints matcher - kept for documentation and future rate limiting.
+	# See issue #129 for rate limiting implementation options.
 	@auth_endpoints {
 		path /api/v1/auth/*
 		path /api/v1/tokens*

--- a/README.md
+++ b/README.md
@@ -40,16 +40,21 @@ The production configuration (`docker-compose.prod.yml` and `Caddyfile.prod`) in
 - Automatic TLS via Let's Encrypt (or manual certificate configuration)
 - Security headers (HSTS, X-Frame-Options, CSP, etc.)
 - JSON access logging
-- Rate limiting must be configured at infrastructure layer - see [issue #129](https://github.com/SouthwestCCDC/magpie/issues/129) for implementation options (custom Caddy build, FastAPI middleware, or load balancer)
+- Rate limiting must be configured at the infrastructure layer. See [issue #129](https://github.com/SouthwestCCDC/magpie/issues/129) for implementation options (custom Caddy build, FastAPI middleware, or load balancer).
 
 For manual TLS certificates, edit `Caddyfile.prod` and uncomment the `tls` directive
 with your certificate paths.
 
 **Let's Encrypt rate limits**: Let's Encrypt enforces a limit of 50 certificates per
-registered domain per week. For testing, use `tls internal` or staging endpoints to
-avoid exhausting your quota. The `caddy_data` volume stores issued certificates --
-persist this volume across container recreations to avoid requesting duplicate
-certificates.
+registered domain per week. For testing, use `tls internal` to generate self-signed
+certificates, or configure the Let's Encrypt staging environment in `Caddyfile.prod`:
+```
+tls {
+    ca https://acme-staging-v02.api.letsencrypt.org/directory
+}
+```
+The `caddy_data` volume stores issued certificates. Persist this volume across
+container recreations to avoid requesting duplicate certificates.
 
 ## Project Structure
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,31 @@ uv run magpie-ctl --help
 docker compose up --build
 ```
 
+## Production Deployment
+
+For production with TLS/HTTPS:
+
+```bash
+# Set required environment variables
+export MAGPIE_DOMAIN=magpie.example.com
+export MAGPIE_DATA_DIR=/path/to/persistent/storage
+
+# Start with production configuration
+docker compose -f docker-compose.prod.yml up -d
+```
+
+The production configuration (`docker-compose.prod.yml` and `Caddyfile.prod`) includes:
+- Automatic TLS via Let's Encrypt (or manual certificate configuration)
+- Security headers (HSTS, X-Frame-Options, CSP, etc.)
+- Rate limiting on authentication endpoints
+- JSON access logging
+
+For manual TLS certificates, also set:
+```bash
+export MAGPIE_TLS_CERT=/path/to/cert.pem
+export MAGPIE_TLS_KEY=/path/to/key.pem
+```
+
 ## Project Structure
 
 ```

--- a/README.md
+++ b/README.md
@@ -35,14 +35,11 @@ docker compose -f docker-compose.prod.yml up -d
 The production configuration (`docker-compose.prod.yml` and `Caddyfile.prod`) includes:
 - Automatic TLS via Let's Encrypt (or manual certificate configuration)
 - Security headers (HSTS, X-Frame-Options, CSP, etc.)
-- Rate limiting on authentication endpoints
 - JSON access logging
+- Rate limiting must be configured at infrastructure layer (see issue #129)
 
-For manual TLS certificates, also set:
-```bash
-export MAGPIE_TLS_CERT=/path/to/cert.pem
-export MAGPIE_TLS_KEY=/path/to/key.pem
-```
+For manual TLS certificates, edit `Caddyfile.prod` and uncomment the `tls` directive
+with your certificate paths.
 
 ## Project Structure
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The production configuration (`docker-compose.prod.yml` and `Caddyfile.prod`) in
 - Automatic TLS via Let's Encrypt (or manual certificate configuration)
 - Security headers (HSTS, X-Frame-Options, CSP, etc.)
 - JSON access logging
-- Rate limiting must be configured at infrastructure layer (see issue #129)
+- Rate limiting must be configured at infrastructure layer - see [issue #129](https://github.com/SouthwestCCDC/magpie/issues/129) for implementation options (custom Caddy build, FastAPI middleware, or load balancer)
 
 For manual TLS certificates, edit `Caddyfile.prod` and uncomment the `tls` directive
 with your certificate paths.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ export MAGPIE_DATA_DIR=/path/to/persistent/storage
 docker compose -f docker-compose.prod.yml up -d
 ```
 
+**Port conflicts**: The production configuration binds to ports 80 and 443. If other
+services (e.g., nginx, Apache, another Caddy instance) are using these ports, either
+stop them first or customize the port bindings in `docker-compose.prod.yml`.
+
 The production configuration (`docker-compose.prod.yml` and `Caddyfile.prod`) includes:
 - Automatic TLS via Let's Encrypt (or manual certificate configuration)
 - Security headers (HSTS, X-Frame-Options, CSP, etc.)
@@ -40,6 +44,12 @@ The production configuration (`docker-compose.prod.yml` and `Caddyfile.prod`) in
 
 For manual TLS certificates, edit `Caddyfile.prod` and uncomment the `tls` directive
 with your certificate paths.
+
+**Let's Encrypt rate limits**: Let's Encrypt enforces a limit of 50 certificates per
+registered domain per week. For testing, use `tls internal` or staging endpoints to
+avoid exhausting your quota. The `caddy_data` volume stores issued certificates --
+persist this volume across container recreations to avoid requesting duplicate
+certificates.
 
 ## Project Structure
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -48,6 +48,9 @@ services:
       - ALL
     cap_add:
       - NET_BIND_SERVICE  # Required for binding to ports 80/443
+    # Filesystem is read-only for security; writable paths use named volumes:
+    # - /data (caddy_data): TLS certificates and Let's Encrypt state
+    # - /config (caddy_config): Caddy runtime configuration
     read_only: true
     tmpfs:
       - /tmp
@@ -74,8 +77,13 @@ services:
     # Security hardening
     cap_drop:
       - ALL
+    # Filesystem is read-only for security; writable paths:
+    # - /data/artifacts: bind mount for artifact storage (includes database and lock file)
+    # - /run: tmpfs for entrypoint runtime files (magpie-user UID/GID marker)
+    # - /tmp: tmpfs for temporary files
     read_only: true
     tmpfs:
+      - /run
       - /tmp
 
 volumes:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,5 +1,7 @@
 # Magpie Artifact Storage - Production Docker Compose Configuration
 #
+# Requires Docker Compose v2.1+ (for healthcheck 'condition' support)
+#
 # This configuration is intended for production deployments with:
 # - TLS/HTTPS enabled via Caddyfile.prod
 # - Security hardening settings
@@ -13,8 +15,6 @@
 #   MAGPIE_DATA_DIR   - Host path for artifact storage (default: ./data/artifacts)
 #
 # Optional Environment Variables:
-#   MAGPIE_TLS_CERT   - Path to TLS certificate (for manual certs, leave empty for Let's Encrypt)
-#   MAGPIE_TLS_KEY    - Path to TLS private key (for manual certs)
 #   MAGPIE_HTTP_PORT  - External HTTP port (default: 80)
 #   MAGPIE_HTTPS_PORT - External HTTPS port (default: 443)
 #
@@ -38,8 +38,6 @@ services:
       - caddy_config:/config  # Caddy configuration
     environment:
       - MAGPIE_DOMAIN=${MAGPIE_DOMAIN:-magpie.example.com}
-      - MAGPIE_TLS_CERT=${MAGPIE_TLS_CERT:-}
-      - MAGPIE_TLS_KEY=${MAGPIE_TLS_KEY:-}
     depends_on:
       magpie:
         condition: service_healthy
@@ -61,7 +59,9 @@ services:
       - ${MAGPIE_DATA_DIR:-./data/artifacts}:/data/artifacts
     environment:
       - MAGPIE_STORAGE_PATH=/data/artifacts
-      - MAGPIE_DEBUG=false  # Disable debug mode in production
+      # IMPORTANT: Keep debug mode disabled in production. Enabling it exposes
+      # detailed error messages and stack traces that could leak sensitive info.
+      - MAGPIE_DEBUG=false
     expose:
       - "8000"  # Internal only - accessed via Caddy
     restart: unless-stopped

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -11,7 +11,7 @@
 #   docker compose -f docker-compose.prod.yml up -d
 #
 # Required Environment Variables:
-#   MAGPIE_DOMAIN     - The domain name for TLS (e.g., magpie.swccdc.com)
+#   MAGPIE_DOMAIN     - The domain name for TLS (REQUIRED - e.g., magpie.swccdc.com)
 #   MAGPIE_DATA_DIR   - Host path for artifact storage (default: ./data/artifacts)
 #
 # Optional Environment Variables:
@@ -37,7 +37,8 @@ services:
       - caddy_data:/data      # TLS certificates and state
       - caddy_config:/config  # Caddy configuration
     environment:
-      - MAGPIE_DOMAIN=${MAGPIE_DOMAIN:-magpie.example.com}
+      # MAGPIE_DOMAIN is required - Let's Encrypt will fail without a valid domain
+      - MAGPIE_DOMAIN=${MAGPIE_DOMAIN:?MAGPIE_DOMAIN must be set}
     depends_on:
       magpie:
         condition: service_healthy

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,83 @@
+# Magpie Artifact Storage - Production Docker Compose Configuration
+#
+# This configuration is intended for production deployments with:
+# - TLS/HTTPS enabled via Caddyfile.prod
+# - Security hardening settings
+# - Production-ready health checks
+#
+# Usage:
+#   docker compose -f docker-compose.prod.yml up -d
+#
+# Required Environment Variables:
+#   MAGPIE_DOMAIN     - The domain name for TLS (e.g., magpie.swccdc.com)
+#   MAGPIE_DATA_DIR   - Host path for artifact storage (default: ./data/artifacts)
+#
+# Optional Environment Variables:
+#   MAGPIE_TLS_CERT   - Path to TLS certificate (for manual certs, leave empty for Let's Encrypt)
+#   MAGPIE_TLS_KEY    - Path to TLS private key (for manual certs)
+#   MAGPIE_HTTP_PORT  - External HTTP port (default: 80)
+#   MAGPIE_HTTPS_PORT - External HTTPS port (default: 443)
+#
+# Note: For Let's Encrypt auto-TLS, ensure:
+# - Port 443 is publicly accessible
+# - MAGPIE_DOMAIN resolves to this server's IP
+# - No other service is using port 443
+
+services:
+  # Caddy reverse proxy - handles TLS, routing, and static file serving
+  # Uses Caddyfile.prod for production configuration
+  caddy:
+    image: caddy:2-alpine
+    ports:
+      - "${MAGPIE_HTTP_PORT:-80}:80"    # HTTP (redirects to HTTPS)
+      - "${MAGPIE_HTTPS_PORT:-443}:443"  # HTTPS
+    volumes:
+      - ./Caddyfile.prod:/etc/caddy/Caddyfile:ro
+      - ${MAGPIE_DATA_DIR:-./data/artifacts}:/data/artifacts:ro
+      - caddy_data:/data      # TLS certificates and state
+      - caddy_config:/config  # Caddy configuration
+    environment:
+      - MAGPIE_DOMAIN=${MAGPIE_DOMAIN:-magpie.example.com}
+      - MAGPIE_TLS_CERT=${MAGPIE_TLS_CERT:-}
+      - MAGPIE_TLS_KEY=${MAGPIE_TLS_KEY:-}
+    depends_on:
+      magpie:
+        condition: service_healthy
+    restart: unless-stopped
+    # Security: Run as non-root where possible (Caddy handles this internally)
+    # Limit capabilities for security
+    cap_drop:
+      - ALL
+    cap_add:
+      - NET_BIND_SERVICE  # Required for binding to ports 80/443
+    read_only: true
+    tmpfs:
+      - /tmp
+
+  # Magpie FastAPI service - handles API requests
+  magpie:
+    build: .
+    volumes:
+      - ${MAGPIE_DATA_DIR:-./data/artifacts}:/data/artifacts
+    environment:
+      - MAGPIE_STORAGE_PATH=/data/artifacts
+      - MAGPIE_DEBUG=false  # Disable debug mode in production
+    expose:
+      - "8000"  # Internal only - accessed via Caddy
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "python", "-c", "import httpx; httpx.get('http://localhost:8000/health').raise_for_status()"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
+    # Security hardening
+    cap_drop:
+      - ALL
+    read_only: true
+    tmpfs:
+      - /tmp
+
+volumes:
+  caddy_data:
+  caddy_config:


### PR DESCRIPTION
## Summary

- Add `Caddyfile.prod` with TLS/HTTPS configuration and security headers
- Add `docker-compose.prod.yml` for production deployments  
- Update README with production deployment instructions

Closes #105

## Changes

**Caddyfile.prod** - Production Caddy configuration with:
- TLS via Let's Encrypt (automatic) or manual certificate paths
- Security headers (HSTS, X-Content-Type-Options, X-Frame-Options, CSP, etc.)
- JSON access logging to stdout
- Admin API disabled
- Note: Rate limiting is not included in standard Caddy; see issue #129 for implementation options

**docker-compose.prod.yml** - Production compose file with:
- Standard ports 80/443
- Debug mode disabled
- Security hardening (cap_drop, read_only)

## Test plan

- [ ] Review Caddyfile.prod syntax
- [ ] Verify security headers configuration
- [ ] Test docker-compose.prod.yml deployment

Generated with Claude Code (Opus 4.5)