### PR TITLE
Config: Add missing documented config settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,6 +58,33 @@
 # Default: false
 # MAGPIE_DEBUG=false
 
+# Maximum upload size in bytes (leave empty for no limit)
+# Example: 1073741824 for 1GB
+# MAGPIE_MAX_UPLOAD_SIZE=
+
+# =============================================================================
+# Garbage Collection
+# =============================================================================
+
+# Lock file path for GC operations (prevents concurrent GC runs)
+# Default: /var/run/magpie-gc.lock
+# MAGPIE_GC_LOCK_PATH=/var/run/magpie-gc.lock
+
+# =============================================================================
+# Logging
+# =============================================================================
+
+# Log format: "json" for structured JSON logs, "console" for human-readable
+# Default: console
+# MAGPIE_LOG_FORMAT=console
+
+# =============================================================================
+# Backup (Optional)
+# =============================================================================
+
+# S3 bucket name for artifact backup (leave empty to disable S3 backup)
+# MAGPIE_S3_BUCKET=
+
 # =============================================================================
 # Observability (Optional)
 # =============================================================================

--- a/src/magpie/config.py
+++ b/src/magpie/config.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import functools
 from pathlib import Path
-from typing import Self
+from typing import Literal, Self
 
 from pydantic import model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -29,6 +29,18 @@ class MagpieSettings(BaseSettings):
     database_path: Path | None = None
     retention_days: int = 90
     debug: bool = False
+
+    # GC settings
+    gc_lock_path: Path = Path("/var/run/magpie-gc.lock")  # MAGPIE_GC_LOCK_PATH
+
+    # Upload limits
+    max_upload_size: int | None = None  # MAGPIE_MAX_UPLOAD_SIZE (bytes)
+
+    # S3 backup settings (optional)
+    s3_bucket: str | None = None  # MAGPIE_S3_BUCKET
+
+    # Logging settings
+    log_format: Literal["json", "console"] = "console"  # MAGPIE_LOG_FORMAT
 
     # Observability settings
     sentry_dsn: str | None = None  # MAGPIE_SENTRY_DSN

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+from pydantic import ValidationError
 
 from magpie.config import MagpieSettings, get_settings
 
@@ -157,6 +158,12 @@ class TestMagpieSettingsEnvironmentOverride:
         monkeypatch.setenv("MAGPIE_LOG_FORMAT", "console")
         settings = MagpieSettings()
         assert settings.log_format == "console"
+
+    def test_log_format_invalid_value_rejected(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Invalid MAGPIE_LOG_FORMAT values should raise ValidationError."""
+        monkeypatch.setenv("MAGPIE_LOG_FORMAT", "invalid")
+        with pytest.raises(ValidationError):
+            MagpieSettings()
 
 
 class TestGetSettingsCaching:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -27,6 +27,26 @@ class TestMagpieSettingsDefaults:
         settings = MagpieSettings()
         assert settings.debug is False
 
+    def test_default_gc_lock_path(self) -> None:
+        """Default gc_lock_path should be /var/run/magpie-gc.lock."""
+        settings = MagpieSettings()
+        assert settings.gc_lock_path == Path("/var/run/magpie-gc.lock")
+
+    def test_default_max_upload_size_none(self) -> None:
+        """Default max_upload_size should be None (no limit)."""
+        settings = MagpieSettings()
+        assert settings.max_upload_size is None
+
+    def test_default_s3_bucket_none(self) -> None:
+        """Default s3_bucket should be None (disabled)."""
+        settings = MagpieSettings()
+        assert settings.s3_bucket is None
+
+    def test_default_log_format_console(self) -> None:
+        """Default log_format should be 'console'."""
+        settings = MagpieSettings()
+        assert settings.log_format == "console"
+
 
 class TestMagpieSettingsPathDerivation:
     """Tests for derived path computation."""
@@ -107,6 +127,36 @@ class TestMagpieSettingsEnvironmentOverride:
         settings = MagpieSettings()
         assert settings.temp_path == Path("/env/storage/.tmp")
         assert settings.database_path == Path("/env/storage/.magpie.db")
+
+    def test_gc_lock_path_env_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """MAGPIE_GC_LOCK_PATH env var should override default."""
+        monkeypatch.setenv("MAGPIE_GC_LOCK_PATH", "/custom/gc.lock")
+        settings = MagpieSettings()
+        assert settings.gc_lock_path == Path("/custom/gc.lock")
+
+    def test_max_upload_size_env_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """MAGPIE_MAX_UPLOAD_SIZE env var should override default."""
+        monkeypatch.setenv("MAGPIE_MAX_UPLOAD_SIZE", "1073741824")
+        settings = MagpieSettings()
+        assert settings.max_upload_size == 1073741824
+
+    def test_s3_bucket_env_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """MAGPIE_S3_BUCKET env var should override default."""
+        monkeypatch.setenv("MAGPIE_S3_BUCKET", "my-backup-bucket")
+        settings = MagpieSettings()
+        assert settings.s3_bucket == "my-backup-bucket"
+
+    def test_log_format_env_override_json(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """MAGPIE_LOG_FORMAT env var should accept 'json'."""
+        monkeypatch.setenv("MAGPIE_LOG_FORMAT", "json")
+        settings = MagpieSettings()
+        assert settings.log_format == "json"
+
+    def test_log_format_env_override_console(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """MAGPIE_LOG_FORMAT env var should accept 'console'."""
+        monkeypatch.setenv("MAGPIE_LOG_FORMAT", "console")
+        settings = MagpieSettings()
+        assert settings.log_format == "console"
 
 
 class TestGetSettingsCaching:


### PR DESCRIPTION
## Summary

- Add four config settings that were documented in design.md but not implemented in config.py:
  - `gc_lock_path`: Path for GC lock file (default: `/var/run/magpie-gc.lock`)
  - `max_upload_size`: Optional upload size limit in bytes
  - `s3_bucket`: Optional S3 bucket name for backup feature
  - `log_format`: Log output format, "json" or "console" (default: console)
- Update `.env.example` with documentation for the new settings
- Add unit tests for defaults and environment variable overrides

## Test plan

- [x] Unit tests pass (`uv run pytest tests/unit/ -x`)
- [x] Ruff check passes
- [x] Ruff format passes
- [ ] CI checks pass

Closes #114

---
Generated with Claude Code (Opus 4.5)