### PR TITLE
docs: Update user-guide.md download URL format

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -439,7 +439,8 @@ The artifact was already stored; the existing hash was returned.
 | GET | `/health` | Health check |
 | GET | `/api/v1/artifacts/{path}` | List versions |
 | GET | `/api/v1/artifacts/{path}/{ref}/info` | Get metadata |
-| GET | `/artifacts/{path}/{ref}` | Download file |
+| GET | `/artifacts/{path}/{tag}` | Download by tag |
+| GET | `/artifacts/{path}/blobs/{hash}` | Download by hash |
 
 **Protected (auth required):**
 


### PR DESCRIPTION
## Summary
- Fixed the API endpoints table to accurately document both download URL formats
- Tag-based downloads use `/artifacts/{path}/{tag}`
- Hash-based downloads use `/artifacts/{path}/blobs/{hash}`

The previous documentation showed a generic `/artifacts/{path}/{ref}` format which did not accurately represent the actual implementation.

## Test plan
- [x] Verified implementation in `src/magpie/server/routes/upload.py` (lines 94-96) confirms hash-based downloads use `/blobs/` path
- [x] Verified implementation in `src/magpie/cli/commands/url.py` (lines 82-89) confirms different URL formats for tags vs hashes
- [x] Verified curl examples in user-guide already show correct formats on lines 470 and 473-474
- [x] Confirmed config section already uses `[client]` (not `[default]`) on line 56

Fixes #110

---
Generated with [Claude Code](https://claude.ai/code) (Opus 4.5)