### PR TITLE
Fix Caddyfile regex to match /api/v1/artifacts base path

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -62,11 +62,13 @@
 	}
 
 	# Artifact read operations (GET only) - public access
-	# Matches: GET /api/v1/artifacts/{path}, GET /api/v1/artifacts/{path}/{ref}/info
+	# Matches: GET /api/v1/artifacts (list all paths)
+	#          GET /api/v1/artifacts/{path} (list versions)
+	#          GET /api/v1/artifacts/{path}/{ref}/info (get info)
 	# Note: POST/DELETE to /artifacts/*/tags* are handled by protected routes below
 	@artifacts_read {
 		method GET
-		path_regexp read ^/api/v1/artifacts/.+
+		path_regexp read ^/api/v1/artifacts(/.*)?$
 	}
 	handle @artifacts_read {
 		reverse_proxy magpie:8000


### PR DESCRIPTION
## Summary
- Fix Caddyfile regex that was preventing `GET /api/v1/artifacts` from working
- The regex `^/api/v1/artifacts/.+` required at least one character after the trailing slash
- Changed to `^/api/v1/artifacts(/.*)?$` which correctly matches the base path
- Fixes `magpie ls` without parameters returning 404

## Test plan
- [ ] Deploy on VM and verify `magpie ls` without parameters works
- [ ] Verify `curl http://localhost:8080/api/v1/artifacts` returns artifact paths list
- [ ] Verify existing routes still work (list versions, get info)

🤖 Generated with [Claude Code](https://claude.com/claude-code)