### PR TITLE
fix: Add __main__.py for magpie.ctl module

### DIFF
--- a/src/magpie/ctl/__main__.py
+++ b/src/magpie/ctl/__main__.py
@@ -1,0 +1,6 @@
+"""Entry point for python -m magpie.ctl."""
+
+from magpie.ctl import main
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds `src/magpie/ctl/__main__.py` to enable `python -m magpie.ctl` execution.

This is required by the Docker entrypoint (`entrypoint.sh`) which runs:
```bash
gosu "$RUN_UID:$RUN_GID" /app/.venv/bin/python -m magpie.ctl init
```

Without `__main__.py`, this fails with:
```
No module named magpie.ctl.__main__; 'magpie.ctl' is a package and cannot be directly executed
```

## Test

```bash
uv run python -m magpie.ctl --help
```

---
Generated with Claude Code (Opus 4.5)