### PR TITLE
docs: Update outdated documentation sections

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -53,18 +53,24 @@ src/magpie/
 
 ## Implementation Phases
 
-### Phase 1: Core Upload + Filesystem (current)
+### Phase 1: Core Upload + Filesystem (complete)
 - [x] Scaffolding (pyproject.toml, Dockerfile, docker-compose, FastAPI, CLIs, tooling)
-- [ ] Storage operations (compute_hash, store_artifact, create_tag, list_artifacts)
-- [ ] Upload endpoint (stream, hash, dedupe, move, metadata, symlink)
+- [x] Storage operations (compute_hash, store_artifact, create_tag, list_artifacts)
+- [x] Upload endpoint (stream, hash, dedupe, move, metadata, symlink)
 
-### Phase 2: Tags + CLI
-- [ ] Tag endpoints (POST/DELETE)
-- [ ] Full CLI implementation (config, push, get, ls, info, tag, untag, url)
-- [ ] Token auth (forward_auth, SQLite storage)
+### Phase 2: Tags + CLI (complete)
+- [x] Tag endpoints (POST/DELETE)
+- [x] Full CLI implementation (config, push, get, ls, info, tag, untag, url, amend, gc, flush-tag)
+- [x] Token auth (forward_auth, SQLite storage)
 
-### Phase 3: Polish + Deployment
-### Phase 4: S3 Backup
+### Phase 3: Polish + Deployment (complete)
+- [x] amend command/endpoint
+- [x] gc with symlink reconciliation
+- [x] flush-tag with confirmation
+- [x] Observability (Sentry SDK, OpenTelemetry)
+- [x] Production Caddy configuration with TLS
+
+### Phase 4: S3 Backup (future)
 
 ## Key Design Decisions
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,38 @@
 # Magpie
 
-Content-addressed artifact storage with mutable tags.
+Content-addressed artifact storage with mutable tags for distributing build artifacts,
+container images, and other binary assets.
+
+## Features
+
+- **Content-addressed storage**: Artifacts stored by SHA-256 hash with automatic deduplication
+- **Mutable tags**: Human-readable tags (`latest`, `stable`, `v1.0`) pointing to specific blobs
+- **Provenance tracking**: Optional source URI metadata for traceability
+- **Token authentication**: Scoped tokens (read, write, admin) for CI/CD and machine access
+- **Garbage collection**: Automatic cleanup of untagged artifacts past retention period
+- **Observability**: Sentry integration and OpenTelemetry support
+
+## Quick Start
+
+```bash
+# Configure the client
+export MAGPIE_SERVER=https://magpie.example.com
+export MAGPIE_TOKEN=mgp_your_token
+
+# Upload an artifact
+magpie push myfile.tar.gz --to images/ubuntu
+
+# Download an artifact
+magpie get images/ubuntu:latest
+
+# List versions
+magpie ls images/ubuntu
+
+# Create a tag
+magpie tag images/ubuntu:latest --as stable
+```
+
+See [docs/user-guide.md](docs/user-guide.md) for complete documentation.
 
 ## Development
 
@@ -64,4 +96,46 @@ src/magpie/
   storage/    # Filesystem operations (blobs, manifests, tags)
   cli/        # Client CLI (magpie)
   ctl/        # Server admin CLI (magpie-ctl)
+  auth/       # Token authentication and database
+```
+
+## CLI Commands
+
+### Client (`magpie`)
+
+| Command | Description |
+|---------|-------------|
+| `push` | Upload an artifact to the server |
+| `get` | Download an artifact |
+| `ls` | List artifact versions |
+| `info` | Show artifact metadata |
+| `url` | Get download URL for scripting |
+| `tag` | Create or update a tag |
+| `untag` | Remove a tag |
+| `amend` | Update artifact metadata |
+| `gc` | Run garbage collection (admin) |
+| `flush-tag` | Remove tag globally (admin) |
+| `config` | Show resolved configuration |
+
+### Server Admin (`magpie-ctl`)
+
+| Command | Description |
+|---------|-------------|
+| `init` | Initialize storage and create admin token |
+| `token` | Manage tokens (create, list, revoke) |
+| `gc` | Run garbage collection |
+| `flush-tag` | Remove tag globally |
+
+## Testing
+
+```bash
+# Run all tests
+uv run pytest
+
+# Run with coverage
+uv run pytest --cov=magpie
+
+# Run linting
+uv run ruff check .
+uv run ruff format --check .
 ```


### PR DESCRIPTION
Closes #149

## Summary

- **copilot-instructions.md**: Updated implementation phases checklist to reflect current state
  - Phase 1-3 now marked as complete with all items checked
  - Added detailed Phase 3 items (amend, gc, flush-tag, observability, production Caddy)
  - Phase 4 (S3 Backup) marked as future work

- **README.md**: Expanded to reflect full feature set
  - Added Features section listing key capabilities
  - Added Quick Start section with common CLI examples
  - Added CLI Commands reference tables for both `magpie` and `magpie-ctl`
  - Added Testing section with pytest and linting commands
  - Updated project structure to include auth/ directory

### Not Updated (already current or non-existent)

- **assessment-findings.md**: File does not exist in this repository
- **user-guide.md**: Already documented MAGPIE_TIMEOUT and uses correct `/blobs/{hash}` URL format

---
Generated with Claude Code (Opus 4.5)