### PR TITLE
security: Set MAGPIE_DEBUG default to false

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
       - ${MAGPIE_DATA_DIR:-./data/artifacts}:/data/artifacts  # Read-write for uploads
     environment:
       - MAGPIE_STORAGE_PATH=/data/artifacts
-      - MAGPIE_DEBUG=true
+      - MAGPIE_DEBUG=${MAGPIE_DEBUG:-false}
     expose:
       - "8000"  # Internal only - accessed via Caddy
     restart: unless-stopped


### PR DESCRIPTION
## Summary

- Change `MAGPIE_DEBUG=true` to `MAGPIE_DEBUG=${MAGPIE_DEBUG:-false}` in docker-compose.yml
- Debug mode is now disabled by default, preventing exposure of stack traces and sensitive information in production
- Developers can still enable debug mode by setting `MAGPIE_DEBUG=true` in their environment

## Test plan

- [ ] Verify `docker-compose config` shows `MAGPIE_DEBUG=false` by default
- [ ] Verify setting `MAGPIE_DEBUG=true` environment variable enables debug mode
- [ ] Confirm application starts correctly with debug disabled

Closes #102

---
Generated with Claude Code (Opus 4.5)