### PR TITLE
feat(deployment): Add GC scheduling configuration

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -1,0 +1,260 @@
+# Deployment Configuration
+
+This directory contains deployment configurations for Magpie services.
+
+## Garbage Collection Scheduling
+
+Magpie's garbage collection (GC) removes untagged blobs older than the retention
+period (default: 90 days). GC should run periodically to reclaim disk space.
+
+### Quick Start (systemd)
+
+```bash
+# Copy unit files
+sudo cp systemd/magpie-gc.service /etc/systemd/system/
+sudo cp systemd/magpie-gc.timer /etc/systemd/system/
+
+# Reload and enable
+sudo systemctl daemon-reload
+sudo systemctl enable --now magpie-gc.timer
+
+# Verify
+systemctl list-timers magpie-gc.timer
+```
+
+### Quick Start (cron)
+
+```bash
+# Copy cron configuration
+sudo cp cron/magpie-gc /etc/cron.d/
+sudo chmod 644 /etc/cron.d/magpie-gc
+
+# Verify (should show in cron logs)
+grep magpie-gc /var/log/syslog
+```
+
+## GC Scheduling Options
+
+### systemd Timer (Recommended)
+
+The systemd timer provides:
+- Persistent scheduling (runs missed jobs after reboot)
+- Randomized delay to reduce load spikes
+- Integration with journald for logging
+- Condition-based execution (skips if lock file exists)
+
+Files:
+- `systemd/magpie-gc.service` - Oneshot service that runs GC
+- `systemd/magpie-gc.timer` - Timer that triggers the service
+
+Default schedule: Daily at 2:00 AM with up to 30 minutes random delay.
+
+### cron (Alternative)
+
+For systems without systemd or where cron is preferred.
+
+File: `cron/magpie-gc`
+
+Default schedule: Daily at 2:00 AM.
+
+Uses `flock` to prevent concurrent runs.
+
+## Configuration
+
+### Retention Period
+
+The retention period determines how long untagged blobs are kept before becoming
+eligible for garbage collection. Tagged blobs are never deleted by GC.
+
+Configure via environment variable:
+
+```bash
+# In .env file or shell environment
+MAGPIE_RETENTION_DAYS=30
+```
+
+Or via command-line override:
+
+```bash
+magpie-ctl gc --retention-days 30
+```
+
+Recommended settings:
+- **High-churn environments** (CI/CD): 7-14 days
+- **Standard deployments**: 30-90 days (default: 90)
+- **Archival storage**: 180+ days
+
+Align your GC schedule with your retention period:
+- Shorter retention = more frequent GC (daily or multiple times per day)
+- Longer retention = less frequent GC (weekly)
+
+### Lock File
+
+The lock file (`MAGPIE_GC_LOCK_PATH`) prevents concurrent GC runs, which could
+cause race conditions or excessive resource usage.
+
+Default path: `/var/run/magpie-gc.lock`
+
+The systemd service uses `ConditionPathExists` to check the lock file before
+starting. The cron configuration uses `flock -n` for the same purpose.
+
+If GC is already running:
+- systemd: Service fails immediately (check `systemctl status magpie-gc`)
+- cron: `flock` exits silently with status 1
+
+To customize the lock path:
+
+```bash
+# In .env file
+MAGPIE_GC_LOCK_PATH=/var/lock/magpie-gc.lock
+```
+
+### Logging
+
+GC output goes to:
+- **systemd**: journald (`journalctl -u magpie-gc.service`)
+- **cron**: syslog via `logger` (`grep magpie-gc /var/log/syslog`)
+
+For JSON-formatted logs (useful for log aggregation):
+
+```bash
+# Direct execution
+magpie-ctl gc --json-output
+
+# Or configure MAGPIE_LOG_FORMAT=json globally
+```
+
+## Customization
+
+### Changing the Schedule
+
+**systemd** - Edit `/etc/systemd/system/magpie-gc.timer`:
+
+```ini
+[Timer]
+# Every 6 hours
+OnCalendar=*-*-* 00/6:00:00
+
+# Weekly on Sunday at 3 AM
+OnCalendar=Sun *-*-* 03:00:00
+
+# First day of each month at midnight
+OnCalendar=*-*-01 00:00:00
+```
+
+Then reload: `systemctl daemon-reload`
+
+**cron** - Edit `/etc/cron.d/magpie-gc`:
+
+```bash
+# Every 6 hours
+0 */6 * * * root flock -n ...
+
+# Weekly on Sunday at 3 AM
+0 3 * * 0 root flock -n ...
+```
+
+### Non-Docker Deployments
+
+If running Magpie directly (not via Docker Compose), update the ExecStart:
+
+**systemd**:
+```ini
+ExecStart=/usr/local/bin/magpie-ctl gc --quiet
+```
+
+**cron**:
+```bash
+0 2 * * * root flock -n $MAGPIE_GC_LOCK_PATH /usr/local/bin/magpie-ctl gc --quiet 2>&1 | logger -t magpie-gc
+```
+
+### Custom Storage Path
+
+If using a non-default storage path:
+
+```bash
+# Environment variable
+MAGPIE_STORAGE_PATH=/mnt/artifacts
+
+# Or in systemd service
+Environment=MAGPIE_STORAGE_PATH=/mnt/artifacts
+```
+
+## Monitoring
+
+### Check Timer Status (systemd)
+
+```bash
+# List all timers
+systemctl list-timers
+
+# Check specific timer
+systemctl status magpie-gc.timer
+
+# View last run and next scheduled
+systemctl list-timers magpie-gc.timer --all
+```
+
+### View GC Logs
+
+```bash
+# systemd
+journalctl -u magpie-gc.service
+journalctl -u magpie-gc.service --since "1 hour ago"
+journalctl -u magpie-gc.service -f  # Follow live
+
+# cron
+grep magpie-gc /var/log/syslog
+tail -f /var/log/syslog | grep magpie-gc
+```
+
+### Manual GC Run
+
+```bash
+# Via systemd
+sudo systemctl start magpie-gc.service
+
+# Direct (Docker)
+docker compose exec magpie magpie-ctl gc
+
+# Direct (non-Docker)
+magpie-ctl gc
+
+# Dry run (preview only)
+docker compose exec magpie magpie-ctl gc --dry-run
+```
+
+## Troubleshooting
+
+### GC Not Running
+
+1. Check timer is enabled: `systemctl is-enabled magpie-gc.timer`
+2. Check timer is active: `systemctl is-active magpie-gc.timer`
+3. Check for lock file: `ls -la /var/run/magpie-gc.lock`
+4. Check service logs: `journalctl -u magpie-gc.service -n 50`
+
+### Lock File Stuck
+
+If GC was interrupted, the lock file may remain:
+
+```bash
+# Check if GC is actually running
+pgrep -f "magpie-ctl gc"
+
+# If not running, remove stale lock
+sudo rm /var/run/magpie-gc.lock
+```
+
+### Permission Errors
+
+Ensure the service user can:
+- Read the storage directory
+- Write to the lock file path
+- Execute docker commands (if using Docker)
+
+For Docker deployments, the user running the cron/systemd service needs access
+to the Docker socket.
+
+---
+
+*Note: This documentation was generated with AI assistance (Claude Code w/ Opus 4.5).*

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -66,16 +66,21 @@ Uses `flock` to prevent concurrent runs.
 The retention period determines how long untagged blobs are kept before becoming
 eligible for garbage collection. Tagged blobs are never deleted by GC.
 
-Configure via environment variable:
+Configure via environment variable in your `.env` or `docker-compose.yml`:
 
 ```bash
-# In .env file or shell environment
+# In .env file (read by Docker Compose)
 MAGPIE_RETENTION_DAYS=30
 ```
 
-Or via command-line override:
+Or via command-line flag (recommended for one-off overrides):
 
 ```bash
+# For Docker deployments, use CLI flags rather than shell environment variables
+# (shell env vars are not passed into the container)
+docker compose run --rm magpie magpie-ctl gc --retention-days 30
+
+# Direct execution
 magpie-ctl gc --retention-days 30
 ```
 
@@ -90,10 +95,13 @@ Align your GC schedule with your retention period:
 
 ### Lock File
 
-The lock file (`MAGPIE_GC_LOCK_PATH`) prevents concurrent GC runs, which could
-cause race conditions or excessive resource usage.
+The lock file prevents concurrent GC runs, which could cause race conditions or
+excessive resource usage.
 
 Default path: `/var/run/magpie-gc.lock`
+
+**Note:** The `/var/run` directory (typically a symlink to `/run`) must exist
+and be writable by the user running GC. This is standard on most Linux systems.
 
 The systemd service uses `ConditionPathExists` to check the lock file before
 starting. The cron configuration uses `flock -n` for the same purpose.
@@ -102,12 +110,8 @@ If GC is already running:
 - systemd: Service fails immediately (check `systemctl status magpie-gc`)
 - cron: `flock` exits silently with status 1
 
-To customize the lock path:
-
-```bash
-# In .env file
-MAGPIE_GC_LOCK_PATH=/var/lock/magpie-gc.lock
-```
+To customize the lock path, edit the cron file's `LOCK_FILE` variable or the
+systemd service's `ExecStartPre`/`ExecStopPost`/`ConditionPathExists` lines.
 
 ### Logging
 
@@ -132,8 +136,8 @@ magpie-ctl gc --json-output
 
 ```ini
 [Timer]
-# Every 6 hours
-OnCalendar=*-*-* 00/6:00:00
+# Every 6 hours (at 00:00, 06:00, 12:00, 18:00)
+OnCalendar=*-*-* 0/6:00:00
 
 # Weekly on Sunday at 3 AM
 OnCalendar=Sun *-*-* 03:00:00
@@ -249,11 +253,16 @@ sudo rm /var/run/magpie-gc.lock
 
 Ensure the service user can:
 - Read the storage directory
-- Write to the lock file path
-- Execute docker commands (if using Docker)
+- Write to the lock file directory (`/var/run`)
+- Execute Docker commands (if using Docker)
 
 For Docker deployments, the user running the cron/systemd service needs access
-to the Docker socket.
+to the Docker socket. By default, the service runs as root. To run as a
+non-root user:
+
+1. Add the user to the `docker` group: `sudo usermod -aG docker <username>`
+2. Uncomment and set `User=<username>` in the systemd service file
+3. Ensure the lock file directory is writable by that user
 
 ---
 

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -169,7 +169,7 @@ ExecStart=/usr/local/bin/magpie-ctl gc --quiet
 
 **cron**:
 ```bash
-0 2 * * * root flock -n $MAGPIE_GC_LOCK_PATH /usr/local/bin/magpie-ctl gc --quiet 2>&1 | logger -t magpie-gc
+0 2 * * * root flock -n /var/run/magpie-gc.lock /usr/local/bin/magpie-ctl gc --quiet 2>&1 | logger -t magpie-gc
 ```
 
 ### Custom Storage Path

--- a/deployment/cron/magpie-gc
+++ b/deployment/cron/magpie-gc
@@ -9,32 +9,44 @@
 #
 # 2. Add to root's crontab:
 #    crontab -e
-#    # Then paste the cron line below (without the 'root' user field)
+#    # Then paste the command portion only, removing the 'root' user field.
+#    # User crontab format: minute hour day month weekday command
+#    # Example: 0 2 * * * flock -n /var/run/magpie-gc.lock docker compose ...
 #
 # Lock file prevents concurrent GC runs. If GC is already running,
 # flock will exit immediately with status 1 (no error logged).
+# The /var/run directory must exist and be writable by the cron user.
 
 # Environment variables (adjust paths as needed)
 SHELL=/bin/bash
 PATH=/usr/local/bin:/usr/bin:/bin
 MAGPIE_DIR=/opt/magpie
-MAGPIE_GC_LOCK_PATH=/var/run/magpie-gc.lock
+
+# Host-side lock file used by flock to prevent concurrent GC runs.
+LOCK_FILE=/var/run/magpie-gc.lock
 
 # Run GC daily at 2:00 AM
 # Format: minute hour day month weekday user command
 #
-# Docker Compose deployment:
-0 2 * * * root flock -n $MAGPIE_GC_LOCK_PATH docker compose -f $MAGPIE_DIR/docker-compose.yml exec -T magpie magpie-ctl gc --quiet 2>&1 | logger -t magpie-gc
+# Uses `docker compose run` so GC works even if the main `magpie` container is
+# stopped (e.g., during maintenance). Creates a temporary container with the
+# same configuration/volumes as the `magpie` service.
+0 2 * * * root flock -n $LOCK_FILE docker compose -f $MAGPIE_DIR/docker-compose.yml run --rm -T magpie magpie-ctl gc --quiet 2>&1 | logger -t magpie-gc
+
+# Alternative: Use `exec` into the running magpie container (requires container to be running)
+# 0 2 * * * root flock -n $LOCK_FILE docker compose -f $MAGPIE_DIR/docker-compose.yml exec -T magpie magpie-ctl gc --quiet 2>&1 | logger -t magpie-gc
 
 # Alternative: Direct execution (if not using Docker)
-# 0 2 * * * root flock -n $MAGPIE_GC_LOCK_PATH /usr/local/bin/magpie-ctl gc --quiet 2>&1 | logger -t magpie-gc
+# 0 2 * * * root flock -n $LOCK_FILE /usr/local/bin/magpie-ctl gc --quiet 2>&1 | logger -t magpie-gc
 
 # Alternative schedules:
 # Every 6 hours:
-# 0 */6 * * * root flock -n $MAGPIE_GC_LOCK_PATH docker compose -f $MAGPIE_DIR/docker-compose.yml exec -T magpie magpie-ctl gc --quiet 2>&1 | logger -t magpie-gc
+# 0 */6 * * * root flock -n $LOCK_FILE docker compose -f $MAGPIE_DIR/docker-compose.yml run --rm -T magpie magpie-ctl gc --quiet 2>&1 | logger -t magpie-gc
 #
 # Weekly on Sunday at 3 AM:
-# 0 3 * * 0 root flock -n $MAGPIE_GC_LOCK_PATH docker compose -f $MAGPIE_DIR/docker-compose.yml exec -T magpie magpie-ctl gc --quiet 2>&1 | logger -t magpie-gc
+# 0 3 * * 0 root flock -n $LOCK_FILE docker compose -f $MAGPIE_DIR/docker-compose.yml run --rm -T magpie magpie-ctl gc --quiet 2>&1 | logger -t magpie-gc
 
-# Custom retention period (override MAGPIE_RETENTION_DAYS):
-# 0 2 * * * root MAGPIE_RETENTION_DAYS=30 flock -n $MAGPIE_GC_LOCK_PATH docker compose -f $MAGPIE_DIR/docker-compose.yml exec -T magpie magpie-ctl gc --quiet 2>&1 | logger -t magpie-gc
+# Custom retention period (use CLI flag, not environment variable):
+# NOTE: Environment variables set in cron are not passed into the Docker container.
+# Use CLI flags instead, or configure retention in the container's .env file.
+# 0 2 * * * root flock -n $LOCK_FILE docker compose -f $MAGPIE_DIR/docker-compose.yml run --rm -T magpie magpie-ctl gc --retention-days 30 --quiet 2>&1 | logger -t magpie-gc

--- a/deployment/cron/magpie-gc
+++ b/deployment/cron/magpie-gc
@@ -1,0 +1,40 @@
+# Magpie Garbage Collection - Cron Configuration
+# Alternative to systemd timer for systems without systemd.
+#
+# Installation options:
+#
+# 1. Copy to /etc/cron.d/ (recommended):
+#    cp magpie-gc /etc/cron.d/
+#    chmod 644 /etc/cron.d/magpie-gc
+#
+# 2. Add to root's crontab:
+#    crontab -e
+#    # Then paste the cron line below (without the 'root' user field)
+#
+# Lock file prevents concurrent GC runs. If GC is already running,
+# flock will exit immediately with status 1 (no error logged).
+
+# Environment variables (adjust paths as needed)
+SHELL=/bin/bash
+PATH=/usr/local/bin:/usr/bin:/bin
+MAGPIE_DIR=/opt/magpie
+MAGPIE_GC_LOCK_PATH=/var/run/magpie-gc.lock
+
+# Run GC daily at 2:00 AM
+# Format: minute hour day month weekday user command
+#
+# Docker Compose deployment:
+0 2 * * * root flock -n $MAGPIE_GC_LOCK_PATH docker compose -f $MAGPIE_DIR/docker-compose.yml exec -T magpie magpie-ctl gc --quiet 2>&1 | logger -t magpie-gc
+
+# Alternative: Direct execution (if not using Docker)
+# 0 2 * * * root flock -n $MAGPIE_GC_LOCK_PATH /usr/local/bin/magpie-ctl gc --quiet 2>&1 | logger -t magpie-gc
+
+# Alternative schedules:
+# Every 6 hours:
+# 0 */6 * * * root flock -n $MAGPIE_GC_LOCK_PATH docker compose -f $MAGPIE_DIR/docker-compose.yml exec -T magpie magpie-ctl gc --quiet 2>&1 | logger -t magpie-gc
+#
+# Weekly on Sunday at 3 AM:
+# 0 3 * * 0 root flock -n $MAGPIE_GC_LOCK_PATH docker compose -f $MAGPIE_DIR/docker-compose.yml exec -T magpie magpie-ctl gc --quiet 2>&1 | logger -t magpie-gc
+
+# Custom retention period (override MAGPIE_RETENTION_DAYS):
+# 0 2 * * * root MAGPIE_RETENTION_DAYS=30 flock -n $MAGPIE_GC_LOCK_PATH docker compose -f $MAGPIE_DIR/docker-compose.yml exec -T magpie magpie-ctl gc --quiet 2>&1 | logger -t magpie-gc

--- a/deployment/systemd/magpie-gc.service
+++ b/deployment/systemd/magpie-gc.service
@@ -17,10 +17,14 @@
 [Unit]
 Description=Magpie Garbage Collection
 Documentation=https://github.com/SouthwestCCDC/magpie
-After=network.target
+After=network.target docker.service
+Requires=docker.service
 
 # Prevent concurrent GC runs
-# If GC is already running, this instance will fail immediately
+# If GC is already running, this instance will fail immediately.
+# NOTE: There is a small race window between condition check and lock creation;
+# for most use cases this is acceptable, but high-frequency triggers should use
+# flock-based locking instead.
 ConditionPathExists=!/var/run/magpie-gc.lock
 
 [Service]
@@ -31,15 +35,27 @@ ExecStartPre=/bin/sh -c 'echo $$ > /var/run/magpie-gc.lock'
 ExecStopPost=/bin/rm -f /var/run/magpie-gc.lock
 
 # Run GC via Docker Compose
-# Adjust the path to match your installation
+# Uses `docker compose run` so GC works even if the main `magpie` container is
+# stopped (e.g., during maintenance). Adjust path to match your installation.
 WorkingDirectory=/opt/magpie
-ExecStart=/usr/bin/docker compose exec -T magpie magpie-ctl gc --quiet
+ExecStart=/usr/bin/docker compose run --rm -T magpie magpie-ctl gc --quiet
+
+# Alternative: Use `exec` into the running magpie container instead of `run`.
+# NOTE: This requires the `magpie` container to already be running; GC will
+# fail if the service is stopped when this unit triggers.
+# ExecStart=/usr/bin/docker compose exec -T magpie magpie-ctl gc --quiet
 
 # Alternative: Direct execution (if not using Docker)
 # ExecStart=/usr/local/bin/magpie-ctl gc --quiet
 
+# User configuration (optional)
+# By default, this service runs as root. To run as a different user, uncomment
+# and set User= to a user with Docker socket access (typically in 'docker' group).
+# User=magpie
+
 # Environment overrides (optional)
-# Uncomment and adjust as needed:
+# NOTE: For Docker deployments, these environment variables are passed to the
+# container. Alternatively, use CLI flags (e.g., --retention-days 30).
 # Environment=MAGPIE_RETENTION_DAYS=30
 # Environment=MAGPIE_STORAGE_PATH=/data/artifacts
 
@@ -54,8 +70,8 @@ ProtectSystem=strict
 ProtectHome=true
 PrivateTmp=true
 
-# Allow write access to storage and lock file
-ReadWritePaths=/var/run/magpie-gc.lock
+# Allow write access to lock file directory (/var/run is typically a symlink to /run)
+ReadWritePaths=/var/run
 # If using direct execution, also add:
 # ReadWritePaths=/data/artifacts
 

--- a/deployment/systemd/magpie-gc.service
+++ b/deployment/systemd/magpie-gc.service
@@ -54,8 +54,11 @@ ExecStart=/usr/bin/docker compose run --rm -T magpie magpie-ctl gc --quiet
 # User=magpie
 
 # Environment overrides (optional)
-# NOTE: For Docker deployments, these environment variables are passed to the
-# container. Alternatively, use CLI flags (e.g., --retention-days 30).
+# NOTE: For Docker deployments using `docker compose run`, these environment
+# variables are NOT passed to the container. Configure settings in the
+# container's .env file or docker-compose.yml, or use CLI flags instead
+# (e.g., --retention-days 30). These Environment= lines only apply when
+# using direct execution (non-Docker).
 # Environment=MAGPIE_RETENTION_DAYS=30
 # Environment=MAGPIE_STORAGE_PATH=/data/artifacts
 

--- a/deployment/systemd/magpie-gc.service
+++ b/deployment/systemd/magpie-gc.service
@@ -1,0 +1,64 @@
+# Magpie Garbage Collection Service
+# This oneshot service runs magpie-ctl gc to clean up untagged blobs.
+# Triggered by magpie-gc.timer (recommended) or can be run manually.
+#
+# Installation:
+#   cp magpie-gc.service /etc/systemd/system/
+#   cp magpie-gc.timer /etc/systemd/system/
+#   systemctl daemon-reload
+#   systemctl enable --now magpie-gc.timer
+#
+# Manual run:
+#   systemctl start magpie-gc.service
+#
+# View logs:
+#   journalctl -u magpie-gc.service
+
+[Unit]
+Description=Magpie Garbage Collection
+Documentation=https://github.com/SouthwestCCDC/magpie
+After=network.target
+
+# Prevent concurrent GC runs
+# If GC is already running, this instance will fail immediately
+ConditionPathExists=!/var/run/magpie-gc.lock
+
+[Service]
+Type=oneshot
+
+# Create lock file before starting, remove on exit
+ExecStartPre=/bin/sh -c 'echo $$ > /var/run/magpie-gc.lock'
+ExecStopPost=/bin/rm -f /var/run/magpie-gc.lock
+
+# Run GC via Docker Compose
+# Adjust the path to match your installation
+WorkingDirectory=/opt/magpie
+ExecStart=/usr/bin/docker compose exec -T magpie magpie-ctl gc --quiet
+
+# Alternative: Direct execution (if not using Docker)
+# ExecStart=/usr/local/bin/magpie-ctl gc --quiet
+
+# Environment overrides (optional)
+# Uncomment and adjust as needed:
+# Environment=MAGPIE_RETENTION_DAYS=30
+# Environment=MAGPIE_STORAGE_PATH=/data/artifacts
+
+# Logging
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=magpie-gc
+
+# Security hardening
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+
+# Allow write access to storage and lock file
+ReadWritePaths=/var/run/magpie-gc.lock
+# If using direct execution, also add:
+# ReadWritePaths=/data/artifacts
+
+# Timeouts
+# GC can take a while for large storage; adjust as needed
+TimeoutStartSec=3600

--- a/deployment/systemd/magpie-gc.timer
+++ b/deployment/systemd/magpie-gc.timer
@@ -24,7 +24,10 @@ Documentation=https://github.com/SouthwestCCDC/magpie
 OnCalendar=*-*-* 02:00:00
 
 # Randomize start time within 30 minutes to reduce load spikes
-# (useful if running multiple Magpie instances)
+# (useful if running multiple Magpie instances on shared infrastructure).
+# For single-instance deployments, you may reduce or remove this delay:
+#   RandomizedDelaySec=0      # Exact scheduling
+#   RandomizedDelaySec=300    # 5-minute window
 RandomizedDelaySec=1800
 
 # Run immediately if the scheduled time was missed

--- a/deployment/systemd/magpie-gc.timer
+++ b/deployment/systemd/magpie-gc.timer
@@ -1,0 +1,38 @@
+# Magpie Garbage Collection Timer
+# Triggers magpie-gc.service on a schedule.
+#
+# Default: Daily at 2:00 AM (local time)
+#
+# Installation:
+#   cp magpie-gc.service /etc/systemd/system/
+#   cp magpie-gc.timer /etc/systemd/system/
+#   systemctl daemon-reload
+#   systemctl enable --now magpie-gc.timer
+#
+# Check timer status:
+#   systemctl list-timers magpie-gc.timer
+#
+# View next scheduled run:
+#   systemctl status magpie-gc.timer
+
+[Unit]
+Description=Magpie Garbage Collection Timer
+Documentation=https://github.com/SouthwestCCDC/magpie
+
+[Timer]
+# Run daily at 2:00 AM
+OnCalendar=*-*-* 02:00:00
+
+# Randomize start time within 30 minutes to reduce load spikes
+# (useful if running multiple Magpie instances)
+RandomizedDelaySec=1800
+
+# Run immediately if the scheduled time was missed
+# (e.g., system was powered off at 2 AM)
+Persistent=true
+
+# Accuracy: allow systemd to batch with other timers
+AccuracySec=60
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary

- Add systemd timer and service files for scheduled garbage collection
- Add cron configuration as an alternative for non-systemd systems
- Add comprehensive deployment documentation with installation, configuration, and troubleshooting guidance

Fixes #123

## Components

| File | Purpose |
|------|---------|
| `deployment/systemd/magpie-gc.service` | Oneshot service that runs `magpie-ctl gc` with lock file protection |
| `deployment/systemd/magpie-gc.timer` | Timer unit (daily at 2 AM with 30min random delay) |
| `deployment/cron/magpie-gc` | Alternative cron configuration using `flock` for locking |
| `deployment/README.md` | Documentation for GC scheduling setup and configuration |

## Key Features

- **Lock file protection**: Prevents concurrent GC runs via `MAGPIE_GC_LOCK_PATH` (systemd uses `ConditionPathExists`, cron uses `flock`)
- **Flexible scheduling**: Default daily at 2 AM; documented alternatives for 6-hourly, weekly, etc.
- **Retention alignment guidance**: Documents how to align GC schedule with `MAGPIE_RETENTION_DAYS`
- **Docker support**: Examples for both Docker Compose and direct installation
- **Logging integration**: Output to journald (systemd) or syslog (cron)

## Test Plan

- [ ] Verify systemd unit files pass `systemd-analyze verify`
- [ ] Test systemd timer installation on a test system
- [ ] Verify cron configuration syntax is valid
- [ ] Review documentation for completeness

Generated with [Claude Code](https://claude.ai/code) (Opus 4.5)