### PR TITLE
docs: Document timeout as CLI-only setting

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -453,6 +453,10 @@ token = "mgp_xxx..."
 
 Environment variables override file settings: `MAGPIE_SERVER`, `MAGPIE_TOKEN`.
 
+**Note:** `MAGPIE_TIMEOUT` is intentionally not read from the config file. It can only be
+set via CLI flag (`--timeout`) or environment variable. This prevents long-lived global
+configuration from silently affecting network behavior.
+
 ### Observability
 
 Observability covers three pillars: **structured logging**, **tracing**, and **metrics**. All server-side

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -66,6 +66,7 @@ Environment variables override config file values:
 |----------|-------------|---------|
 | `MAGPIE_SERVER` | Server URL | `https://magpie.example.com` |
 | `MAGPIE_TOKEN` | Authentication token | `mgp_abc123...` |
+| `MAGPIE_TIMEOUT` | Request timeout (see note below) | `600`, `5m`, `1h30m` |
 
 ### Configuration Precedence
 
@@ -73,6 +74,11 @@ Environment variables override config file values:
 2. Environment variables (`MAGPIE_SERVER`, `MAGPIE_TOKEN`)
 3. Config file (`~/.magpie/config.toml`)
 4. Defaults - lowest priority
+
+**Note:** The `--timeout` setting has a different precedence. It can only be set via
+CLI flag or the `MAGPIE_TIMEOUT` environment variable -- it is intentionally not read
+from the config file. This prevents long-lived global configuration from silently
+affecting network behavior. The default is 600 seconds (10 minutes).
 
 ### Getting a Token
 
@@ -424,6 +430,7 @@ The artifact was already stored; the existing hash was returned.
 |----------|-------|-------------|
 | `MAGPIE_SERVER` | Client | Server URL |
 | `MAGPIE_TOKEN` | Client | Auth token |
+| `MAGPIE_TIMEOUT` | Client | Request timeout (CLI/env only, not config file) |
 | `MAGPIE_HTTP_PORT` | Deploy | External HTTP port (default: 8080) |
 | `MAGPIE_HTTPS_PORT` | Deploy | External HTTPS port (default: 8443) |
 | `MAGPIE_STORAGE_PATH` | Server | Storage directory |


### PR DESCRIPTION
## Summary

- Document that `MAGPIE_TIMEOUT` has a different configuration precedence than `MAGPIE_SERVER` and `MAGPIE_TOKEN`
- Timeout is intentionally not read from the config file - only CLI flag or environment variable
- Add `MAGPIE_TIMEOUT` to environment variables tables in user-guide.md
- Add corresponding note to design.md Configuration section

Closes #111

## Test plan

- [ ] Review documentation changes for accuracy
- [ ] Verify timeout behavior matches documentation by testing with `--timeout` flag and `MAGPIE_TIMEOUT` env var

---
Generated with Claude Code (Claude Opus 4.5)