### PR TITLE
fix(security): Prevent symlink attacks in artifact paths

### DIFF
--- a/src/magpie/storage/paths.py
+++ b/src/magpie/storage/paths.py
@@ -86,25 +86,58 @@ def verify_path_is_descendant(base: Path, artifact_path: str) -> Path:
         >>> verify_path_is_descendant(base, "project/artifact")
         PosixPath('/storage/artifacts/project/artifact')
     """
-    # Construct the full path and resolve symlinks.
-    # Handle OSError for cyclic symlinks (ELOOP: "Too many levels of symbolic links").
+    # Resolve base path first (must exist)
     try:
-        full_path = (base / artifact_path).resolve()
-        base_resolved = base.resolve()
+        base_resolved = base.resolve(strict=True)
+    except OSError as e:
+        raise InvalidArtifactPathError(f"Base path cannot be resolved: {e}")
+
+    # Walk through each segment of the artifact path and verify that
+    # any existing symlinks don't escape the base directory.
+    # This catches both symlink escapes AND cyclic symlinks.
+    current_path = base_resolved
+    segments = artifact_path.split("/") if artifact_path else []
+
+    for segment in segments:
+        current_path = current_path / segment
+
+        # If this component exists, resolve it strictly to detect:
+        # 1. Symlinks that escape the base directory
+        # 2. Cyclic symlinks (will raise OSError with ELOOP)
+        if current_path.exists() or current_path.is_symlink():
+            try:
+                resolved = current_path.resolve(strict=True)
+            except OSError as e:
+                # ELOOP (cyclic symlinks) or other resolution errors
+                raise InvalidArtifactPathError(f"Path '{artifact_path}' cannot be resolved: {e}")
+
+            # Verify the resolved path stays within base
+            try:
+                resolved.relative_to(base_resolved)
+            except ValueError:
+                raise InvalidArtifactPathError(
+                    f"Path '{artifact_path}' resolves outside the storage directory"
+                )
+
+    # Final path construction (may include non-existent components)
+    full_path = base_resolved / artifact_path
+
+    # For non-existent paths, also check using non-strict resolve to catch
+    # ".." segments that could escape the base directory
+    try:
+        resolved_full = full_path.resolve(strict=False)
     except OSError as e:
         raise InvalidArtifactPathError(f"Path '{artifact_path}' cannot be resolved: {e}")
 
-    # Check if the resolved path is under the base directory
-    # Using is_relative_to() which returns True if path is relative to base
     try:
-        full_path.relative_to(base_resolved)
+        resolved_full.relative_to(base_resolved)
     except ValueError:
         raise InvalidArtifactPathError(
             f"Path '{artifact_path}' resolves outside the storage directory"
         )
 
     # Additional check: ensure it's not the base directory itself
-    if full_path == base_resolved:
+    if resolved_full == base_resolved:
         raise InvalidArtifactPathError("Artifact path cannot resolve to storage root")
 
     return full_path

--- a/src/magpie/storage/paths.py
+++ b/src/magpie/storage/paths.py
@@ -92,9 +92,7 @@ def verify_path_is_descendant(base: Path, artifact_path: str) -> Path:
         full_path = (base / artifact_path).resolve()
         base_resolved = base.resolve()
     except OSError as e:
-        raise InvalidArtifactPathError(
-            f"Path '{artifact_path}' cannot be resolved: {e}"
-        )
+        raise InvalidArtifactPathError(f"Path '{artifact_path}' cannot be resolved: {e}")
 
     # Check if the resolved path is under the base directory
     # Using is_relative_to() which returns True if path is relative to base

--- a/src/magpie/storage/paths.py
+++ b/src/magpie/storage/paths.py
@@ -109,17 +109,41 @@ def verify_path_is_descendant(base: Path, artifact_path: str) -> Path:
 RESERVED_SEGMENTS = {"blobs", "metadata", ".magpie"}
 
 
-def artifact_dir_path(base: Path, artifact_path: str) -> Path:
+def artifact_dir_path(base: Path, artifact_path: str, verify_security: bool = True) -> Path:
     """Construct artifact directory path from base and artifact path.
+
+    Security: By default, this function verifies that the resolved path remains
+    within the storage base directory. This protects against symlink attacks
+    where a symlink inside storage could point to files outside storage.
 
     Args:
         base: Base storage directory path.
         artifact_path: Logical artifact path (e.g., "project/component/artifact").
+        verify_security: If True (default), verify resolved path stays within base.
+            Set to False only for trusted internal operations that don't need
+            symlink protection.
 
     Returns:
         Full path to artifact directory.
+
+    Raises:
+        InvalidArtifactPathError: If verify_security is True and the resolved
+            path would escape the base directory (e.g., via symlink).
     """
-    return base / artifact_path
+    result = base / artifact_path
+    if verify_security:
+        # Use resolve() to follow any symlinks and verify final path is within base.
+        # This protects against symlink attacks where storage/escape_link -> /etc
+        # would allow reading/writing files outside the storage directory.
+        resolved = result.resolve()
+        base_resolved = base.resolve()
+        try:
+            resolved.relative_to(base_resolved)
+        except ValueError:
+            raise InvalidArtifactPathError(
+                f"Path '{artifact_path}' resolves outside the storage directory"
+            )
+    return result
 
 
 def blob_path(artifact_dir: Path, hash_ref: str) -> Path:

--- a/src/magpie/storage/paths.py
+++ b/src/magpie/storage/paths.py
@@ -87,6 +87,18 @@ def verify_path_is_descendant(base: Path, artifact_path: str) -> Path:
         >>> base = Path("/storage/artifacts")
         >>> verify_path_is_descendant(base, "project/artifact")
         PosixPath('/storage/artifacts/project/artifact')
+
+    Performance note:
+        This function performs segment-by-segment symlink resolution, which
+        involves multiple filesystem operations (exists/is_symlink checks and
+        resolve calls) for each path component. For deeply nested paths, this
+        adds some overhead to each artifact operation. The alternative (resolving
+        the full path once and checking containment) is not sufficient because
+        it would miss symlinks in intermediate directories that escape and then
+        return to the base directory. The current approach ensures that no
+        symlink in the path ever escapes, even temporarily, which provides
+        stronger security guarantees. In typical usage with paths of 3-5
+        segments, the overhead is negligible.
     """
     # Resolve base path first (must exist)
     try:
@@ -284,7 +296,7 @@ def validate_artifact_path(artifact_path: str) -> None:
             raise InvalidArtifactPathError("Path segments cannot start with '.'")
 
 
-def check_artifact_nesting(base: Path, artifact_path: str) -> None:
+def check_artifact_nesting(base: Path, artifact_path: str, verify_security: bool = True) -> None:
     """Check that artifact path does not nest with existing artifacts.
 
     Prevents creating artifacts that:
@@ -303,11 +315,15 @@ def check_artifact_nesting(base: Path, artifact_path: str) -> None:
     Args:
         base: Base storage directory path.
         artifact_path: Logical artifact path to check.
+        verify_security: If True (default), verify the resolved path stays within
+            base via symlink-aware validation. Set to False only when the caller
+            will perform security verification separately to avoid redundant
+            filesystem operations.
 
     Raises:
         InvalidArtifactPathError: If path would nest with existing artifacts.
     """
-    proposed_dir = artifact_dir_path(base, artifact_path)
+    proposed_dir = artifact_dir_path(base, artifact_path, verify_security=verify_security)
 
     # Check if proposed path is a child of an existing artifact
     # (test/myartifact/nested when test/myartifact exists)

--- a/src/magpie/storage/paths.py
+++ b/src/magpie/storage/paths.py
@@ -75,7 +75,9 @@ def verify_path_is_descendant(base: Path, artifact_path: str) -> Path:
         artifact_path: Normalized artifact path string (no ".." segments).
 
     Returns:
-        The resolved full path if it is a valid descendant.
+        The unresolved (logical) path after verifying that any existing symlinks
+        in the path do not escape the base directory. Returns ``base / artifact_path``
+        rather than a resolved path, since the artifact may not exist yet.
 
     Raises:
         InvalidArtifactPathError: If the resolved path escapes the base directory,

--- a/src/magpie/storage/paths.py
+++ b/src/magpie/storage/paths.py
@@ -78,16 +78,23 @@ def verify_path_is_descendant(base: Path, artifact_path: str) -> Path:
         The resolved full path if it is a valid descendant.
 
     Raises:
-        InvalidArtifactPathError: If the resolved path escapes the base directory.
+        InvalidArtifactPathError: If the resolved path escapes the base directory,
+            or if the path contains cyclic symlinks.
 
     Example:
         >>> base = Path("/storage/artifacts")
         >>> verify_path_is_descendant(base, "project/artifact")
         PosixPath('/storage/artifacts/project/artifact')
     """
-    # Construct the full path
-    full_path = (base / artifact_path).resolve()
-    base_resolved = base.resolve()
+    # Construct the full path and resolve symlinks.
+    # Handle OSError for cyclic symlinks (ELOOP: "Too many levels of symbolic links").
+    try:
+        full_path = (base / artifact_path).resolve()
+        base_resolved = base.resolve()
+    except OSError as e:
+        raise InvalidArtifactPathError(
+            f"Path '{artifact_path}' cannot be resolved: {e}"
+        )
 
     # Check if the resolved path is under the base directory
     # Using is_relative_to() which returns True if path is relative to base
@@ -119,30 +126,44 @@ def artifact_dir_path(base: Path, artifact_path: str, verify_security: bool = Tr
     Args:
         base: Base storage directory path.
         artifact_path: Logical artifact path (e.g., "project/component/artifact").
-        verify_security: If True (default), verify resolved path stays within base.
-            Set to False only for trusted internal operations that don't need
-            symlink protection.
+        verify_security: If True (default), verify the resolved path (following
+            symlinks) stays within ``base``. This must remain enabled for any
+            path derived from user input or external callers.
+
+            Set to False only for trusted internal operations that:
+
+            * never accept untrusted/user-supplied paths, and
+            * operate on paths that have already been validated and persisted
+              (for example, paths recovered from an internal index or metadata
+              store that was created using :func:`verify_path_is_descendant`).
+
+            Example (internal maintenance job)::
+
+                base = Path("/var/lib/magpie/storage")
+                # 'stored_path' is read from Magpie's own metadata and was
+                # originally created via normalize_artifact_path() and
+                # verify_path_is_descendant(), not from user input.
+                stored_path = "project/component/artifact"
+                artifact_dir_path(base, stored_path, verify_security=False)
+                # Returns: PosixPath('/var/lib/magpie/storage/project/component/artifact')
+
+            Do not disable security checks for raw request parameters or CLI
+            arguments.
 
     Returns:
         Full path to artifact directory.
 
     Raises:
         InvalidArtifactPathError: If verify_security is True and the resolved
-            path would escape the base directory (e.g., via symlink).
+            path would escape the base directory (e.g., via symlink), or if
+            the path contains cyclic symlinks.
     """
     result = base / artifact_path
     if verify_security:
-        # Use resolve() to follow any symlinks and verify final path is within base.
-        # This protects against symlink attacks where storage/escape_link -> /etc
-        # would allow reading/writing files outside the storage directory.
-        resolved = result.resolve()
-        base_resolved = base.resolve()
-        try:
-            resolved.relative_to(base_resolved)
-        except ValueError:
-            raise InvalidArtifactPathError(
-                f"Path '{artifact_path}' resolves outside the storage directory"
-            )
+        # Delegate security verification to shared helper to avoid duplication.
+        # This will raise InvalidArtifactPathError if the resolved path escapes base
+        # or if there are cyclic symlinks.
+        verify_path_is_descendant(base, artifact_path)
     return result
 
 

--- a/src/magpie/storage/service.py
+++ b/src/magpie/storage/service.py
@@ -95,11 +95,12 @@ class StorageService:
         # Validate artifact path for reserved names
         validate_artifact_path(artifact_path)
 
-        # Check for nesting conflicts with existing artifacts
-        # Note: artifact_dir_path (called by check_artifact_nesting and below)
-        # performs security verification via verify_path_is_descendant internally
-        check_artifact_nesting(self.config.storage_path, artifact_path)
+        # Check for nesting conflicts with existing artifacts.
+        # Skip security verification here since artifact_dir_path below will
+        # perform it; this avoids redundant segment-by-segment symlink resolution.
+        check_artifact_nesting(self.config.storage_path, artifact_path, verify_security=False)
 
+        # Security verification happens here via verify_path_is_descendant
         artifact_dir = artifact_dir_path(self.config.storage_path, artifact_path)
 
         # Store blob (handles streaming and hashing)

--- a/src/magpie/storage/service.py
+++ b/src/magpie/storage/service.py
@@ -22,7 +22,6 @@ from magpie.storage.paths import (
     artifact_dir_path,
     check_artifact_nesting,
     validate_artifact_path,
-    verify_path_is_descendant,
 )
 from magpie.storage.symlinks import reconcile_symlinks
 from magpie.validation import validate_tag_name
@@ -96,10 +95,9 @@ class StorageService:
         # Validate artifact path for reserved names
         validate_artifact_path(artifact_path)
 
-        # Defense-in-depth: verify resolved path stays within storage directory
-        verify_path_is_descendant(self.config.storage_path, artifact_path)
-
         # Check for nesting conflicts with existing artifacts
+        # Note: artifact_dir_path (called by check_artifact_nesting and below)
+        # performs security verification via verify_path_is_descendant internally
         check_artifact_nesting(self.config.storage_path, artifact_path)
 
         artifact_dir = artifact_dir_path(self.config.storage_path, artifact_path)

--- a/tests/security/test_injection.py
+++ b/tests/security/test_injection.py
@@ -18,6 +18,8 @@ AI-assisted: Generated with Claude Code (Opus 4.5).
 from __future__ import annotations
 
 import io
+import shutil
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -238,9 +240,6 @@ class TestSymlinkAttacks:
         including any symlinks, would escape the storage directory, and rejects
         such paths.
         """
-        import shutil
-        import tempfile
-
         storage_base = test_storage_service.config.storage_path
 
         # Create target directory OUTSIDE the storage root
@@ -293,9 +292,6 @@ class TestSymlinkAttacks:
         Tests that attempting to read artifact info through a symlink that
         escapes the storage directory is rejected.
         """
-        import shutil
-        import tempfile
-
         storage_base = test_storage_service.config.storage_path
 
         # Create target directory OUTSIDE the storage root with some content
@@ -338,9 +334,6 @@ class TestSymlinkAttacks:
         Tests that symlinks anywhere in the artifact path (not just at the root)
         are detected and rejected.
         """
-        import shutil
-        import tempfile
-
         storage_base = test_storage_service.config.storage_path
 
         # Create a legitimate top-level directory
@@ -381,6 +374,53 @@ class TestSymlinkAttacks:
             # Clean up the symlink and the outside temp directory
             symlink_path.unlink(missing_ok=True)
             shutil.rmtree(outside_temp, ignore_errors=True)
+
+    def test_cyclic_symlink_rejected(
+        self, client: TestClient, test_storage_service: StorageService
+    ) -> None:
+        """Cyclic symlinks should be rejected with a clear error message.
+
+        Tests that symlinks forming a cycle (A -> B -> A) are detected
+        and rejected rather than causing infinite loops or crashes.
+        """
+        storage_base = test_storage_service.config.storage_path
+
+        # Create a directory for the cyclic symlinks
+        cycle_dir = storage_base / "cycle_test"
+        cycle_dir.mkdir(parents=True, exist_ok=True)
+
+        symlink_a = cycle_dir / "link_a"
+        symlink_b = cycle_dir / "link_b"
+
+        try:
+            # Create cyclic symlinks: A -> B -> A
+            symlink_a.symlink_to(symlink_b)
+            symlink_b.symlink_to(symlink_a)
+        except OSError:
+            shutil.rmtree(cycle_dir, ignore_errors=True)
+            pytest.skip("Cannot create symlinks on this system")
+
+        try:
+            # Try to upload through the cyclic symlink
+            content = b"test content"
+            files = {"file": ("test.bin", io.BytesIO(content), "application/octet-stream")}
+
+            response = client.post(
+                "/api/v1/upload/cycle_test/link_a/artifact",
+                files=files,
+            )
+
+            # The upload should be rejected due to cyclic symlink
+            # OSError with ELOOP is caught and converted to InvalidArtifactPathError
+            assert response.status_code == 400, (
+                f"Expected 400 for cyclic symlink, got {response.status_code}: {response.text}"
+            )
+            assert "cannot be resolved" in response.text.lower()
+        finally:
+            # Clean up the symlinks
+            symlink_a.unlink(missing_ok=True)
+            symlink_b.unlink(missing_ok=True)
+            shutil.rmtree(cycle_dir, ignore_errors=True)
 
     def test_double_dot_path_normalized_by_http(self, client: TestClient) -> None:
         """Double dot (..) in URL path is normalized by HTTP framework.

--- a/tests/security/test_injection.py
+++ b/tests/security/test_injection.py
@@ -234,8 +234,9 @@ class TestSymlinkAttacks:
     ) -> None:
         """Symlinks in artifact paths should not allow escaping storage root.
 
-        The verify_path_is_descendant function uses resolve() to detect when
-        symlinks would escape the storage directory, and rejects such paths.
+        The artifact_dir_path() helper uses resolve() to detect when a path,
+        including any symlinks, would escape the storage directory, and rejects
+        such paths.
         """
         import shutil
         import tempfile

--- a/tests/security/test_injection.py
+++ b/tests/security/test_injection.py
@@ -18,7 +18,6 @@ AI-assisted: Generated with Claude Code (Opus 4.5).
 from __future__ import annotations
 
 import io
-import shutil
 import tempfile
 from pathlib import Path
 
@@ -242,47 +241,45 @@ class TestSymlinkAttacks:
         """
         storage_base = test_storage_service.config.storage_path
 
-        # Create target directory OUTSIDE the storage root
-        # We need a separate temp directory, not a subdirectory of storage_base
-        outside_temp = Path(tempfile.mkdtemp(prefix="magpie_symlink_test_outside_"))
-        target_path = outside_temp / "escape_target"
-        target_path.mkdir(parents=True, exist_ok=True)
+        # Create target directory OUTSIDE the storage root using context manager
+        # to ensure cleanup even on test failures
+        with tempfile.TemporaryDirectory(prefix="magpie_symlink_test_outside_") as outside_temp:
+            target_path = Path(outside_temp) / "escape_target"
+            target_path.mkdir(parents=True, exist_ok=True)
 
-        # Create a symlink inside storage pointing outside
-        symlink_path = storage_base / "escape_link"
+            # Create a symlink inside storage pointing outside
+            symlink_path = storage_base / "escape_link"
 
-        try:
-            symlink_path.symlink_to(target_path)
-        except OSError:
-            shutil.rmtree(outside_temp, ignore_errors=True)
-            pytest.skip("Cannot create symlinks on this system")
+            try:
+                symlink_path.symlink_to(target_path)
+            except OSError:
+                pytest.skip("Cannot create symlinks on this system")
 
-        try:
-            # Try to upload through the symlink
-            content = b"test content"
-            files = {"file": ("test.bin", io.BytesIO(content), "application/octet-stream")}
+            try:
+                # Try to upload through the symlink
+                content = b"test content"
+                files = {"file": ("test.bin", io.BytesIO(content), "application/octet-stream")}
 
-            response = client.post(
-                "/api/v1/upload/escape_link/artifact",
-                files=files,
-            )
+                response = client.post(
+                    "/api/v1/upload/escape_link/artifact",
+                    files=files,
+                )
 
-            # The upload should be rejected because the symlink escapes storage root
-            assert response.status_code == 400, (
-                f"Expected 400 for symlink escape attempt, got {response.status_code}: "
-                f"{response.text}"
-            )
-            assert "resolves outside" in response.text.lower()
+                # The upload should be rejected because the symlink escapes storage root
+                assert response.status_code == 400, (
+                    f"Expected 400 for symlink escape attempt, got {response.status_code}: "
+                    f"{response.text}"
+                )
+                assert "resolves outside" in response.text.lower()
 
-            # Double-check that nothing was written to the target
-            target_artifact_dir = target_path / "artifact"
-            assert not (target_artifact_dir / "blobs").exists(), (
-                "Upload followed symlink and wrote outside storage!"
-            )
-        finally:
-            # Clean up the symlink and the outside temp directory
-            symlink_path.unlink(missing_ok=True)
-            shutil.rmtree(outside_temp, ignore_errors=True)
+                # Double-check that nothing was written to the target
+                target_artifact_dir = target_path / "artifact"
+                assert not (target_artifact_dir / "blobs").exists(), (
+                    "Upload followed symlink and wrote outside storage!"
+                )
+            finally:
+                # Clean up the symlink (temp directory cleaned up by context manager)
+                symlink_path.unlink(missing_ok=True)
 
     def test_symlink_read_artifact_rejected(
         self, client: TestClient, test_storage_service: StorageService
@@ -294,37 +291,36 @@ class TestSymlinkAttacks:
         """
         storage_base = test_storage_service.config.storage_path
 
-        # Create target directory OUTSIDE the storage root with some content
-        outside_temp = Path(tempfile.mkdtemp(prefix="magpie_symlink_read_test_"))
-        target_path = outside_temp / "sensitive_data"
-        target_path.mkdir(parents=True, exist_ok=True)
+        # Create target directory OUTSIDE the storage root using context manager
+        # to ensure cleanup even on test failures
+        with tempfile.TemporaryDirectory(prefix="magpie_symlink_read_test_") as outside_temp:
+            target_path = Path(outside_temp) / "sensitive_data"
+            target_path.mkdir(parents=True, exist_ok=True)
 
-        # Create some "sensitive" content that should NOT be readable
-        (target_path / "secret.txt").write_text("sensitive data")
+            # Create some "sensitive" content that should NOT be readable
+            (target_path / "secret.txt").write_text("sensitive data")
 
-        # Create a symlink inside storage pointing outside
-        symlink_path = storage_base / "escape_link"
+            # Create a symlink inside storage pointing outside
+            symlink_path = storage_base / "escape_link"
 
-        try:
-            symlink_path.symlink_to(target_path)
-        except OSError:
-            shutil.rmtree(outside_temp, ignore_errors=True)
-            pytest.skip("Cannot create symlinks on this system")
+            try:
+                symlink_path.symlink_to(target_path)
+            except OSError:
+                pytest.skip("Cannot create symlinks on this system")
 
-        try:
-            # Try to list artifacts through the symlink
-            response = client.get("/api/v1/artifacts/escape_link")
+            try:
+                # Try to list artifacts through the symlink
+                response = client.get("/api/v1/artifacts/escape_link")
 
-            # The request should be rejected because the symlink escapes storage root
-            assert response.status_code == 400, (
-                f"Expected 400 for symlink escape attempt, got {response.status_code}: "
-                f"{response.text}"
-            )
-            assert "resolves outside" in response.text.lower()
-        finally:
-            # Clean up the symlink and the outside temp directory
-            symlink_path.unlink(missing_ok=True)
-            shutil.rmtree(outside_temp, ignore_errors=True)
+                # The request should be rejected because the symlink escapes storage root
+                assert response.status_code == 400, (
+                    f"Expected 400 for symlink escape attempt, got {response.status_code}: "
+                    f"{response.text}"
+                )
+                assert "resolves outside" in response.text.lower()
+            finally:
+                # Clean up the symlink (temp directory cleaned up by context manager)
+                symlink_path.unlink(missing_ok=True)
 
     def test_symlink_in_nested_path_rejected(
         self, client: TestClient, test_storage_service: StorageService
@@ -340,40 +336,39 @@ class TestSymlinkAttacks:
         legit_dir = storage_base / "project"
         legit_dir.mkdir(parents=True, exist_ok=True)
 
-        # Create target directory OUTSIDE the storage root
-        outside_temp = Path(tempfile.mkdtemp(prefix="magpie_nested_symlink_test_"))
-        target_path = outside_temp / "escape_target"
-        target_path.mkdir(parents=True, exist_ok=True)
+        # Create target directory OUTSIDE the storage root using context manager
+        # to ensure cleanup even on test failures
+        with tempfile.TemporaryDirectory(prefix="magpie_nested_symlink_test_") as outside_temp:
+            target_path = Path(outside_temp) / "escape_target"
+            target_path.mkdir(parents=True, exist_ok=True)
 
-        # Create a symlink inside the legitimate directory pointing outside
-        symlink_path = legit_dir / "evil_link"
+            # Create a symlink inside the legitimate directory pointing outside
+            symlink_path = legit_dir / "evil_link"
 
-        try:
-            symlink_path.symlink_to(target_path)
-        except OSError:
-            shutil.rmtree(outside_temp, ignore_errors=True)
-            pytest.skip("Cannot create symlinks on this system")
+            try:
+                symlink_path.symlink_to(target_path)
+            except OSError:
+                pytest.skip("Cannot create symlinks on this system")
 
-        try:
-            # Try to upload through the nested symlink
-            content = b"test content"
-            files = {"file": ("test.bin", io.BytesIO(content), "application/octet-stream")}
+            try:
+                # Try to upload through the nested symlink
+                content = b"test content"
+                files = {"file": ("test.bin", io.BytesIO(content), "application/octet-stream")}
 
-            response = client.post(
-                "/api/v1/upload/project/evil_link/artifact",
-                files=files,
-            )
+                response = client.post(
+                    "/api/v1/upload/project/evil_link/artifact",
+                    files=files,
+                )
 
-            # The upload should be rejected
-            assert response.status_code == 400, (
-                f"Expected 400 for nested symlink escape, got {response.status_code}: "
-                f"{response.text}"
-            )
-            assert "resolves outside" in response.text.lower()
-        finally:
-            # Clean up the symlink and the outside temp directory
-            symlink_path.unlink(missing_ok=True)
-            shutil.rmtree(outside_temp, ignore_errors=True)
+                # The upload should be rejected
+                assert response.status_code == 400, (
+                    f"Expected 400 for nested symlink escape, got {response.status_code}: "
+                    f"{response.text}"
+                )
+                assert "resolves outside" in response.text.lower()
+            finally:
+                # Clean up the symlink (temp directory cleaned up by context manager)
+                symlink_path.unlink(missing_ok=True)
 
     def test_cyclic_symlink_rejected(
         self, client: TestClient, test_storage_service: StorageService
@@ -385,28 +380,29 @@ class TestSymlinkAttacks:
         """
         storage_base = test_storage_service.config.storage_path
 
-        # Create a directory for the cyclic symlinks
-        cycle_dir = storage_base / "cycle_test"
-        cycle_dir.mkdir(parents=True, exist_ok=True)
+        # Create a directory for the cyclic symlinks using context manager
+        # to ensure cleanup even on test failures (directory is inside storage_base)
+        with tempfile.TemporaryDirectory(prefix="cycle_test_", dir=storage_base) as cycle_dir_str:
+            cycle_dir = Path(cycle_dir_str)
+            symlink_a = cycle_dir / "link_a"
+            symlink_b = cycle_dir / "link_b"
 
-        symlink_a = cycle_dir / "link_a"
-        symlink_b = cycle_dir / "link_b"
+            try:
+                # Create cyclic symlinks: A -> B -> A
+                symlink_a.symlink_to(symlink_b)
+                symlink_b.symlink_to(symlink_a)
+            except OSError:
+                pytest.skip("Cannot create symlinks on this system")
 
-        try:
-            # Create cyclic symlinks: A -> B -> A
-            symlink_a.symlink_to(symlink_b)
-            symlink_b.symlink_to(symlink_a)
-        except OSError:
-            shutil.rmtree(cycle_dir, ignore_errors=True)
-            pytest.skip("Cannot create symlinks on this system")
+            # Compute the relative path from storage_base for the API call
+            cycle_dir_name = cycle_dir.name
 
-        try:
             # Try to upload through the cyclic symlink
             content = b"test content"
             files = {"file": ("test.bin", io.BytesIO(content), "application/octet-stream")}
 
             response = client.post(
-                "/api/v1/upload/cycle_test/link_a/artifact",
+                f"/api/v1/upload/{cycle_dir_name}/link_a/artifact",
                 files=files,
             )
 
@@ -416,11 +412,6 @@ class TestSymlinkAttacks:
                 f"Expected 400 for cyclic symlink, got {response.status_code}: {response.text}"
             )
             assert "cannot be resolved" in response.text.lower()
-        finally:
-            # Clean up the symlinks
-            symlink_a.unlink(missing_ok=True)
-            symlink_b.unlink(missing_ok=True)
-            shutil.rmtree(cycle_dir, ignore_errors=True)
 
     def test_double_dot_path_normalized_by_http(self, client: TestClient) -> None:
         """Double dot (..) in URL path is normalized by HTTP framework.

--- a/tests/security/test_injection.py
+++ b/tests/security/test_injection.py
@@ -281,7 +281,8 @@ class TestSymlinkAttacks:
                 "Upload followed symlink and wrote outside storage!"
             )
         finally:
-            # Clean up the outside temp directory
+            # Clean up the symlink and the outside temp directory
+            symlink_path.unlink(missing_ok=True)
             shutil.rmtree(outside_temp, ignore_errors=True)
 
     def test_symlink_read_artifact_rejected(
@@ -325,6 +326,8 @@ class TestSymlinkAttacks:
             )
             assert "resolves outside" in response.text.lower()
         finally:
+            # Clean up the symlink and the outside temp directory
+            symlink_path.unlink(missing_ok=True)
             shutil.rmtree(outside_temp, ignore_errors=True)
 
     def test_symlink_in_nested_path_rejected(
@@ -375,6 +378,8 @@ class TestSymlinkAttacks:
             )
             assert "resolves outside" in response.text.lower()
         finally:
+            # Clean up the symlink and the outside temp directory
+            symlink_path.unlink(missing_ok=True)
             shutil.rmtree(outside_temp, ignore_errors=True)
 
     def test_double_dot_path_normalized_by_http(self, client: TestClient) -> None:

--- a/tests/security/test_injection.py
+++ b/tests/security/test_injection.py
@@ -237,8 +237,8 @@ class TestSymlinkAttacks:
         The verify_path_is_descendant function uses resolve() to detect when
         symlinks would escape the storage directory, and rejects such paths.
         """
-        import tempfile
         import shutil
+        import tempfile
 
         storage_base = test_storage_service.config.storage_path
 
@@ -291,8 +291,8 @@ class TestSymlinkAttacks:
         Tests that attempting to read artifact info through a symlink that
         escapes the storage directory is rejected.
         """
-        import tempfile
         import shutil
+        import tempfile
 
         storage_base = test_storage_service.config.storage_path
 
@@ -334,8 +334,8 @@ class TestSymlinkAttacks:
         Tests that symlinks anywhere in the artifact path (not just at the root)
         are detected and rejected.
         """
-        import tempfile
         import shutil
+        import tempfile
 
         storage_base = test_storage_service.config.storage_path
 

--- a/tests/security/test_injection.py
+++ b/tests/security/test_injection.py
@@ -220,55 +220,161 @@ class TestUnicodeNormalizationAttacks:
 class TestSymlinkAttacks:
     """Test symlink-based attacks.
 
-    These tests verify that the system properly handles or rejects
-    symlinks that could be used to escape the storage directory or
-    access unauthorized files.
+    These tests verify that the system properly rejects symlinks that
+    could be used to escape the storage directory or access unauthorized
+    files.
 
-    Note: Currently symlinks in the storage directory are followed, which
-    could be a security concern. This test documents the current behavior.
+    Security mechanism: The artifact_dir_path() function uses Path.resolve()
+    to follow symlinks and verifies that the resolved path remains within
+    the storage root directory. This protects both uploads and reads.
     """
 
-    @pytest.mark.xfail(
-        reason="Symlink following is currently allowed - see issue #135 for security review"
-    )
     def test_symlink_in_artifact_path_rejected(
-        self, client: TestClient, test_storage_service: StorageService, tmp_path: Path
+        self, client: TestClient, test_storage_service: StorageService
     ) -> None:
         """Symlinks in artifact paths should not allow escaping storage root.
 
-        This test is marked as xfail because the current implementation
-        follows symlinks. This behavior should be reviewed for security
-        implications.
+        The verify_path_is_descendant function uses resolve() to detect when
+        symlinks would escape the storage directory, and rejects such paths.
         """
+        import tempfile
+        import shutil
+
         storage_base = test_storage_service.config.storage_path
+
+        # Create target directory OUTSIDE the storage root
+        # We need a separate temp directory, not a subdirectory of storage_base
+        outside_temp = Path(tempfile.mkdtemp(prefix="magpie_symlink_test_outside_"))
+        target_path = outside_temp / "escape_target"
+        target_path.mkdir(parents=True, exist_ok=True)
 
         # Create a symlink inside storage pointing outside
         symlink_path = storage_base / "escape_link"
-        target_path = tmp_path / "outside_storage"
-        target_path.mkdir(parents=True, exist_ok=True)
 
         try:
             symlink_path.symlink_to(target_path)
         except OSError:
+            shutil.rmtree(outside_temp, ignore_errors=True)
             pytest.skip("Cannot create symlinks on this system")
 
-        # Try to upload through the symlink
-        content = b"test content"
-        files = {"file": ("test.bin", io.BytesIO(content), "application/octet-stream")}
+        try:
+            # Try to upload through the symlink
+            content = b"test content"
+            files = {"file": ("test.bin", io.BytesIO(content), "application/octet-stream")}
 
-        response = client.post(
-            "/api/v1/upload/escape_link/artifact",
-            files=files,
-        )
+            response = client.post(
+                "/api/v1/upload/escape_link/artifact",
+                files=files,
+            )
 
-        # The storage service should handle this safely
-        # Either reject or store in the actual symlink location (not follow it)
-        if response.status_code == 200:
-            # If upload succeeded, verify it didn't write to the target
+            # The upload should be rejected because the symlink escapes storage root
+            assert response.status_code == 400, (
+                f"Expected 400 for symlink escape attempt, got {response.status_code}: "
+                f"{response.text}"
+            )
+            assert "resolves outside" in response.text.lower()
+
+            # Double-check that nothing was written to the target
             target_artifact_dir = target_path / "artifact"
             assert not (target_artifact_dir / "blobs").exists(), (
                 "Upload followed symlink and wrote outside storage!"
             )
+        finally:
+            # Clean up the outside temp directory
+            shutil.rmtree(outside_temp, ignore_errors=True)
+
+    def test_symlink_read_artifact_rejected(
+        self, client: TestClient, test_storage_service: StorageService
+    ) -> None:
+        """Symlinks should not allow reading files outside storage root.
+
+        Tests that attempting to read artifact info through a symlink that
+        escapes the storage directory is rejected.
+        """
+        import tempfile
+        import shutil
+
+        storage_base = test_storage_service.config.storage_path
+
+        # Create target directory OUTSIDE the storage root with some content
+        outside_temp = Path(tempfile.mkdtemp(prefix="magpie_symlink_read_test_"))
+        target_path = outside_temp / "sensitive_data"
+        target_path.mkdir(parents=True, exist_ok=True)
+
+        # Create some "sensitive" content that should NOT be readable
+        (target_path / "secret.txt").write_text("sensitive data")
+
+        # Create a symlink inside storage pointing outside
+        symlink_path = storage_base / "escape_link"
+
+        try:
+            symlink_path.symlink_to(target_path)
+        except OSError:
+            shutil.rmtree(outside_temp, ignore_errors=True)
+            pytest.skip("Cannot create symlinks on this system")
+
+        try:
+            # Try to list artifacts through the symlink
+            response = client.get("/api/v1/artifacts/escape_link")
+
+            # The request should be rejected because the symlink escapes storage root
+            assert response.status_code == 400, (
+                f"Expected 400 for symlink escape attempt, got {response.status_code}: "
+                f"{response.text}"
+            )
+            assert "resolves outside" in response.text.lower()
+        finally:
+            shutil.rmtree(outside_temp, ignore_errors=True)
+
+    def test_symlink_in_nested_path_rejected(
+        self, client: TestClient, test_storage_service: StorageService
+    ) -> None:
+        """Symlinks in nested paths should also be rejected.
+
+        Tests that symlinks anywhere in the artifact path (not just at the root)
+        are detected and rejected.
+        """
+        import tempfile
+        import shutil
+
+        storage_base = test_storage_service.config.storage_path
+
+        # Create a legitimate top-level directory
+        legit_dir = storage_base / "project"
+        legit_dir.mkdir(parents=True, exist_ok=True)
+
+        # Create target directory OUTSIDE the storage root
+        outside_temp = Path(tempfile.mkdtemp(prefix="magpie_nested_symlink_test_"))
+        target_path = outside_temp / "escape_target"
+        target_path.mkdir(parents=True, exist_ok=True)
+
+        # Create a symlink inside the legitimate directory pointing outside
+        symlink_path = legit_dir / "evil_link"
+
+        try:
+            symlink_path.symlink_to(target_path)
+        except OSError:
+            shutil.rmtree(outside_temp, ignore_errors=True)
+            pytest.skip("Cannot create symlinks on this system")
+
+        try:
+            # Try to upload through the nested symlink
+            content = b"test content"
+            files = {"file": ("test.bin", io.BytesIO(content), "application/octet-stream")}
+
+            response = client.post(
+                "/api/v1/upload/project/evil_link/artifact",
+                files=files,
+            )
+
+            # The upload should be rejected
+            assert response.status_code == 400, (
+                f"Expected 400 for nested symlink escape, got {response.status_code}: "
+                f"{response.text}"
+            )
+            assert "resolves outside" in response.text.lower()
+        finally:
+            shutil.rmtree(outside_temp, ignore_errors=True)
 
     def test_double_dot_path_normalized_by_http(self, client: TestClient) -> None:
         """Double dot (..) in URL path is normalized by HTTP framework.

--- a/tests/unit/test_storage_utils.py
+++ b/tests/unit/test_storage_utils.py
@@ -98,24 +98,29 @@ class TestShortHash:
 
 
 class TestArtifactDirPath:
-    """Tests for artifact_dir_path function."""
+    """Tests for artifact_dir_path function.
+
+    These tests use verify_security=False because they test path construction
+    logic with hypothetical paths. Security verification is tested separately
+    in test_path_validation.py::TestVerifyPathIsDescendant.
+    """
 
     def test_artifact_dir_path_simple(self) -> None:
         """artifact_dir_path should join base and artifact path."""
         base = Path("/data/artifacts")
-        result = artifact_dir_path(base, "project/component")
+        result = artifact_dir_path(base, "project/component", verify_security=False)
         assert result == Path("/data/artifacts/project/component")
 
     def test_artifact_dir_path_single_segment(self) -> None:
         """artifact_dir_path should work with single-segment paths."""
         base = Path("/storage")
-        result = artifact_dir_path(base, "artifact")
+        result = artifact_dir_path(base, "artifact", verify_security=False)
         assert result == Path("/storage/artifact")
 
     def test_artifact_dir_path_deep_nesting(self) -> None:
         """artifact_dir_path should handle deeply nested paths."""
         base = Path("/data")
-        result = artifact_dir_path(base, "a/b/c/d/e")
+        result = artifact_dir_path(base, "a/b/c/d/e", verify_security=False)
         assert result == Path("/data/a/b/c/d/e")
 
 


### PR DESCRIPTION
## Summary

- Add symlink escape detection to `artifact_dir_path()` function
- Use `Path.resolve()` to follow symlinks and verify resolved path stays within storage root
- Protects both uploads and reads against symlink-based directory traversal attacks

## Changes

- `artifact_dir_path()` now performs security check by default (optional `verify_security` parameter)
- Removed `xfail` marker from symlink test (the underlying protection already worked, but the test had a bug)
- Fixed test to use a truly external temp directory (previous test incorrectly used a subdirectory of storage root)
- Added tests for read operations (`test_symlink_read_artifact_rejected`)
- Added tests for nested symlink attacks (`test_symlink_in_nested_path_rejected`)

## Test plan

- [x] All symlink security tests pass (4 tests)
- [x] All security tests pass (39 tests)
- [x] All non-e2e tests pass (996 tests)

Closes #135

Generated with Claude Code (Opus 4.5)