### PR TITLE
test(cli): Add comprehensive CLI workflow integration tests

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -33,7 +33,6 @@ from magpie.server.deps import (
 )
 from magpie.storage.service import StorageService
 
-
 # =============================================================================
 # Mock Classes for CLI Download Tests
 # =============================================================================

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -149,6 +149,7 @@ class MockClientWithDownload:
     def __exit__(self, *args: object) -> None:
         pass
 
+
 # =============================================================================
 # Core Configuration Fixtures
 # =============================================================================

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -11,11 +11,15 @@ from __future__ import annotations
 
 import io
 from pathlib import Path
-from unittest.mock import patch
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
 
 import pytest
 from click.testing import CliRunner
 from fastapi.testclient import TestClient
+
+if TYPE_CHECKING:
+    import httpx
 
 from magpie.auth.models import TokenScope
 from magpie.auth.service import TokenInfo, TokenService
@@ -28,6 +32,123 @@ from magpie.server.deps import (
     require_write_scope,
 )
 from magpie.storage.service import StorageService
+
+
+# =============================================================================
+# Mock Classes for CLI Download Tests
+# =============================================================================
+
+
+class MockStreamResponse:
+    """Mock streaming response for download tests.
+
+    Provides a context manager interface for simulating httpx streaming responses
+    in CLI integration tests.
+    """
+
+    def __init__(self, status_code: int, content: bytes) -> None:
+        self.status_code = status_code
+        self._content = content
+        self.headers = {"content-length": str(len(content))}
+
+    def iter_bytes(self):
+        """Yield content in chunks."""
+        yield self._content
+
+    def read(self) -> bytes:
+        """Read full response body."""
+        return self._content
+
+    def __enter__(self) -> "MockStreamResponse":
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        pass
+
+
+class MockClientWithDownload:
+    """Wrapper around TestClient that handles download endpoints.
+
+    The /artifacts/{path}/{hash_ref} download path isn't a real API endpoint -
+    it's typically served by a static file server. This wrapper intercepts
+    those requests and returns the appropriate content.
+
+    Used by CLI integration tests that need to test the full push/get workflow.
+    """
+
+    def __init__(self, api_client: TestClient, storage_service: StorageService) -> None:
+        self.api_client = api_client
+        self.storage_service = storage_service
+
+    def get(self, url: str) -> "MagicMock | httpx.Response":
+        """Handle GET requests, routing downloads to storage."""
+        if url.startswith("/artifacts/"):
+            return self._handle_download(url)
+        return self.api_client.get(url)
+
+    def stream(self, method: str, url: str) -> MockStreamResponse:
+        """Handle streaming requests for downloads."""
+        if method == "GET" and url.startswith("/artifacts/"):
+            return self._handle_stream_download(url)
+        response = self.api_client.get(url)
+        return MockStreamResponse(response.status_code, response.content)
+
+    def post(self, url: str, **kwargs: object) -> "httpx.Response":
+        """Delegate POST to api_client."""
+        return self.api_client.post(url, **kwargs)
+
+    def delete(self, url: str, **kwargs: object) -> "httpx.Response":
+        """Delegate DELETE to api_client."""
+        return self.api_client.delete(url, **kwargs)
+
+    def patch(self, url: str, **kwargs: object) -> "httpx.Response":
+        """Delegate PATCH to api_client."""
+        return self.api_client.patch(url, **kwargs)
+
+    def _get_download_content(self, url: str) -> tuple[int, bytes]:
+        """Get download content and status code for a URL."""
+        from magpie.storage.blob import read_blob
+        from magpie.storage.paths import artifact_dir_path
+
+        parts = url.split("/")
+
+        if "blobs" in parts:
+            # Pattern: /artifacts/{path}/blobs/{hash}
+            blobs_idx = parts.index("blobs")
+            path = "/".join(parts[2:blobs_idx])
+            hash_ref = "@" + parts[blobs_idx + 1]
+        else:
+            # Pattern: /artifacts/{path}/{hash_ref}
+            hash_ref = parts[-1]
+            path = "/".join(parts[2:-1])
+
+        try:
+            info = self.storage_service.get_artifact_info(path, hash_ref)
+            artifact_dir = artifact_dir_path(self.storage_service.config.storage_path, path)
+            blob_file = read_blob(artifact_dir, info.hash)
+            content = blob_file.read_bytes()
+            return 200, content
+        except Exception:
+            return 404, b""
+
+    def _handle_download(self, url: str) -> MagicMock:
+        """Handle download from /artifacts/ URL."""
+        status_code, content = self._get_download_content(url)
+        response = MagicMock()
+        response.status_code = status_code
+        response.content = content
+        return response
+
+    def _handle_stream_download(self, url: str) -> MockStreamResponse:
+        """Handle streaming download from /artifacts/ URLs."""
+        status_code, content = self._get_download_content(url)
+        return MockStreamResponse(status_code, content)
+
+    def __enter__(self) -> "MockClientWithDownload":
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        pass
 
 # =============================================================================
 # Core Configuration Fixtures

--- a/tests/integration/test_cli_push_get.py
+++ b/tests/integration/test_cli_push_get.py
@@ -5,128 +5,19 @@ from __future__ import annotations
 import hashlib
 import io
 from pathlib import Path
-from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
-if TYPE_CHECKING:
-    import httpx
 from click.testing import CliRunner
 from fastapi.testclient import TestClient
 
 from magpie.cli import cli
 from magpie.cli.commands.parse import parse_artifact_ref
 from magpie.storage.service import StorageService
+from tests.integration.conftest import MockClientWithDownload, MockStreamResponse
 
 # Patch path for get_client - must match where it's imported/used in the CLI module
 # Since CLIContext imports get_client from magpie.cli.client, we patch there
 PATCH_GET_CLIENT = "magpie.cli.get_client"
-
-
-class MockStreamResponse:
-    """Mock streaming response for download tests."""
-
-    def __init__(self, status_code: int, content: bytes) -> None:
-        self.status_code = status_code
-        self._content = content
-        self.headers = {"content-length": str(len(content))}
-
-    def iter_bytes(self):
-        """Yield content in chunks."""
-        # Yield content in a single chunk for simplicity
-        yield self._content
-
-    def read(self) -> bytes:
-        """Read full response body."""
-        return self._content
-
-    def __enter__(self) -> "MockStreamResponse":
-        return self
-
-    def __exit__(self, *args: object) -> None:
-        pass
-
-
-class MockClientWithDownload:
-    """Wrapper around TestClient that handles download endpoints.
-
-    The /artifacts/{path}/{hash_ref} download path isn't a real API endpoint -
-    it's typically served by a static file server. This wrapper intercepts
-    those requests and returns the appropriate content.
-    """
-
-    def __init__(self, api_client: TestClient, storage_service: StorageService) -> None:
-        self.api_client = api_client
-        self.storage_service = storage_service
-
-    def get(self, url: str) -> "httpx.Response":
-        """Handle GET requests, routing downloads to storage."""
-        if url.startswith("/artifacts/"):
-            return self._handle_download(url)
-        return self.api_client.get(url)
-
-    def stream(self, method: str, url: str) -> MockStreamResponse:
-        """Handle streaming requests for downloads."""
-        if method == "GET" and url.startswith("/artifacts/"):
-            return self._handle_stream_download(url)
-        # For non-artifact requests, delegate to api_client
-        response = self.api_client.get(url)
-        return MockStreamResponse(response.status_code, response.content)
-
-    def post(self, url: str, **kwargs: object) -> "httpx.Response":
-        """Delegate POST to api_client."""
-        return self.api_client.post(url, **kwargs)
-
-    def _get_download_content(self, url: str) -> tuple[int, bytes]:
-        """Get download content and status code for a URL."""
-        from magpie.storage.blob import read_blob
-        from magpie.storage.paths import artifact_dir_path
-
-        # Parse URL - handle both patterns:
-        # /artifacts/{path}/{tag}  (tag symlinks)
-        # /artifacts/{path}/blobs/{hash}  (direct blob access)
-        parts = url.split("/")
-        # parts = ['', 'artifacts', path_parts..., ref_or_blobs, maybe_hash]
-
-        if "blobs" in parts:
-            # Pattern: /artifacts/{path}/blobs/{hash}
-            blobs_idx = parts.index("blobs")
-            path = "/".join(parts[2:blobs_idx])
-            hash_ref = "@" + parts[blobs_idx + 1]  # Add @ prefix for lookup
-        else:
-            # Pattern: /artifacts/{path}/{hash_ref}
-            hash_ref = parts[-1]
-            path = "/".join(parts[2:-1])
-
-        try:
-            # Get the full hash from storage service
-            info = self.storage_service.get_artifact_info(path, hash_ref)
-
-            # Read the blob using the full hash
-            artifact_dir = artifact_dir_path(self.storage_service.config.storage_path, path)
-            blob_file = read_blob(artifact_dir, info.hash)
-            content = blob_file.read_bytes()
-            return 200, content
-        except Exception:
-            return 404, b""
-
-    def _handle_download(self, url: str) -> MagicMock:
-        """Handle download from /artifacts/{path}/{hash_ref} or /artifacts/{path}/blobs/{hash}."""
-        status_code, content = self._get_download_content(url)
-        response = MagicMock()
-        response.status_code = status_code
-        response.content = content
-        return response
-
-    def _handle_stream_download(self, url: str) -> MockStreamResponse:
-        """Handle streaming download from /artifacts/ URLs."""
-        status_code, content = self._get_download_content(url)
-        return MockStreamResponse(status_code, content)
-
-    def __enter__(self) -> "MockClientWithDownload":
-        return self
-
-    def __exit__(self, *args: object) -> None:
-        pass
 
 
 class TestParseArtifactRef:

--- a/tests/integration/test_cli_workflow.py
+++ b/tests/integration/test_cli_workflow.py
@@ -265,13 +265,9 @@ class TestMultiSegmentPathGet:
 class TestMultiSegmentPathTag:
     """Tests for tag command with multi-segment paths."""
 
-    def test_tag_three_segment_path(
-        self, cli_runner: CliRunner, api_client: TestClient
-    ) -> None:
+    def test_tag_three_segment_path(self, cli_runner: CliRunner, api_client: TestClient) -> None:
         """Tag on org/project/artifact path works correctly."""
-        upload_data = upload_test_artifact(
-            api_client, "acme/webapp/config", b"config content"
-        )
+        upload_data = upload_test_artifact(api_client, "acme/webapp/config", b"config content")
         hash_ref = upload_data["hash_ref"]
 
         with patch(PATCH_GET_CLIENT) as mock_get_client:
@@ -292,13 +288,9 @@ class TestMultiSegmentPathTag:
         assert result.exit_code == 0, f"Output: {result.output}"
         assert "v1.0.0" in result.output
 
-    def test_tag_four_segment_path(
-        self, cli_runner: CliRunner, api_client: TestClient
-    ) -> None:
+    def test_tag_four_segment_path(self, cli_runner: CliRunner, api_client: TestClient) -> None:
         """Tag on org/project/component/artifact path works correctly."""
-        upload_test_artifact(
-            api_client, "acme/platform/db/migrations", b"migration content"
-        )
+        upload_test_artifact(api_client, "acme/platform/db/migrations", b"migration content")
 
         with patch(PATCH_GET_CLIENT) as mock_get_client:
             mock_get_client.return_value = api_client
@@ -322,9 +314,7 @@ class TestMultiSegmentPathTag:
 class TestMultiSegmentPathAmend:
     """Tests for amend command with multi-segment paths."""
 
-    def test_amend_three_segment_path(
-        self, cli_runner: CliRunner, api_client: TestClient
-    ) -> None:
+    def test_amend_three_segment_path(self, cli_runner: CliRunner, api_client: TestClient) -> None:
         """Amend on org/project/artifact path works correctly."""
         upload_test_artifact(api_client, "acme/webapp/assets", b"assets content")
 
@@ -347,13 +337,9 @@ class TestMultiSegmentPathAmend:
         assert "Updated:" in result.output
         assert "https://github.com/acme/webapp/assets" in result.output
 
-    def test_amend_four_segment_path(
-        self, cli_runner: CliRunner, api_client: TestClient
-    ) -> None:
+    def test_amend_four_segment_path(self, cli_runner: CliRunner, api_client: TestClient) -> None:
         """Amend on org/project/component/artifact path works correctly."""
-        upload_test_artifact(
-            api_client, "acme/platform/auth/keys", b"keys content"
-        )
+        upload_test_artifact(api_client, "acme/platform/auth/keys", b"keys content")
 
         with patch(PATCH_GET_CLIENT) as mock_get_client:
             mock_get_client.return_value = api_client
@@ -377,9 +363,7 @@ class TestMultiSegmentPathAmend:
 class TestMultiSegmentPathUntag:
     """Tests for untag command with multi-segment paths."""
 
-    def test_untag_three_segment_path(
-        self, cli_runner: CliRunner, api_client: TestClient
-    ) -> None:
+    def test_untag_three_segment_path(self, cli_runner: CliRunner, api_client: TestClient) -> None:
         """Untag on org/project/artifact path works correctly."""
         upload_test_artifact(api_client, "acme/webapp/cache", b"cache content")
 
@@ -400,13 +384,9 @@ class TestMultiSegmentPathUntag:
         assert result.exit_code == 0, f"Output: {result.output}"
         assert "Removed tag 'temp-tag'" in result.output
 
-    def test_untag_four_segment_path(
-        self, cli_runner: CliRunner, api_client: TestClient
-    ) -> None:
+    def test_untag_four_segment_path(self, cli_runner: CliRunner, api_client: TestClient) -> None:
         """Untag on org/project/component/artifact path works correctly."""
-        upload_test_artifact(
-            api_client, "acme/platform/cdn/static", b"static content"
-        )
+        upload_test_artifact(api_client, "acme/platform/cdn/static", b"static content")
 
         api_client.post(
             "/api/v1/artifacts/acme/platform/cdn/static/latest/tags",
@@ -434,9 +414,7 @@ class TestMultiSegmentPathUntag:
 class TestMultiSegmentPathInfo:
     """Tests for info command with multi-segment paths."""
 
-    def test_info_three_segment_path(
-        self, cli_runner: CliRunner, api_client: TestClient
-    ) -> None:
+    def test_info_three_segment_path(self, cli_runner: CliRunner, api_client: TestClient) -> None:
         """Info on org/project/artifact path displays metadata correctly."""
         upload_data = upload_test_artifact(
             api_client,
@@ -459,9 +437,7 @@ class TestMultiSegmentPathInfo:
         assert "Source URI:" in result.output
         assert "https://github.com/acme/webapp" in result.output
 
-    def test_info_four_segment_path(
-        self, cli_runner: CliRunner, api_client: TestClient
-    ) -> None:
+    def test_info_four_segment_path(self, cli_runner: CliRunner, api_client: TestClient) -> None:
         """Info on org/project/component/artifact path displays metadata correctly."""
         upload_data = upload_test_artifact(
             api_client,
@@ -593,7 +569,9 @@ class TestCompleteArtifactLifecycle:
                 ],
             )
 
-            assert get_stable_result.exit_code == 0, f"Get stable failed: {get_stable_result.output}"
+            assert get_stable_result.exit_code == 0, (
+                f"Get stable failed: {get_stable_result.output}"
+            )
             assert output_file_stable.read_bytes() == test_content
 
             # Step 6: Amend source-uri

--- a/tests/integration/test_cli_workflow.py
+++ b/tests/integration/test_cli_workflow.py
@@ -1,0 +1,831 @@
+"""Integration tests for CLI workflows with multi-segment paths and complete lifecycle.
+
+This module tests CLI commands using Click's CliRunner, focusing on:
+1. Multi-segment paths (org/project/artifact style paths)
+2. Complete artifact lifecycle (push -> ls -> get -> tag -> amend -> untag)
+3. Hash ref vs tag retrieval comparison
+
+Generated with assistance from Claude Code (Opus 4.5).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+from fastapi.testclient import TestClient
+
+from magpie.cli import cli
+from magpie.storage.service import StorageService
+from tests.integration.conftest import upload_test_artifact
+
+# Patch path for get_client - must match where it's imported/used in the CLI module
+PATCH_GET_CLIENT = "magpie.cli.get_client"
+
+
+class MockStreamResponse:
+    """Mock streaming response for download tests."""
+
+    def __init__(self, status_code: int, content: bytes) -> None:
+        self.status_code = status_code
+        self._content = content
+        self.headers = {"content-length": str(len(content))}
+
+    def iter_bytes(self):
+        """Yield content in chunks."""
+        yield self._content
+
+    def read(self) -> bytes:
+        """Read full response body."""
+        return self._content
+
+    def __enter__(self) -> "MockStreamResponse":
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        pass
+
+
+class MockClientWithDownload:
+    """Wrapper around TestClient that handles download endpoints.
+
+    The /artifacts/{path}/{hash_ref} download path isn't a real API endpoint -
+    it's typically served by a static file server. This wrapper intercepts
+    those requests and returns the appropriate content.
+    """
+
+    def __init__(self, api_client: TestClient, storage_service: StorageService) -> None:
+        self.api_client = api_client
+        self.storage_service = storage_service
+
+    def get(self, url: str) -> MagicMock:
+        """Handle GET requests, routing downloads to storage."""
+        if url.startswith("/artifacts/"):
+            return self._handle_download(url)
+        return self.api_client.get(url)
+
+    def stream(self, method: str, url: str) -> MockStreamResponse:
+        """Handle streaming requests for downloads."""
+        if method == "GET" and url.startswith("/artifacts/"):
+            return self._handle_stream_download(url)
+        response = self.api_client.get(url)
+        return MockStreamResponse(response.status_code, response.content)
+
+    def post(self, url: str, **kwargs: object) -> MagicMock:
+        """Delegate POST to api_client."""
+        return self.api_client.post(url, **kwargs)
+
+    def delete(self, url: str, **kwargs: object) -> MagicMock:
+        """Delegate DELETE to api_client."""
+        return self.api_client.delete(url, **kwargs)
+
+    def patch(self, url: str, **kwargs: object) -> MagicMock:
+        """Delegate PATCH to api_client."""
+        return self.api_client.patch(url, **kwargs)
+
+    def _get_download_content(self, url: str) -> tuple[int, bytes]:
+        """Get download content and status code for a URL."""
+        from magpie.storage.blob import read_blob
+        from magpie.storage.paths import artifact_dir_path
+
+        parts = url.split("/")
+
+        if "blobs" in parts:
+            # Pattern: /artifacts/{path}/blobs/{hash}
+            blobs_idx = parts.index("blobs")
+            path = "/".join(parts[2:blobs_idx])
+            hash_ref = "@" + parts[blobs_idx + 1]
+        else:
+            # Pattern: /artifacts/{path}/{hash_ref}
+            hash_ref = parts[-1]
+            path = "/".join(parts[2:-1])
+
+        try:
+            info = self.storage_service.get_artifact_info(path, hash_ref)
+            artifact_dir = artifact_dir_path(self.storage_service.config.storage_path, path)
+            blob_file = read_blob(artifact_dir, info.hash)
+            content = blob_file.read_bytes()
+            return 200, content
+        except Exception:
+            return 404, b""
+
+    def _handle_download(self, url: str) -> MagicMock:
+        """Handle download from /artifacts/ URL."""
+        status_code, content = self._get_download_content(url)
+        response = MagicMock()
+        response.status_code = status_code
+        response.content = content
+        return response
+
+    def _handle_stream_download(self, url: str) -> MockStreamResponse:
+        """Handle streaming download from /artifacts/ URLs."""
+        status_code, content = self._get_download_content(url)
+        return MockStreamResponse(status_code, content)
+
+    def __enter__(self) -> "MockClientWithDownload":
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        pass
+
+
+class TestMultiSegmentPathPush:
+    """Tests for push command with multi-segment paths (org/project/artifact)."""
+
+    def test_push_three_segment_path(
+        self, cli_runner: CliRunner, api_client: TestClient, tmp_path: Path
+    ) -> None:
+        """Push to org/project/artifact path works correctly."""
+        test_file = tmp_path / "artifact.bin"
+        test_content = b"multi-segment push content"
+        test_file.write_bytes(test_content)
+
+        expected_hash = hashlib.sha256(test_content).hexdigest()
+
+        with patch(PATCH_GET_CLIENT) as mock_get_client:
+            mock_get_client.return_value = api_client
+
+            result = cli_runner.invoke(
+                cli,
+                [
+                    "--server",
+                    "http://test",
+                    "push",
+                    str(test_file),
+                    "--to",
+                    "acme/webapp/frontend",
+                ],
+            )
+
+        assert result.exit_code == 0, f"Exit code: {result.exit_code}, Output: {result.output}"
+        assert expected_hash in result.output
+        assert "Uploaded:" in result.output or "Duplicate:" in result.output
+
+    def test_push_four_segment_path(
+        self, cli_runner: CliRunner, api_client: TestClient, tmp_path: Path
+    ) -> None:
+        """Push to org/project/component/artifact path works correctly."""
+        test_file = tmp_path / "deep_artifact.bin"
+        test_content = b"deep nested push content"
+        test_file.write_bytes(test_content)
+
+        with patch(PATCH_GET_CLIENT) as mock_get_client:
+            mock_get_client.return_value = api_client
+
+            result = cli_runner.invoke(
+                cli,
+                [
+                    "--server",
+                    "http://test",
+                    "push",
+                    str(test_file),
+                    "--to",
+                    "acme/webapp/frontend/bundle",
+                ],
+            )
+
+        assert result.exit_code == 0, f"Exit code: {result.exit_code}, Output: {result.output}"
+        assert "Uploaded:" in result.output or "Duplicate:" in result.output
+
+
+class TestMultiSegmentPathGet:
+    """Tests for get command with multi-segment paths."""
+
+    def test_get_three_segment_path(
+        self,
+        cli_runner: CliRunner,
+        api_client: TestClient,
+        tmp_path: Path,
+        test_storage_service: StorageService,
+    ) -> None:
+        """Get from org/project/artifact path works correctly."""
+        test_content = b"content for get test"
+        files = {"file": ("artifact.bin", io.BytesIO(test_content), "application/octet-stream")}
+        api_client.post("/api/v1/upload/acme/webapp/backend", files=files)
+
+        output_file = tmp_path / "downloaded.bin"
+        mock_client = MockClientWithDownload(api_client, test_storage_service)
+
+        with patch(PATCH_GET_CLIENT) as mock_get_client:
+            mock_get_client.return_value = mock_client
+
+            result = cli_runner.invoke(
+                cli,
+                [
+                    "--server",
+                    "http://test",
+                    "get",
+                    "acme/webapp/backend:latest",
+                    "-o",
+                    str(output_file),
+                ],
+            )
+
+        assert result.exit_code == 0, f"Exit code: {result.exit_code}, Output: {result.output}"
+        assert output_file.exists()
+        assert output_file.read_bytes() == test_content
+
+    def test_get_four_segment_path(
+        self,
+        cli_runner: CliRunner,
+        api_client: TestClient,
+        tmp_path: Path,
+        test_storage_service: StorageService,
+    ) -> None:
+        """Get from org/project/component/artifact path works correctly."""
+        test_content = b"deep nested get content"
+        files = {"file": ("artifact.bin", io.BytesIO(test_content), "application/octet-stream")}
+        api_client.post("/api/v1/upload/acme/webapp/api/schema", files=files)
+
+        output_file = tmp_path / "schema_downloaded.bin"
+        mock_client = MockClientWithDownload(api_client, test_storage_service)
+
+        with patch(PATCH_GET_CLIENT) as mock_get_client:
+            mock_get_client.return_value = mock_client
+
+            result = cli_runner.invoke(
+                cli,
+                [
+                    "--server",
+                    "http://test",
+                    "get",
+                    "acme/webapp/api/schema",
+                    "-o",
+                    str(output_file),
+                ],
+            )
+
+        assert result.exit_code == 0, f"Exit code: {result.exit_code}, Output: {result.output}"
+        assert output_file.read_bytes() == test_content
+
+
+class TestMultiSegmentPathTag:
+    """Tests for tag command with multi-segment paths."""
+
+    def test_tag_three_segment_path(
+        self, cli_runner: CliRunner, api_client: TestClient
+    ) -> None:
+        """Tag on org/project/artifact path works correctly."""
+        upload_data = upload_test_artifact(
+            api_client, "acme/webapp/config", b"config content"
+        )
+        hash_ref = upload_data["hash_ref"]
+
+        with patch(PATCH_GET_CLIENT) as mock_get_client:
+            mock_get_client.return_value = api_client
+
+            result = cli_runner.invoke(
+                cli,
+                [
+                    "--server",
+                    "http://test",
+                    "tag",
+                    f"acme/webapp/config:{hash_ref}",
+                    "--as",
+                    "v1.0.0",
+                ],
+            )
+
+        assert result.exit_code == 0, f"Output: {result.output}"
+        assert "v1.0.0" in result.output
+
+    def test_tag_four_segment_path(
+        self, cli_runner: CliRunner, api_client: TestClient
+    ) -> None:
+        """Tag on org/project/component/artifact path works correctly."""
+        upload_test_artifact(
+            api_client, "acme/platform/db/migrations", b"migration content"
+        )
+
+        with patch(PATCH_GET_CLIENT) as mock_get_client:
+            mock_get_client.return_value = api_client
+
+            result = cli_runner.invoke(
+                cli,
+                [
+                    "--server",
+                    "http://test",
+                    "tag",
+                    "acme/platform/db/migrations:latest",
+                    "--as",
+                    "v2.0.0",
+                ],
+            )
+
+        assert result.exit_code == 0, f"Output: {result.output}"
+        assert "v2.0.0" in result.output
+
+
+class TestMultiSegmentPathAmend:
+    """Tests for amend command with multi-segment paths."""
+
+    def test_amend_three_segment_path(
+        self, cli_runner: CliRunner, api_client: TestClient
+    ) -> None:
+        """Amend on org/project/artifact path works correctly."""
+        upload_test_artifact(api_client, "acme/webapp/assets", b"assets content")
+
+        with patch(PATCH_GET_CLIENT) as mock_get_client:
+            mock_get_client.return_value = api_client
+
+            result = cli_runner.invoke(
+                cli,
+                [
+                    "--server",
+                    "http://test",
+                    "amend",
+                    "acme/webapp/assets:latest",
+                    "--source-uri",
+                    "https://github.com/acme/webapp/assets",
+                ],
+            )
+
+        assert result.exit_code == 0, f"Output: {result.output}"
+        assert "Updated:" in result.output
+        assert "https://github.com/acme/webapp/assets" in result.output
+
+    def test_amend_four_segment_path(
+        self, cli_runner: CliRunner, api_client: TestClient
+    ) -> None:
+        """Amend on org/project/component/artifact path works correctly."""
+        upload_test_artifact(
+            api_client, "acme/platform/auth/keys", b"keys content"
+        )
+
+        with patch(PATCH_GET_CLIENT) as mock_get_client:
+            mock_get_client.return_value = api_client
+
+            result = cli_runner.invoke(
+                cli,
+                [
+                    "--server",
+                    "http://test",
+                    "amend",
+                    "acme/platform/auth/keys:latest",
+                    "--source-uri",
+                    "https://vault.acme.com/keys/v1",
+                ],
+            )
+
+        assert result.exit_code == 0, f"Output: {result.output}"
+        assert "https://vault.acme.com/keys/v1" in result.output
+
+
+class TestMultiSegmentPathUntag:
+    """Tests for untag command with multi-segment paths."""
+
+    def test_untag_three_segment_path(
+        self, cli_runner: CliRunner, api_client: TestClient
+    ) -> None:
+        """Untag on org/project/artifact path works correctly."""
+        upload_test_artifact(api_client, "acme/webapp/cache", b"cache content")
+
+        # Create a tag first via API
+        api_client.post(
+            "/api/v1/artifacts/acme/webapp/cache/latest/tags",
+            json={"tag_name": "temp-tag"},
+        )
+
+        with patch(PATCH_GET_CLIENT) as mock_get_client:
+            mock_get_client.return_value = api_client
+
+            result = cli_runner.invoke(
+                cli,
+                ["--server", "http://test", "untag", "acme/webapp/cache", "temp-tag"],
+            )
+
+        assert result.exit_code == 0, f"Output: {result.output}"
+        assert "Removed tag 'temp-tag'" in result.output
+
+    def test_untag_four_segment_path(
+        self, cli_runner: CliRunner, api_client: TestClient
+    ) -> None:
+        """Untag on org/project/component/artifact path works correctly."""
+        upload_test_artifact(
+            api_client, "acme/platform/cdn/static", b"static content"
+        )
+
+        api_client.post(
+            "/api/v1/artifacts/acme/platform/cdn/static/latest/tags",
+            json={"tag_name": "preview"},
+        )
+
+        with patch(PATCH_GET_CLIENT) as mock_get_client:
+            mock_get_client.return_value = api_client
+
+            result = cli_runner.invoke(
+                cli,
+                [
+                    "--server",
+                    "http://test",
+                    "untag",
+                    "acme/platform/cdn/static",
+                    "preview",
+                ],
+            )
+
+        assert result.exit_code == 0, f"Output: {result.output}"
+        assert "Removed tag 'preview'" in result.output
+
+
+class TestMultiSegmentPathInfo:
+    """Tests for info command with multi-segment paths."""
+
+    def test_info_three_segment_path(
+        self, cli_runner: CliRunner, api_client: TestClient
+    ) -> None:
+        """Info on org/project/artifact path displays metadata correctly."""
+        upload_data = upload_test_artifact(
+            api_client,
+            "acme/webapp/manifest",
+            b"manifest content",
+            source_uri="https://github.com/acme/webapp",
+        )
+
+        with patch(PATCH_GET_CLIENT) as mock_get_client:
+            mock_get_client.return_value = api_client
+
+            result = cli_runner.invoke(
+                cli,
+                ["--server", "http://test", "info", "acme/webapp/manifest:latest"],
+            )
+
+        assert result.exit_code == 0, f"Output: {result.output}"
+        assert upload_data["hash"] in result.output
+        assert upload_data["hash_ref"] in result.output
+        assert "Source URI:" in result.output
+        assert "https://github.com/acme/webapp" in result.output
+
+    def test_info_four_segment_path(
+        self, cli_runner: CliRunner, api_client: TestClient
+    ) -> None:
+        """Info on org/project/component/artifact path displays metadata correctly."""
+        upload_data = upload_test_artifact(
+            api_client,
+            "acme/platform/search/index",
+            b"index content",
+            source_uri="https://github.com/acme/platform/search",
+        )
+
+        with patch(PATCH_GET_CLIENT) as mock_get_client:
+            mock_get_client.return_value = api_client
+
+            result = cli_runner.invoke(
+                cli,
+                [
+                    "--server",
+                    "http://test",
+                    "info",
+                    "acme/platform/search/index:latest",
+                ],
+            )
+
+        assert result.exit_code == 0, f"Output: {result.output}"
+        assert upload_data["hash_ref"] in result.output
+
+
+class TestCompleteArtifactLifecycle:
+    """End-to-end test of complete artifact lifecycle through CLI."""
+
+    def test_complete_artifact_lifecycle(
+        self,
+        cli_runner: CliRunner,
+        api_client: TestClient,
+        tmp_path: Path,
+        test_storage_service: StorageService,
+    ) -> None:
+        """Test complete artifact lifecycle: push -> ls -> get -> tag -> info -> amend -> untag."""
+        # Test data
+        artifact_path = "lifecycle/test/artifact"
+        test_content = b"lifecycle test content - unique data for verification"
+        test_file = tmp_path / "lifecycle_test.bin"
+        test_file.write_bytes(test_content)
+        expected_hash = hashlib.sha256(test_content).hexdigest()
+
+        mock_client = MockClientWithDownload(api_client, test_storage_service)
+
+        with patch(PATCH_GET_CLIENT) as mock_get_client:
+            mock_get_client.return_value = mock_client
+
+            # Step 1: Push artifact
+            push_result = cli_runner.invoke(
+                cli,
+                [
+                    "--server",
+                    "http://test",
+                    "push",
+                    str(test_file),
+                    "--to",
+                    artifact_path,
+                ],
+            )
+
+            assert push_result.exit_code == 0, f"Push failed: {push_result.output}"
+            assert expected_hash in push_result.output
+            assert "Hash ref:" in push_result.output
+
+            # Extract hash ref from output for later use
+            hash_ref = None
+            for line in push_result.output.split("\n"):
+                if "Hash ref:" in line:
+                    hash_ref = line.split("Hash ref:")[-1].strip()
+                    break
+            assert hash_ref is not None, "Could not extract hash_ref from push output"
+
+            # Step 2: Verify via ls
+            ls_result = cli_runner.invoke(
+                cli,
+                ["--server", "http://test", "ls", artifact_path],
+            )
+
+            assert ls_result.exit_code == 0, f"Ls failed: {ls_result.output}"
+            assert "latest" in ls_result.output
+            assert hash_ref in ls_result.output
+
+            # Step 3: Get and verify content matches
+            output_file = tmp_path / "downloaded_lifecycle.bin"
+            get_result = cli_runner.invoke(
+                cli,
+                [
+                    "--server",
+                    "http://test",
+                    "get",
+                    f"{artifact_path}:latest",
+                    "-o",
+                    str(output_file),
+                ],
+            )
+
+            assert get_result.exit_code == 0, f"Get failed: {get_result.output}"
+            assert output_file.exists()
+            assert output_file.read_bytes() == test_content
+
+            # Step 4: Tag as stable
+            tag_result = cli_runner.invoke(
+                cli,
+                [
+                    "--server",
+                    "http://test",
+                    "tag",
+                    f"{artifact_path}:latest",
+                    "--as",
+                    "stable",
+                ],
+            )
+
+            assert tag_result.exit_code == 0, f"Tag failed: {tag_result.output}"
+            assert "stable" in tag_result.output
+
+            # Step 5: Get via tag name (stable)
+            output_file_stable = tmp_path / "downloaded_stable.bin"
+            get_stable_result = cli_runner.invoke(
+                cli,
+                [
+                    "--server",
+                    "http://test",
+                    "get",
+                    f"{artifact_path}:stable",
+                    "-o",
+                    str(output_file_stable),
+                ],
+            )
+
+            assert get_stable_result.exit_code == 0, f"Get stable failed: {get_stable_result.output}"
+            assert output_file_stable.read_bytes() == test_content
+
+            # Step 6: Amend source-uri
+            amend_result = cli_runner.invoke(
+                cli,
+                [
+                    "--server",
+                    "http://test",
+                    "amend",
+                    f"{artifact_path}:stable",
+                    "--source-uri",
+                    "https://github.com/lifecycle/test@v1.0.0",
+                ],
+            )
+
+            assert amend_result.exit_code == 0, f"Amend failed: {amend_result.output}"
+            assert "Updated:" in amend_result.output
+            assert "https://github.com/lifecycle/test@v1.0.0" in amend_result.output
+
+            # Step 7: Verify amended metadata via info
+            info_result = cli_runner.invoke(
+                cli,
+                ["--server", "http://test", "info", f"{artifact_path}:stable"],
+            )
+
+            assert info_result.exit_code == 0, f"Info failed: {info_result.output}"
+            assert expected_hash in info_result.output
+            assert "https://github.com/lifecycle/test@v1.0.0" in info_result.output
+            assert "stable" in info_result.output
+            assert "latest" in info_result.output
+
+            # Step 8: Untag the stable tag
+            untag_result = cli_runner.invoke(
+                cli,
+                ["--server", "http://test", "untag", artifact_path, "stable"],
+            )
+
+            assert untag_result.exit_code == 0, f"Untag failed: {untag_result.output}"
+            assert "Removed tag 'stable'" in untag_result.output
+
+            # Step 9: Verify tag removed via ls
+            ls_after_untag = cli_runner.invoke(
+                cli,
+                ["--server", "http://test", "ls", artifact_path],
+            )
+
+            assert ls_after_untag.exit_code == 0
+            assert "stable" not in ls_after_untag.output
+            # latest should still be there
+            assert "latest" in ls_after_untag.output
+
+
+class TestHashRefVsTagRetrieval:
+    """Tests comparing hash ref retrieval vs tag retrieval."""
+
+    def test_hash_ref_and_tag_return_identical_content(
+        self,
+        cli_runner: CliRunner,
+        api_client: TestClient,
+        tmp_path: Path,
+        test_storage_service: StorageService,
+    ) -> None:
+        """Download by tag and hash ref return identical content."""
+        test_content = b"content for hash vs tag comparison test"
+        files = {"file": ("artifact.bin", io.BytesIO(test_content), "application/octet-stream")}
+        upload_response = api_client.post("/api/v1/upload/hashvstag/compare", files=files)
+        assert upload_response.status_code == 200
+        upload_data = upload_response.json()
+        hash_ref = upload_data["hash_ref"]
+
+        mock_client = MockClientWithDownload(api_client, test_storage_service)
+
+        with patch(PATCH_GET_CLIENT) as mock_get_client:
+            mock_get_client.return_value = mock_client
+
+            # Download by tag
+            output_by_tag = tmp_path / "by_tag.bin"
+            tag_result = cli_runner.invoke(
+                cli,
+                [
+                    "--server",
+                    "http://test",
+                    "get",
+                    "hashvstag/compare:latest",
+                    "-o",
+                    str(output_by_tag),
+                ],
+            )
+
+            assert tag_result.exit_code == 0, f"Tag get failed: {tag_result.output}"
+
+            # Download by hash ref
+            output_by_hash = tmp_path / "by_hash.bin"
+            hash_result = cli_runner.invoke(
+                cli,
+                [
+                    "--server",
+                    "http://test",
+                    "get",
+                    f"hashvstag/compare:{hash_ref}",
+                    "-o",
+                    str(output_by_hash),
+                ],
+            )
+
+            assert hash_result.exit_code == 0, f"Hash get failed: {hash_result.output}"
+
+        # Verify both return identical content
+        assert output_by_tag.read_bytes() == test_content
+        assert output_by_hash.read_bytes() == test_content
+        assert output_by_tag.read_bytes() == output_by_hash.read_bytes()
+
+    def test_tag_uses_symlink_path_hash_uses_blob_path(
+        self,
+        cli_runner: CliRunner,
+        api_client: TestClient,
+        tmp_path: Path,
+        test_storage_service: StorageService,
+    ) -> None:
+        """Verify tag retrieval uses symlink path, hash ref uses blobs/ path."""
+        test_content = b"content for path verification"
+        files = {"file": ("artifact.bin", io.BytesIO(test_content), "application/octet-stream")}
+        upload_response = api_client.post("/api/v1/upload/pathtest/verify", files=files)
+        upload_data = upload_response.json()
+        hash_ref = upload_data["hash_ref"]
+
+        # Track URLs requested
+        urls_requested: list[str] = []
+
+        mock_client = MockClientWithDownload(api_client, test_storage_service)
+        original_stream = mock_client.stream
+
+        def tracking_stream(method: str, url: str) -> MockStreamResponse:
+            urls_requested.append(url)
+            return original_stream(method, url)
+
+        mock_client.stream = tracking_stream
+
+        with patch(PATCH_GET_CLIENT) as mock_get_client:
+            mock_get_client.return_value = mock_client
+
+            # Get by tag
+            output_tag = tmp_path / "tag_path.bin"
+            cli_runner.invoke(
+                cli,
+                [
+                    "--server",
+                    "http://test",
+                    "get",
+                    "pathtest/verify:latest",
+                    "-o",
+                    str(output_tag),
+                ],
+            )
+
+            # Get by hash ref
+            output_hash = tmp_path / "hash_path.bin"
+            cli_runner.invoke(
+                cli,
+                [
+                    "--server",
+                    "http://test",
+                    "get",
+                    f"pathtest/verify:{hash_ref}",
+                    "-o",
+                    str(output_hash),
+                ],
+            )
+
+        # Verify URL patterns
+        assert len(urls_requested) == 2
+        # First request (by tag) should use tag symlink path
+        assert urls_requested[0] == "/artifacts/pathtest/verify/latest"
+        # Second request (by hash) should use blobs/ path
+        blob_name = hash_ref.lstrip("@")
+        assert urls_requested[1] == f"/artifacts/pathtest/verify/blobs/{blob_name}"
+
+    def test_get_specific_version_by_hash_while_latest_differs(
+        self,
+        cli_runner: CliRunner,
+        api_client: TestClient,
+        tmp_path: Path,
+        test_storage_service: StorageService,
+    ) -> None:
+        """Get specific version by hash ref while latest points to different content."""
+        # Upload first version
+        content_v1 = b"version 1 content"
+        files_v1 = {"file": ("artifact.bin", io.BytesIO(content_v1), "application/octet-stream")}
+        upload_v1 = api_client.post("/api/v1/upload/versions/test", files=files_v1)
+        hash_ref_v1 = upload_v1.json()["hash_ref"]
+
+        # Upload second version (this becomes "latest")
+        content_v2 = b"version 2 content - different"
+        files_v2 = {"file": ("artifact.bin", io.BytesIO(content_v2), "application/octet-stream")}
+        api_client.post("/api/v1/upload/versions/test", files=files_v2)
+
+        mock_client = MockClientWithDownload(api_client, test_storage_service)
+
+        with patch(PATCH_GET_CLIENT) as mock_get_client:
+            mock_get_client.return_value = mock_client
+
+            # Get latest (should be v2)
+            output_latest = tmp_path / "latest.bin"
+            cli_runner.invoke(
+                cli,
+                [
+                    "--server",
+                    "http://test",
+                    "get",
+                    "versions/test:latest",
+                    "-o",
+                    str(output_latest),
+                ],
+            )
+
+            # Get v1 by hash ref
+            output_v1 = tmp_path / "v1.bin"
+            cli_runner.invoke(
+                cli,
+                [
+                    "--server",
+                    "http://test",
+                    "get",
+                    f"versions/test:{hash_ref_v1}",
+                    "-o",
+                    str(output_v1),
+                ],
+            )
+
+        # Latest should return v2 content
+        assert output_latest.read_bytes() == content_v2
+        # Hash ref should return v1 content
+        assert output_v1.read_bytes() == content_v1
+        # They should be different
+        assert output_latest.read_bytes() != output_v1.read_bytes()

--- a/tests/integration/test_cli_workflow.py
+++ b/tests/integration/test_cli_workflow.py
@@ -13,123 +13,21 @@ from __future__ import annotations
 import hashlib
 import io
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from click.testing import CliRunner
 from fastapi.testclient import TestClient
 
 from magpie.cli import cli
 from magpie.storage.service import StorageService
-from tests.integration.conftest import upload_test_artifact
+from tests.integration.conftest import (
+    MockClientWithDownload,
+    MockStreamResponse,
+    upload_test_artifact,
+)
 
 # Patch path for get_client - must match where it's imported/used in the CLI module
 PATCH_GET_CLIENT = "magpie.cli.get_client"
-
-
-class MockStreamResponse:
-    """Mock streaming response for download tests."""
-
-    def __init__(self, status_code: int, content: bytes) -> None:
-        self.status_code = status_code
-        self._content = content
-        self.headers = {"content-length": str(len(content))}
-
-    def iter_bytes(self):
-        """Yield content in chunks."""
-        yield self._content
-
-    def read(self) -> bytes:
-        """Read full response body."""
-        return self._content
-
-    def __enter__(self) -> "MockStreamResponse":
-        return self
-
-    def __exit__(self, *args: object) -> None:
-        pass
-
-
-class MockClientWithDownload:
-    """Wrapper around TestClient that handles download endpoints.
-
-    The /artifacts/{path}/{hash_ref} download path isn't a real API endpoint -
-    it's typically served by a static file server. This wrapper intercepts
-    those requests and returns the appropriate content.
-    """
-
-    def __init__(self, api_client: TestClient, storage_service: StorageService) -> None:
-        self.api_client = api_client
-        self.storage_service = storage_service
-
-    def get(self, url: str) -> MagicMock:
-        """Handle GET requests, routing downloads to storage."""
-        if url.startswith("/artifacts/"):
-            return self._handle_download(url)
-        return self.api_client.get(url)
-
-    def stream(self, method: str, url: str) -> MockStreamResponse:
-        """Handle streaming requests for downloads."""
-        if method == "GET" and url.startswith("/artifacts/"):
-            return self._handle_stream_download(url)
-        response = self.api_client.get(url)
-        return MockStreamResponse(response.status_code, response.content)
-
-    def post(self, url: str, **kwargs: object) -> MagicMock:
-        """Delegate POST to api_client."""
-        return self.api_client.post(url, **kwargs)
-
-    def delete(self, url: str, **kwargs: object) -> MagicMock:
-        """Delegate DELETE to api_client."""
-        return self.api_client.delete(url, **kwargs)
-
-    def patch(self, url: str, **kwargs: object) -> MagicMock:
-        """Delegate PATCH to api_client."""
-        return self.api_client.patch(url, **kwargs)
-
-    def _get_download_content(self, url: str) -> tuple[int, bytes]:
-        """Get download content and status code for a URL."""
-        from magpie.storage.blob import read_blob
-        from magpie.storage.paths import artifact_dir_path
-
-        parts = url.split("/")
-
-        if "blobs" in parts:
-            # Pattern: /artifacts/{path}/blobs/{hash}
-            blobs_idx = parts.index("blobs")
-            path = "/".join(parts[2:blobs_idx])
-            hash_ref = "@" + parts[blobs_idx + 1]
-        else:
-            # Pattern: /artifacts/{path}/{hash_ref}
-            hash_ref = parts[-1]
-            path = "/".join(parts[2:-1])
-
-        try:
-            info = self.storage_service.get_artifact_info(path, hash_ref)
-            artifact_dir = artifact_dir_path(self.storage_service.config.storage_path, path)
-            blob_file = read_blob(artifact_dir, info.hash)
-            content = blob_file.read_bytes()
-            return 200, content
-        except Exception:
-            return 404, b""
-
-    def _handle_download(self, url: str) -> MagicMock:
-        """Handle download from /artifacts/ URL."""
-        status_code, content = self._get_download_content(url)
-        response = MagicMock()
-        response.status_code = status_code
-        response.content = content
-        return response
-
-    def _handle_stream_download(self, url: str) -> MockStreamResponse:
-        """Handle streaming download from /artifacts/ URLs."""
-        status_code, content = self._get_download_content(url)
-        return MockStreamResponse(status_code, content)
-
-    def __enter__(self) -> "MockClientWithDownload":
-        return self
-
-    def __exit__(self, *args: object) -> None:
-        pass
 
 
 class TestMultiSegmentPathPush:
@@ -695,6 +593,7 @@ class TestHashRefVsTagRetrieval:
         test_content = b"content for path verification"
         files = {"file": ("artifact.bin", io.BytesIO(test_content), "application/octet-stream")}
         upload_response = api_client.post("/api/v1/upload/pathtest/verify", files=files)
+        assert upload_response.status_code == 200
         upload_data = upload_response.json()
         hash_ref = upload_data["hash_ref"]
 
@@ -761,12 +660,14 @@ class TestHashRefVsTagRetrieval:
         content_v1 = b"version 1 content"
         files_v1 = {"file": ("artifact.bin", io.BytesIO(content_v1), "application/octet-stream")}
         upload_v1 = api_client.post("/api/v1/upload/versions/test", files=files_v1)
+        assert upload_v1.status_code == 200
         hash_ref_v1 = upload_v1.json()["hash_ref"]
 
         # Upload second version (this becomes "latest")
         content_v2 = b"version 2 content - different"
         files_v2 = {"file": ("artifact.bin", io.BytesIO(content_v2), "application/octet-stream")}
-        api_client.post("/api/v1/upload/versions/test", files=files_v2)
+        upload_v2 = api_client.post("/api/v1/upload/versions/test", files=files_v2)
+        assert upload_v2.status_code == 200
 
         mock_client = MockClientWithDownload(api_client, test_storage_service)
 


### PR DESCRIPTION
## Summary

- Add new integration test file `tests/integration/test_cli_workflow.py` with 16 tests covering:
  - Multi-segment path tests (org/project/artifact style) for all CLI commands
  - Complete artifact lifecycle test through all CLI operations
  - Hash ref vs tag retrieval comparison tests
- All tests use Click's CliRunner to test the actual CLI layer
- All 261 integration tests pass

Closes #30

## Test plan

- [x] Run `pytest tests/integration/test_cli_workflow.py -v` - all 16 tests pass
- [x] Run `pytest tests/integration/ -v` - all 261 tests pass
- [ ] CI pipeline passes

---
Generated with Claude Code (Opus 4.5)