### PR TITLE
docs: Add Ansible integration guide for authenticated artifact pulls

### DIFF
--- a/docs/ansible-integration.md
+++ b/docs/ansible-integration.md
@@ -1,12 +1,13 @@
 # Ansible Integration Guide
 
 This guide covers how to download artifacts from Magpie in Ansible playbooks,
-with secure token handling and checksum verification.
+with optional secure token handling and checksum verification.
 
 ## Overview
 
 Magpie artifacts can be pulled from Ansible using the `ansible.builtin.get_url`
-module with bearer token authentication. This is the recommended approach for:
+module. Bearer token authentication is optional for downloads (public by default)
+but required for uploads and tag management. This is the recommended approach for:
 
 - Deploying scripts and binaries to managed hosts
 - Distributing configuration files
@@ -16,10 +17,58 @@ module with bearer token authentication. This is the recommended approach for:
 ## Prerequisites
 
 - Magpie server accessible from Ansible control node or target hosts
-- Read-scoped bearer token (created via `magpie-ctl token create --scope read`)
-- Ansible Vault configured for secret storage
+- (Optional) Magpie bearer token if your playbooks will upload artifacts or manage tags
+- (Recommended) Ansible Vault configured for secret storage when using bearer tokens
 
-## Secure Token Storage
+## Basic Download Pattern
+
+Artifact downloads are public by default and do not require authentication.
+
+### Simple Artifact Download
+
+```yaml
+---
+- name: Download artifact from Magpie
+  hosts: all
+  vars:
+    magpie_server: "https://magpie.example.com"
+
+  tasks:
+    - name: Download scoring engine
+      ansible.builtin.get_url:
+        url: "{{ magpie_server }}/artifacts/scoring/engine/latest"
+        dest: /opt/scoring/engine
+        mode: "0755"
+        owner: root
+        group: root
+```
+
+### Download with Specific Tag
+
+```yaml
+- name: Download specific version of config bundle
+  ansible.builtin.get_url:
+    url: "{{ magpie_server }}/artifacts/configs/webapp/v2.1"
+    dest: /etc/webapp/config.tar.gz
+    mode: "0644"
+```
+
+### Download by Hash Reference
+
+For immutable deployments, pin to a specific blob hash:
+
+```yaml
+- name: Download artifact by hash ref
+  ansible.builtin.get_url:
+    url: "{{ magpie_server }}/artifacts/tools/validator/blobs/a1b2c3d4"
+    dest: /usr/local/bin/validator
+    mode: "0755"
+```
+
+## Secure Token Storage (For Write Operations)
+
+Tokens are only required for write operations (uploads, tag management). If you
+only need to download artifacts, you can skip this section.
 
 **Never store tokens in plaintext in playbooks or variable files.**
 
@@ -49,56 +98,6 @@ ansible-vault encrypt_string 'mgp_your_read_token_here' --name 'vault_magpie_tok
 
 Paste the output into your vars file.
 
-## Basic Download Pattern
-
-### Simple Artifact Download
-
-```yaml
----
-- name: Download artifact from Magpie
-  hosts: all
-  vars:
-    magpie_server: "https://magpie.example.com"
-    magpie_token: "{{ vault_magpie_token }}"
-
-  tasks:
-    - name: Download scoring engine
-      ansible.builtin.get_url:
-        url: "{{ magpie_server }}/artifacts/scoring/engine/latest"
-        dest: /opt/scoring/engine
-        headers:
-          Authorization: "Bearer {{ magpie_token }}"
-        mode: "0755"
-        owner: root
-        group: root
-```
-
-### Download with Specific Tag
-
-```yaml
-- name: Download specific version of config bundle
-  ansible.builtin.get_url:
-    url: "{{ magpie_server }}/artifacts/configs/webapp/v2.1"
-    dest: /etc/webapp/config.tar.gz
-    headers:
-      Authorization: "Bearer {{ magpie_token }}"
-    mode: "0644"
-```
-
-### Download by Hash Reference
-
-For immutable deployments, pin to a specific blob hash:
-
-```yaml
-- name: Download artifact by hash ref
-  ansible.builtin.get_url:
-    url: "{{ magpie_server }}/artifacts/tools/validator/blobs/a1b2c3d4"
-    dest: /usr/local/bin/validator
-    headers:
-      Authorization: "Bearer {{ magpie_token }}"
-    mode: "0755"
-```
-
 ## Checksum Verification
 
 ### Using Hash References for Immutable Downloads
@@ -119,12 +118,10 @@ tasks:
     ansible.builtin.get_url:
       url: "{{ magpie_server }}/artifacts/scoring/engine/blobs/{{ artifact_hashes.scoring_engine }}"
       dest: /opt/scoring/engine
-      headers:
-        Authorization: "Bearer {{ magpie_token }}"
       mode: "0755"
 ```
 
-Use `magpie tags <artifact-path>` to list tags with their blob hashes.
+Use `magpie ls <artifact-path>` to list tags with their blob hashes.
 
 ### Pre-defined Checksum in Variables
 
@@ -141,8 +138,6 @@ tasks:
     ansible.builtin.get_url:
       url: "{{ magpie_server }}/artifacts/scoring/engine/stable"
       dest: /opt/scoring/engine
-      headers:
-        Authorization: "Bearer {{ magpie_token }}"
       checksum: "{{ artifact_checksums.scoring_engine }}"
       mode: "0755"
 ```
@@ -156,8 +151,6 @@ tasks:
   ansible.builtin.get_url:
     url: "{{ magpie_server }}/artifacts/scripts/{{ item.name }}/latest"
     dest: "/usr/local/bin/{{ item.name }}"
-    headers:
-      Authorization: "Bearer {{ magpie_token }}"
     mode: "0755"
   loop:
     - name: setup-network
@@ -172,8 +165,6 @@ tasks:
   ansible.builtin.get_url:
     url: "{{ magpie_server }}/artifacts/configs/nginx/{{ config_version }}"
     dest: /tmp/nginx-config.tar.gz
-    headers:
-      Authorization: "Bearer {{ magpie_token }}"
     mode: "0644"
 
 - name: Extract configuration
@@ -198,8 +189,6 @@ tasks:
       ansible.builtin.get_url:
         url: "{{ magpie_server }}/artifacts/apps/myapp/{{ myapp_version | default('stable') }}"
         dest: /opt/myapp/bin/myapp
-        headers:
-          Authorization: "Bearer {{ magpie_token }}"
         mode: "0755"
         force: true  # Re-download if changed
       register: download_result
@@ -223,8 +212,6 @@ tasks:
   ansible.builtin.get_url:
     url: "{{ magpie_server }}/artifacts/tools/analyzer/latest"
     dest: /opt/tools/analyzer
-    headers:
-      Authorization: "Bearer {{ magpie_token }}"
     mode: "0755"
   when: not existing_binary.stat.exists
 ```
@@ -264,15 +251,12 @@ magpie_force: false
     that:
       - magpie_artifact_path | length > 0
       - magpie_dest | length > 0
-      - vault_magpie_token is defined
     fail_msg: "Required magpie_artifact variables not set"
 
 - name: Download artifact from Magpie
   ansible.builtin.get_url:
     url: "{{ magpie_server }}/artifacts/{{ magpie_artifact_path }}/{{ magpie_artifact_tag }}"
     dest: "{{ magpie_dest }}"
-    headers:
-      Authorization: "Bearer {{ vault_magpie_token }}"
     mode: "{{ magpie_mode }}"
     owner: "{{ magpie_owner }}"
     group: "{{ magpie_group }}"
@@ -304,36 +288,37 @@ magpie_force: false
 
 ## Troubleshooting
 
-### 401 Unauthorized
+### 401 Unauthorized / 403 Forbidden
 
-The token is missing or invalid:
+These errors should not occur for artifact downloads since downloads are public
+by default. If you encounter these errors:
 
-```yaml
-# Verify token is being passed
-- name: Debug token presence
-  ansible.builtin.debug:
-    msg: "Token starts with: {{ vault_magpie_token[:10] }}..."
-  no_log: false  # Temporarily enable for debugging
-```
+1. **For downloads**: Check if your administrator has enabled Authentik SSO for
+   browser-based artifact browsing. If so, you may need to add authentication
+   headers.
 
-Check that:
-- The vault file is being decrypted (run with `--ask-vault-pass`)
-- Variable name matches exactly (`vault_magpie_token`)
-- Token has not been revoked on the server
+2. **For write operations** (uploads, tag management): Verify your token:
+   ```yaml
+   # Verify token is being passed
+   - name: Debug token presence
+     ansible.builtin.debug:
+       msg: "Token starts with: {{ vault_magpie_token[:10] }}..."
+     no_log: false  # Temporarily enable for debugging
+   ```
 
-### 403 Forbidden
-
-Token lacks required permissions. For downloads, you need at least `read` scope.
-Contact your Magpie administrator for a token with appropriate scope.
+   Check that:
+   - The vault file is being decrypted (run with `--ask-vault-pass`)
+   - Variable name matches exactly (`vault_magpie_token`)
+   - Token has not been revoked on the server
+   - Token has appropriate scope for the operation (write scope for uploads)
 
 ### 404 Not Found
 
 The artifact path or tag does not exist:
 
 ```bash
-# Verify artifact exists using curl
-curl -H "Authorization: Bearer $TOKEN" \
-  https://magpie.example.com/api/v1/artifacts/path/to/artifact
+# Verify artifact exists using curl (no auth needed for downloads)
+curl https://magpie.example.com/artifacts/path/to/artifact/latest
 ```
 
 ### Connection Timeouts
@@ -345,8 +330,6 @@ For large artifacts, increase the timeout:
   ansible.builtin.get_url:
     url: "{{ magpie_server }}/artifacts/images/large-vm/latest"
     dest: /var/lib/images/vm.qcow2
-    headers:
-      Authorization: "Bearer {{ magpie_token }}"
     timeout: 600  # 10 minutes
     mode: "0644"
 ```
@@ -364,7 +347,7 @@ integrity. Hash refs are immutable--they always return the same content:
 
 ```yaml
 vars:
-  # Get hash from: magpie tags app/binary
+  # Get hash from: magpie ls app/binary
   app_binary_hash: "a1b2c3d4"
 
 tasks:
@@ -372,30 +355,32 @@ tasks:
     ansible.builtin.get_url:
       url: "{{ magpie_server }}/artifacts/app/binary/blobs/{{ app_binary_hash }}"
       dest: /opt/app/binary
-      headers:
-        Authorization: "Bearer {{ magpie_token }}"
       mode: "0755"
 ```
 
 ## Security Best Practices
 
-1. **Use read-only tokens** - Create tokens with minimal scope for artifact pulls
-2. **Vault-encrypt tokens** - Never store tokens in plaintext
-3. **Use `no_log`** - Prevent token exposure in logs:
+1. **Token usage** - Artifact downloads are public by default and do not require
+   tokens. For write operations (uploads, tag management), use tokens with the
+   minimal required scope. If your administrator has enabled authentication for
+   downloads, use read-only tokens for download operations.
+2. **Vault-encrypt tokens** - When using tokens, never store them in plaintext
+3. **Use `no_log`** - When using tokens, prevent exposure in logs:
    ```yaml
-   - name: Download sensitive artifact
-     ansible.builtin.get_url:
-       url: "{{ magpie_server }}/artifacts/secrets/cert/latest"
-       dest: /etc/ssl/cert.pem
+   - name: Upload artifact to Magpie (requires token)
+     ansible.builtin.uri:
+       url: "{{ magpie_server }}/api/v1/upload/path/to/artifact"
+       method: POST
        headers:
          Authorization: "Bearer {{ magpie_token }}"
+       # ... upload configuration
      no_log: true
    ```
 4. **Pin versions for production** - Use specific tags or hash refs instead of `latest`
 5. **Verify integrity** - For security-sensitive artifacts, use one of these approaches:
    - **Hash refs** (recommended): Download via `/blobs/<hash>` for content-addressed immutability
    - **Pre-defined checksums**: Store expected SHA-256 in vault-encrypted variables
-6. **Rotate tokens periodically** - Update vault-stored tokens on a schedule
+6. **Rotate tokens periodically** - If using tokens, update vault-stored tokens on a schedule
 
 ## See Also
 

--- a/docs/ansible-integration.md
+++ b/docs/ansible-integration.md
@@ -5,30 +5,23 @@ with secure token handling and checksum verification.
 
 ## Overview
 
-Magpie artifact downloads are **public by default** -- no authentication is required
-to download from `/artifacts/*` endpoints. Simply use `ansible.builtin.get_url`
-without any Authorization header for:
+Magpie artifacts can be pulled from Ansible using the `ansible.builtin.get_url`
+module with bearer token authentication. This is the recommended approach for:
 
 - Deploying scripts and binaries to managed hosts
 - Distributing configuration files
 - Pulling game assets during competition setup
 - Retrieving certificates or other security artifacts
 
-Bearer tokens are only required for **write operations** (uploads, tag management)
-and **admin operations** (token management, garbage collection).
-
 ## Prerequisites
 
 - Magpie server accessible from Ansible control node or target hosts
-- (Optional) Bearer token -- only needed if SSO is enabled or for write operations
-- Ansible Vault configured for secret storage (if using tokens)
+- Read-scoped bearer token (created via `magpie-ctl token create --scope read`)
+- Ansible Vault configured for secret storage
 
 ## Secure Token Storage
 
-> **Note:** Tokens are only required for write operations (uploads, tag management)
-> and admin operations. For download-only playbooks, you can skip this section entirely.
-
-**If you need tokens, never store them in plaintext in playbooks or variable files.**
+**Never store tokens in plaintext in playbooks or variable files.**
 
 ### Creating an Encrypted Variables File
 
@@ -58,8 +51,6 @@ Paste the output into your vars file.
 
 ## Basic Download Pattern
 
-Artifact downloads from Magpie are public -- no authentication header is needed.
-
 ### Simple Artifact Download
 
 ```yaml
@@ -68,12 +59,15 @@ Artifact downloads from Magpie are public -- no authentication header is needed.
   hosts: all
   vars:
     magpie_server: "https://magpie.example.com"
+    magpie_token: "{{ vault_magpie_token }}"
 
   tasks:
     - name: Download scoring engine
       ansible.builtin.get_url:
         url: "{{ magpie_server }}/artifacts/scoring/engine/latest"
         dest: /opt/scoring/engine
+        headers:
+          Authorization: "Bearer {{ magpie_token }}"
         mode: "0755"
         owner: root
         group: root
@@ -86,6 +80,8 @@ Artifact downloads from Magpie are public -- no authentication header is needed.
   ansible.builtin.get_url:
     url: "{{ magpie_server }}/artifacts/configs/webapp/v2.1"
     dest: /etc/webapp/config.tar.gz
+    headers:
+      Authorization: "Bearer {{ magpie_token }}"
     mode: "0644"
 ```
 
@@ -98,6 +94,8 @@ For immutable deployments, pin to a specific blob hash:
   ansible.builtin.get_url:
     url: "{{ magpie_server }}/artifacts/tools/validator/blobs/a1b2c3d4"
     dest: /usr/local/bin/validator
+    headers:
+      Authorization: "Bearer {{ magpie_token }}"
     mode: "0755"
 ```
 
@@ -121,6 +119,8 @@ tasks:
     ansible.builtin.get_url:
       url: "{{ magpie_server }}/artifacts/scoring/engine/blobs/{{ artifact_hashes.scoring_engine }}"
       dest: /opt/scoring/engine
+      headers:
+        Authorization: "Bearer {{ magpie_token }}"
       mode: "0755"
 ```
 
@@ -141,6 +141,8 @@ tasks:
     ansible.builtin.get_url:
       url: "{{ magpie_server }}/artifacts/scoring/engine/stable"
       dest: /opt/scoring/engine
+      headers:
+        Authorization: "Bearer {{ magpie_token }}"
       checksum: "{{ artifact_checksums.scoring_engine }}"
       mode: "0755"
 ```
@@ -154,6 +156,8 @@ tasks:
   ansible.builtin.get_url:
     url: "{{ magpie_server }}/artifacts/scripts/{{ item.name }}/latest"
     dest: "/usr/local/bin/{{ item.name }}"
+    headers:
+      Authorization: "Bearer {{ magpie_token }}"
     mode: "0755"
   loop:
     - name: setup-network
@@ -168,6 +172,8 @@ tasks:
   ansible.builtin.get_url:
     url: "{{ magpie_server }}/artifacts/configs/nginx/{{ config_version }}"
     dest: /tmp/nginx-config.tar.gz
+    headers:
+      Authorization: "Bearer {{ magpie_token }}"
     mode: "0644"
 
 - name: Extract configuration
@@ -192,6 +198,8 @@ tasks:
       ansible.builtin.get_url:
         url: "{{ magpie_server }}/artifacts/apps/myapp/{{ myapp_version | default('stable') }}"
         dest: /opt/myapp/bin/myapp
+        headers:
+          Authorization: "Bearer {{ magpie_token }}"
         mode: "0755"
         force: true  # Re-download if changed
       register: download_result
@@ -215,14 +223,15 @@ tasks:
   ansible.builtin.get_url:
     url: "{{ magpie_server }}/artifacts/tools/analyzer/latest"
     dest: /opt/tools/analyzer
+    headers:
+      Authorization: "Bearer {{ magpie_token }}"
     mode: "0755"
   when: not existing_binary.stat.exists
 ```
 
 ## Role Example
 
-A reusable role for pulling Magpie artifacts. Since downloads are public by default,
-the token is optional and only needed if SSO is enabled on the server.
+A reusable role for pulling Magpie artifacts:
 
 ### Role Structure
 
@@ -244,8 +253,6 @@ magpie_mode: "0644"
 magpie_owner: root
 magpie_group: root
 magpie_force: false
-# Optional: only needed if SSO is enabled on the Magpie server
-# magpie_token: "{{ vault_magpie_token }}"
 ```
 
 ### tasks/main.yml
@@ -257,13 +264,15 @@ magpie_force: false
     that:
       - magpie_artifact_path | length > 0
       - magpie_dest | length > 0
+      - vault_magpie_token is defined
     fail_msg: "Required magpie_artifact variables not set"
 
 - name: Download artifact from Magpie
   ansible.builtin.get_url:
     url: "{{ magpie_server }}/artifacts/{{ magpie_artifact_path }}/{{ magpie_artifact_tag }}"
     dest: "{{ magpie_dest }}"
-    headers: "{{ {'Authorization': 'Bearer ' + magpie_token} if magpie_token is defined else omit }}"
+    headers:
+      Authorization: "Bearer {{ vault_magpie_token }}"
     mode: "{{ magpie_mode }}"
     owner: "{{ magpie_owner }}"
     group: "{{ magpie_group }}"
@@ -295,28 +304,36 @@ magpie_force: false
 
 ## Troubleshooting
 
-### 401 Unauthorized / 403 Forbidden
+### 401 Unauthorized
 
-**For artifact downloads:** These errors should NOT occur for public download endpoints
-(`/artifacts/*`) unless SSO is enabled on the Magpie server. If you see these errors
-when downloading artifacts:
+The token is missing or invalid:
 
-1. Check if SSO is enabled -- if so, you need a token
-2. Verify you are using the correct URL path (`/artifacts/...` not `/api/...`)
+```yaml
+# Verify token is being passed
+- name: Debug token presence
+  ansible.builtin.debug:
+    msg: "Token starts with: {{ vault_magpie_token[:10] }}..."
+  no_log: false  # Temporarily enable for debugging
+```
 
-**For write operations (uploads, tag management):** Token is required. Check that:
+Check that:
 - The vault file is being decrypted (run with `--ask-vault-pass`)
 - Variable name matches exactly (`vault_magpie_token`)
 - Token has not been revoked on the server
-- Token has appropriate scope (`write` or `admin`)
+
+### 403 Forbidden
+
+Token lacks required permissions. For downloads, you need at least `read` scope.
+Contact your Magpie administrator for a token with appropriate scope.
 
 ### 404 Not Found
 
 The artifact path or tag does not exist:
 
 ```bash
-# Verify artifact exists using curl (no auth needed for downloads)
-curl https://magpie.example.com/artifacts/path/to/artifact/latest
+# Verify artifact exists using curl
+curl -H "Authorization: Bearer $TOKEN" \
+  https://magpie.example.com/api/v1/artifacts/path/to/artifact
 ```
 
 ### Connection Timeouts
@@ -328,6 +345,8 @@ For large artifacts, increase the timeout:
   ansible.builtin.get_url:
     url: "{{ magpie_server }}/artifacts/images/large-vm/latest"
     dest: /var/lib/images/vm.qcow2
+    headers:
+      Authorization: "Bearer {{ magpie_token }}"
     timeout: 600  # 10 minutes
     mode: "0644"
 ```
@@ -353,31 +372,30 @@ tasks:
     ansible.builtin.get_url:
       url: "{{ magpie_server }}/artifacts/app/binary/blobs/{{ app_binary_hash }}"
       dest: /opt/app/binary
+      headers:
+        Authorization: "Bearer {{ magpie_token }}"
       mode: "0755"
 ```
 
 ## Security Best Practices
 
-1. **Downloads are public** - Magpie artifact downloads require no authentication by default.
-   Tokens are only needed for write operations (uploads, tag management) or if SSO is enabled.
-2. **Vault-encrypt tokens when needed** - If you use tokens for write operations, never store
-   them in plaintext
-3. **Use `no_log` for upload tasks** - Prevent token exposure in logs when uploading:
+1. **Use read-only tokens** - Create tokens with minimal scope for artifact pulls
+2. **Vault-encrypt tokens** - Never store tokens in plaintext
+3. **Use `no_log`** - Prevent token exposure in logs:
    ```yaml
-   - name: Upload artifact to Magpie
-     ansible.builtin.uri:
-       url: "{{ magpie_server }}/api/v1/artifacts/path/tag"
-       method: PUT
+   - name: Download sensitive artifact
+     ansible.builtin.get_url:
+       url: "{{ magpie_server }}/artifacts/secrets/cert/latest"
+       dest: /etc/ssl/cert.pem
        headers:
          Authorization: "Bearer {{ magpie_token }}"
-       src: /path/to/artifact
      no_log: true
    ```
 4. **Pin versions for production** - Use specific tags or hash refs instead of `latest`
 5. **Verify integrity** - For security-sensitive artifacts, use one of these approaches:
    - **Hash refs** (recommended): Download via `/blobs/<hash>` for content-addressed immutability
-   - **Pre-defined checksums**: Store expected SHA-256 in variables
-6. **Rotate tokens periodically** - If using tokens for write operations, update them on a schedule
+   - **Pre-defined checksums**: Store expected SHA-256 in vault-encrypted variables
+6. **Rotate tokens periodically** - Update vault-stored tokens on a schedule
 
 ## See Also
 

--- a/docs/ansible-integration.md
+++ b/docs/ansible-integration.md
@@ -1,0 +1,409 @@
+# Ansible Integration Guide
+
+This guide covers how to download artifacts from Magpie in Ansible playbooks,
+with secure token handling and checksum verification.
+
+## Overview
+
+Magpie artifacts can be pulled from Ansible using the `ansible.builtin.get_url`
+module with bearer token authentication. This is the recommended approach for:
+
+- Deploying scripts and binaries to managed hosts
+- Distributing configuration files
+- Pulling game assets during competition setup
+- Retrieving certificates or other security artifacts
+
+## Prerequisites
+
+- Magpie server accessible from Ansible control node or target hosts
+- Read-scoped bearer token (created via `magpie-ctl token create --scope read`)
+- Ansible Vault configured for secret storage
+
+## Secure Token Storage
+
+**Never store tokens in plaintext in playbooks or variable files.**
+
+### Creating an Encrypted Variables File
+
+Create a vault-encrypted file for Magpie credentials:
+
+```bash
+# Create encrypted vars file
+ansible-vault create group_vars/all/vault.yml
+```
+
+Add the token:
+
+```yaml
+# group_vars/all/vault.yml (encrypted)
+vault_magpie_token: "mgp_your_read_token_here"
+```
+
+### Alternative: Single Variable Encryption
+
+For simpler setups, encrypt just the token value:
+
+```bash
+ansible-vault encrypt_string 'mgp_your_read_token_here' --name 'vault_magpie_token'
+```
+
+Paste the output into your vars file.
+
+## Basic Download Pattern
+
+### Simple Artifact Download
+
+```yaml
+---
+- name: Download artifact from Magpie
+  hosts: all
+  vars:
+    magpie_server: "https://magpie.example.com"
+    magpie_token: "{{ vault_magpie_token }}"
+
+  tasks:
+    - name: Download scoring engine
+      ansible.builtin.get_url:
+        url: "{{ magpie_server }}/artifacts/scoring/engine/latest"
+        dest: /opt/scoring/engine
+        headers:
+          Authorization: "Bearer {{ magpie_token }}"
+        mode: "0755"
+        owner: root
+        group: root
+```
+
+### Download with Specific Tag
+
+```yaml
+- name: Download specific version of config bundle
+  ansible.builtin.get_url:
+    url: "{{ magpie_server }}/artifacts/configs/webapp/v2.1"
+    dest: /etc/webapp/config.tar.gz
+    headers:
+      Authorization: "Bearer {{ magpie_token }}"
+    mode: "0644"
+```
+
+### Download by Hash Reference
+
+For immutable deployments, pin to a specific blob hash:
+
+```yaml
+- name: Download artifact by hash ref
+  ansible.builtin.get_url:
+    url: "{{ magpie_server }}/artifacts/tools/validator/blobs/a1b2c3d4"
+    dest: /usr/local/bin/validator
+    headers:
+      Authorization: "Bearer {{ magpie_token }}"
+    mode: "0755"
+```
+
+## Checksum Verification
+
+### Using Magpie's SHA-256 Checksums
+
+If your Magpie deployment provides `.sha256` sidecar files, you can verify
+downloads automatically:
+
+```yaml
+- name: Get checksum for artifact
+  ansible.builtin.uri:
+    url: "{{ magpie_server }}/artifacts/binaries/app/latest.sha256"
+    headers:
+      Authorization: "Bearer {{ magpie_token }}"
+    return_content: true
+  register: checksum_result
+
+- name: Download artifact with checksum verification
+  ansible.builtin.get_url:
+    url: "{{ magpie_server }}/artifacts/binaries/app/latest"
+    dest: /opt/app/binary
+    headers:
+      Authorization: "Bearer {{ magpie_token }}"
+    checksum: "sha256:{{ checksum_result.content | trim }}"
+    mode: "0755"
+```
+
+### Pre-defined Checksum in Variables
+
+For critical artifacts, define expected checksums in your playbook or vars:
+
+```yaml
+vars:
+  artifact_checksums:
+    scoring_engine: "sha256:abc123def456..."
+    config_bundle: "sha256:789xyz..."
+
+tasks:
+  - name: Download with known checksum
+    ansible.builtin.get_url:
+      url: "{{ magpie_server }}/artifacts/scoring/engine/stable"
+      dest: /opt/scoring/engine
+      headers:
+        Authorization: "Bearer {{ magpie_token }}"
+      checksum: "{{ artifact_checksums.scoring_engine }}"
+      mode: "0755"
+```
+
+## Common Use Patterns
+
+### Deploying Scripts
+
+```yaml
+- name: Deploy initialization scripts
+  ansible.builtin.get_url:
+    url: "{{ magpie_server }}/artifacts/scripts/{{ item.name }}/latest"
+    dest: "/usr/local/bin/{{ item.name }}"
+    headers:
+      Authorization: "Bearer {{ magpie_token }}"
+    mode: "0755"
+  loop:
+    - name: setup-network
+    - name: configure-firewall
+    - name: init-services
+```
+
+### Deploying Configuration Archives
+
+```yaml
+- name: Download configuration archive
+  ansible.builtin.get_url:
+    url: "{{ magpie_server }}/artifacts/configs/nginx/{{ config_version }}"
+    dest: /tmp/nginx-config.tar.gz
+    headers:
+      Authorization: "Bearer {{ magpie_token }}"
+    mode: "0644"
+
+- name: Extract configuration
+  ansible.builtin.unarchive:
+    src: /tmp/nginx-config.tar.gz
+    dest: /etc/nginx/
+    remote_src: true
+  notify: Reload nginx
+
+- name: Clean up archive
+  ansible.builtin.file:
+    path: /tmp/nginx-config.tar.gz
+    state: absent
+```
+
+### Installing Binaries with Version Pinning
+
+```yaml
+- name: Install application binary
+  block:
+    - name: Download binary
+      ansible.builtin.get_url:
+        url: "{{ magpie_server }}/artifacts/apps/myapp/{{ myapp_version | default('stable') }}"
+        dest: /opt/myapp/bin/myapp
+        headers:
+          Authorization: "Bearer {{ magpie_token }}"
+        mode: "0755"
+        force: true  # Re-download if changed
+      register: download_result
+
+    - name: Restart service if binary changed
+      ansible.builtin.systemd:
+        name: myapp
+        state: restarted
+      when: download_result.changed
+```
+
+### Conditional Downloads
+
+```yaml
+- name: Check if artifact needs update
+  ansible.builtin.stat:
+    path: /opt/tools/analyzer
+  register: existing_binary
+
+- name: Download artifact only if missing
+  ansible.builtin.get_url:
+    url: "{{ magpie_server }}/artifacts/tools/analyzer/latest"
+    dest: /opt/tools/analyzer
+    headers:
+      Authorization: "Bearer {{ magpie_token }}"
+    mode: "0755"
+  when: not existing_binary.stat.exists
+```
+
+## Role Example
+
+A reusable role for pulling Magpie artifacts:
+
+### Role Structure
+
+```
+roles/magpie_artifact/
+  defaults/main.yml
+  tasks/main.yml
+```
+
+### defaults/main.yml
+
+```yaml
+---
+magpie_server: "https://magpie.example.com"
+magpie_artifact_path: ""
+magpie_artifact_tag: "latest"
+magpie_dest: ""
+magpie_mode: "0644"
+magpie_owner: root
+magpie_group: root
+magpie_force: false
+```
+
+### tasks/main.yml
+
+```yaml
+---
+- name: Validate required variables
+  ansible.builtin.assert:
+    that:
+      - magpie_artifact_path | length > 0
+      - magpie_dest | length > 0
+      - vault_magpie_token is defined
+    fail_msg: "Required magpie_artifact variables not set"
+
+- name: Download artifact from Magpie
+  ansible.builtin.get_url:
+    url: "{{ magpie_server }}/artifacts/{{ magpie_artifact_path }}/{{ magpie_artifact_tag }}"
+    dest: "{{ magpie_dest }}"
+    headers:
+      Authorization: "Bearer {{ vault_magpie_token }}"
+    mode: "{{ magpie_mode }}"
+    owner: "{{ magpie_owner }}"
+    group: "{{ magpie_group }}"
+    force: "{{ magpie_force }}"
+  register: magpie_download_result
+```
+
+### Using the Role
+
+```yaml
+- name: Deploy scoring components
+  hosts: scoring_servers
+  roles:
+    - role: magpie_artifact
+      vars:
+        magpie_artifact_path: "scoring/engine"
+        magpie_artifact_tag: "stable"
+        magpie_dest: /opt/scoring/engine
+        magpie_mode: "0755"
+
+    - role: magpie_artifact
+      vars:
+        magpie_artifact_path: "scoring/config"
+        magpie_artifact_tag: "quals-2026"
+        magpie_dest: /opt/scoring/config.yml
+        magpie_mode: "0640"
+        magpie_group: scoring
+```
+
+## Troubleshooting
+
+### 401 Unauthorized
+
+The token is missing or invalid:
+
+```yaml
+# Verify token is being passed
+- name: Debug token presence
+  ansible.builtin.debug:
+    msg: "Token starts with: {{ vault_magpie_token[:10] }}..."
+  no_log: false  # Temporarily enable for debugging
+```
+
+Check that:
+- The vault file is being decrypted (run with `--ask-vault-pass`)
+- Variable name matches exactly (`vault_magpie_token`)
+- Token has not been revoked on the server
+
+### 403 Forbidden
+
+Token lacks required permissions. For downloads, you need at least `read` scope.
+Contact your Magpie administrator for a token with appropriate scope.
+
+### 404 Not Found
+
+The artifact path or tag does not exist:
+
+```bash
+# Verify artifact exists using curl
+curl -H "Authorization: Bearer $TOKEN" \
+  https://magpie.example.com/api/v1/artifacts/path/to/artifact
+```
+
+### Connection Timeouts
+
+For large artifacts, increase the timeout:
+
+```yaml
+- name: Download large artifact
+  ansible.builtin.get_url:
+    url: "{{ magpie_server }}/artifacts/images/large-vm/latest"
+    dest: /var/lib/images/vm.qcow2
+    headers:
+      Authorization: "Bearer {{ magpie_token }}"
+    timeout: 600  # 10 minutes
+    mode: "0644"
+```
+
+### Checksum Mismatch
+
+If checksum verification fails:
+
+1. Verify the checksum source matches the artifact version
+2. Try re-downloading (network corruption)
+3. Check if artifact was updated between checksum fetch and download
+
+```yaml
+# Atomic checksum + download pattern
+- name: Get checksum and download atomically
+  block:
+    - name: Fetch checksum
+      ansible.builtin.uri:
+        url: "{{ magpie_server }}/artifacts/app/binary/stable.sha256"
+        headers:
+          Authorization: "Bearer {{ magpie_token }}"
+        return_content: true
+      register: checksum
+
+    - name: Download with verification
+      ansible.builtin.get_url:
+        url: "{{ magpie_server }}/artifacts/app/binary/stable"
+        dest: /opt/app/binary
+        headers:
+          Authorization: "Bearer {{ magpie_token }}"
+        checksum: "sha256:{{ checksum.content | trim }}"
+        mode: "0755"
+  rescue:
+    - name: Handle download failure
+      ansible.builtin.fail:
+        msg: "Failed to download artifact: checksum may have changed"
+```
+
+## Security Best Practices
+
+1. **Use read-only tokens** - Create tokens with minimal scope for artifact pulls
+2. **Vault-encrypt tokens** - Never store tokens in plaintext
+3. **Use `no_log`** - Prevent token exposure in logs:
+   ```yaml
+   - name: Download sensitive artifact
+     ansible.builtin.get_url:
+       url: "{{ magpie_server }}/artifacts/secrets/cert/latest"
+       dest: /etc/ssl/cert.pem
+       headers:
+         Authorization: "Bearer {{ magpie_token }}"
+     no_log: true
+   ```
+4. **Pin versions for production** - Use specific tags or hash refs instead of `latest`
+5. **Verify checksums** - Always verify integrity for security-sensitive artifacts
+6. **Rotate tokens periodically** - Update vault-stored tokens on a schedule
+
+## See Also
+
+- [User Guide](user-guide.md) - CLI usage and server administration
+- [Authentik Integration](authentik-setup.md) - SSO for browser access
+- [Design Document](design.md) - Architecture and design decisions

--- a/docs/ansible-integration.md
+++ b/docs/ansible-integration.md
@@ -5,23 +5,30 @@ with secure token handling and checksum verification.
 
 ## Overview
 
-Magpie artifacts can be pulled from Ansible using the `ansible.builtin.get_url`
-module with bearer token authentication. This is the recommended approach for:
+Magpie artifact downloads are **public by default** -- no authentication is required
+to download from `/artifacts/*` endpoints. Simply use `ansible.builtin.get_url`
+without any Authorization header for:
 
 - Deploying scripts and binaries to managed hosts
 - Distributing configuration files
 - Pulling game assets during competition setup
 - Retrieving certificates or other security artifacts
 
+Bearer tokens are only required for **write operations** (uploads, tag management)
+and **admin operations** (token management, garbage collection).
+
 ## Prerequisites
 
 - Magpie server accessible from Ansible control node or target hosts
-- Read-scoped bearer token (created via `magpie-ctl token create --scope read`)
-- Ansible Vault configured for secret storage
+- (Optional) Bearer token -- only needed if SSO is enabled or for write operations
+- Ansible Vault configured for secret storage (if using tokens)
 
 ## Secure Token Storage
 
-**Never store tokens in plaintext in playbooks or variable files.**
+> **Note:** Tokens are only required for write operations (uploads, tag management)
+> and admin operations. For download-only playbooks, you can skip this section entirely.
+
+**If you need tokens, never store them in plaintext in playbooks or variable files.**
 
 ### Creating an Encrypted Variables File
 
@@ -51,6 +58,8 @@ Paste the output into your vars file.
 
 ## Basic Download Pattern
 
+Artifact downloads from Magpie are public -- no authentication header is needed.
+
 ### Simple Artifact Download
 
 ```yaml
@@ -59,15 +68,12 @@ Paste the output into your vars file.
   hosts: all
   vars:
     magpie_server: "https://magpie.example.com"
-    magpie_token: "{{ vault_magpie_token }}"
 
   tasks:
     - name: Download scoring engine
       ansible.builtin.get_url:
         url: "{{ magpie_server }}/artifacts/scoring/engine/latest"
         dest: /opt/scoring/engine
-        headers:
-          Authorization: "Bearer {{ magpie_token }}"
         mode: "0755"
         owner: root
         group: root
@@ -80,8 +86,6 @@ Paste the output into your vars file.
   ansible.builtin.get_url:
     url: "{{ magpie_server }}/artifacts/configs/webapp/v2.1"
     dest: /etc/webapp/config.tar.gz
-    headers:
-      Authorization: "Bearer {{ magpie_token }}"
     mode: "0644"
 ```
 
@@ -94,8 +98,6 @@ For immutable deployments, pin to a specific blob hash:
   ansible.builtin.get_url:
     url: "{{ magpie_server }}/artifacts/tools/validator/blobs/a1b2c3d4"
     dest: /usr/local/bin/validator
-    headers:
-      Authorization: "Bearer {{ magpie_token }}"
     mode: "0755"
 ```
 
@@ -119,8 +121,6 @@ tasks:
     ansible.builtin.get_url:
       url: "{{ magpie_server }}/artifacts/scoring/engine/blobs/{{ artifact_hashes.scoring_engine }}"
       dest: /opt/scoring/engine
-      headers:
-        Authorization: "Bearer {{ magpie_token }}"
       mode: "0755"
 ```
 
@@ -141,8 +141,6 @@ tasks:
     ansible.builtin.get_url:
       url: "{{ magpie_server }}/artifacts/scoring/engine/stable"
       dest: /opt/scoring/engine
-      headers:
-        Authorization: "Bearer {{ magpie_token }}"
       checksum: "{{ artifact_checksums.scoring_engine }}"
       mode: "0755"
 ```
@@ -156,8 +154,6 @@ tasks:
   ansible.builtin.get_url:
     url: "{{ magpie_server }}/artifacts/scripts/{{ item.name }}/latest"
     dest: "/usr/local/bin/{{ item.name }}"
-    headers:
-      Authorization: "Bearer {{ magpie_token }}"
     mode: "0755"
   loop:
     - name: setup-network
@@ -172,8 +168,6 @@ tasks:
   ansible.builtin.get_url:
     url: "{{ magpie_server }}/artifacts/configs/nginx/{{ config_version }}"
     dest: /tmp/nginx-config.tar.gz
-    headers:
-      Authorization: "Bearer {{ magpie_token }}"
     mode: "0644"
 
 - name: Extract configuration
@@ -198,8 +192,6 @@ tasks:
       ansible.builtin.get_url:
         url: "{{ magpie_server }}/artifacts/apps/myapp/{{ myapp_version | default('stable') }}"
         dest: /opt/myapp/bin/myapp
-        headers:
-          Authorization: "Bearer {{ magpie_token }}"
         mode: "0755"
         force: true  # Re-download if changed
       register: download_result
@@ -223,15 +215,14 @@ tasks:
   ansible.builtin.get_url:
     url: "{{ magpie_server }}/artifacts/tools/analyzer/latest"
     dest: /opt/tools/analyzer
-    headers:
-      Authorization: "Bearer {{ magpie_token }}"
     mode: "0755"
   when: not existing_binary.stat.exists
 ```
 
 ## Role Example
 
-A reusable role for pulling Magpie artifacts:
+A reusable role for pulling Magpie artifacts. Since downloads are public by default,
+the token is optional and only needed if SSO is enabled on the server.
 
 ### Role Structure
 
@@ -253,6 +244,8 @@ magpie_mode: "0644"
 magpie_owner: root
 magpie_group: root
 magpie_force: false
+# Optional: only needed if SSO is enabled on the Magpie server
+# magpie_token: "{{ vault_magpie_token }}"
 ```
 
 ### tasks/main.yml
@@ -264,15 +257,13 @@ magpie_force: false
     that:
       - magpie_artifact_path | length > 0
       - magpie_dest | length > 0
-      - vault_magpie_token is defined
     fail_msg: "Required magpie_artifact variables not set"
 
 - name: Download artifact from Magpie
   ansible.builtin.get_url:
     url: "{{ magpie_server }}/artifacts/{{ magpie_artifact_path }}/{{ magpie_artifact_tag }}"
     dest: "{{ magpie_dest }}"
-    headers:
-      Authorization: "Bearer {{ vault_magpie_token }}"
+    headers: "{{ {'Authorization': 'Bearer ' + magpie_token} if magpie_token is defined else omit }}"
     mode: "{{ magpie_mode }}"
     owner: "{{ magpie_owner }}"
     group: "{{ magpie_group }}"
@@ -304,36 +295,28 @@ magpie_force: false
 
 ## Troubleshooting
 
-### 401 Unauthorized
+### 401 Unauthorized / 403 Forbidden
 
-The token is missing or invalid:
+**For artifact downloads:** These errors should NOT occur for public download endpoints
+(`/artifacts/*`) unless SSO is enabled on the Magpie server. If you see these errors
+when downloading artifacts:
 
-```yaml
-# Verify token is being passed
-- name: Debug token presence
-  ansible.builtin.debug:
-    msg: "Token starts with: {{ vault_magpie_token[:10] }}..."
-  no_log: false  # Temporarily enable for debugging
-```
+1. Check if SSO is enabled -- if so, you need a token
+2. Verify you are using the correct URL path (`/artifacts/...` not `/api/...`)
 
-Check that:
+**For write operations (uploads, tag management):** Token is required. Check that:
 - The vault file is being decrypted (run with `--ask-vault-pass`)
 - Variable name matches exactly (`vault_magpie_token`)
 - Token has not been revoked on the server
-
-### 403 Forbidden
-
-Token lacks required permissions. For downloads, you need at least `read` scope.
-Contact your Magpie administrator for a token with appropriate scope.
+- Token has appropriate scope (`write` or `admin`)
 
 ### 404 Not Found
 
 The artifact path or tag does not exist:
 
 ```bash
-# Verify artifact exists using curl
-curl -H "Authorization: Bearer $TOKEN" \
-  https://magpie.example.com/api/v1/artifacts/path/to/artifact
+# Verify artifact exists using curl (no auth needed for downloads)
+curl https://magpie.example.com/artifacts/path/to/artifact/latest
 ```
 
 ### Connection Timeouts
@@ -345,8 +328,6 @@ For large artifacts, increase the timeout:
   ansible.builtin.get_url:
     url: "{{ magpie_server }}/artifacts/images/large-vm/latest"
     dest: /var/lib/images/vm.qcow2
-    headers:
-      Authorization: "Bearer {{ magpie_token }}"
     timeout: 600  # 10 minutes
     mode: "0644"
 ```
@@ -372,30 +353,31 @@ tasks:
     ansible.builtin.get_url:
       url: "{{ magpie_server }}/artifacts/app/binary/blobs/{{ app_binary_hash }}"
       dest: /opt/app/binary
-      headers:
-        Authorization: "Bearer {{ magpie_token }}"
       mode: "0755"
 ```
 
 ## Security Best Practices
 
-1. **Use read-only tokens** - Create tokens with minimal scope for artifact pulls
-2. **Vault-encrypt tokens** - Never store tokens in plaintext
-3. **Use `no_log`** - Prevent token exposure in logs:
+1. **Downloads are public** - Magpie artifact downloads require no authentication by default.
+   Tokens are only needed for write operations (uploads, tag management) or if SSO is enabled.
+2. **Vault-encrypt tokens when needed** - If you use tokens for write operations, never store
+   them in plaintext
+3. **Use `no_log` for upload tasks** - Prevent token exposure in logs when uploading:
    ```yaml
-   - name: Download sensitive artifact
-     ansible.builtin.get_url:
-       url: "{{ magpie_server }}/artifacts/secrets/cert/latest"
-       dest: /etc/ssl/cert.pem
+   - name: Upload artifact to Magpie
+     ansible.builtin.uri:
+       url: "{{ magpie_server }}/api/v1/artifacts/path/tag"
+       method: PUT
        headers:
          Authorization: "Bearer {{ magpie_token }}"
+       src: /path/to/artifact
      no_log: true
    ```
 4. **Pin versions for production** - Use specific tags or hash refs instead of `latest`
 5. **Verify integrity** - For security-sensitive artifacts, use one of these approaches:
    - **Hash refs** (recommended): Download via `/blobs/<hash>` for content-addressed immutability
-   - **Pre-defined checksums**: Store expected SHA-256 in vault-encrypted variables
-6. **Rotate tokens periodically** - Update vault-stored tokens on a schedule
+   - **Pre-defined checksums**: Store expected SHA-256 in variables
+6. **Rotate tokens periodically** - If using tokens for write operations, update them on a schedule
 
 ## See Also
 

--- a/docs/ansible-integration.md
+++ b/docs/ansible-integration.md
@@ -101,29 +101,30 @@ For immutable deployments, pin to a specific blob hash:
 
 ## Checksum Verification
 
-### Using Magpie's SHA-256 Checksums
+### Using Hash References for Immutable Downloads
 
-If your Magpie deployment provides `.sha256` sidecar files, you can verify
-downloads automatically:
+The most reliable verification method is to use Magpie's hash-based blob
+references. When you download via a hash ref, you are guaranteed to get
+exactly that content:
 
 ```yaml
-- name: Get checksum for artifact
-  ansible.builtin.uri:
-    url: "{{ magpie_server }}/artifacts/binaries/app/latest.sha256"
-    headers:
-      Authorization: "Bearer {{ magpie_token }}"
-    return_content: true
-  register: checksum_result
+vars:
+  # Pin to specific blob hashes for verified, immutable deployments
+  artifact_hashes:
+    scoring_engine: "a1b2c3d4e5f6"  # Short hash from tag listing
+    config_bundle: "9f8e7d6c5b4a"
 
-- name: Download artifact with checksum verification
-  ansible.builtin.get_url:
-    url: "{{ magpie_server }}/artifacts/binaries/app/latest"
-    dest: /opt/app/binary
-    headers:
-      Authorization: "Bearer {{ magpie_token }}"
-    checksum: "sha256:{{ checksum_result.content | trim }}"
-    mode: "0755"
+tasks:
+  - name: Download artifact by hash (content-verified)
+    ansible.builtin.get_url:
+      url: "{{ magpie_server }}/artifacts/scoring/engine/blobs/{{ artifact_hashes.scoring_engine }}"
+      dest: /opt/scoring/engine
+      headers:
+        Authorization: "Bearer {{ magpie_token }}"
+      mode: "0755"
 ```
+
+Use `magpie tags <artifact-path>` to list tags with their blob hashes.
 
 ### Pre-defined Checksum in Variables
 
@@ -354,34 +355,26 @@ For large artifacts, increase the timeout:
 
 If checksum verification fails:
 
-1. Verify the checksum source matches the artifact version
-2. Try re-downloading (network corruption)
-3. Check if artifact was updated between checksum fetch and download
+1. Verify the checksum in your variables matches the current artifact version
+2. Try re-downloading (possible network corruption)
+3. Use hash refs instead of mutable tags for guaranteed consistency
+
+For critical deployments, use hash-based blob references to guarantee content
+integrity. Hash refs are immutable--they always return the same content:
 
 ```yaml
-# Atomic checksum + download pattern
-- name: Get checksum and download atomically
-  block:
-    - name: Fetch checksum
-      ansible.builtin.uri:
-        url: "{{ magpie_server }}/artifacts/app/binary/stable.sha256"
-        headers:
-          Authorization: "Bearer {{ magpie_token }}"
-        return_content: true
-      register: checksum
+vars:
+  # Get hash from: magpie tags app/binary
+  app_binary_hash: "a1b2c3d4"
 
-    - name: Download with verification
-      ansible.builtin.get_url:
-        url: "{{ magpie_server }}/artifacts/app/binary/stable"
-        dest: /opt/app/binary
-        headers:
-          Authorization: "Bearer {{ magpie_token }}"
-        checksum: "sha256:{{ checksum.content | trim }}"
-        mode: "0755"
-  rescue:
-    - name: Handle download failure
-      ansible.builtin.fail:
-        msg: "Failed to download artifact: checksum may have changed"
+tasks:
+  - name: Download by hash ref (guaranteed immutable)
+    ansible.builtin.get_url:
+      url: "{{ magpie_server }}/artifacts/app/binary/blobs/{{ app_binary_hash }}"
+      dest: /opt/app/binary
+      headers:
+        Authorization: "Bearer {{ magpie_token }}"
+      mode: "0755"
 ```
 
 ## Security Best Practices
@@ -399,7 +392,9 @@ If checksum verification fails:
      no_log: true
    ```
 4. **Pin versions for production** - Use specific tags or hash refs instead of `latest`
-5. **Verify checksums** - Always verify integrity for security-sensitive artifacts
+5. **Verify integrity** - For security-sensitive artifacts, use one of these approaches:
+   - **Hash refs** (recommended): Download via `/blobs/<hash>` for content-addressed immutability
+   - **Pre-defined checksums**: Store expected SHA-256 in vault-encrypted variables
 6. **Rotate tokens periodically** - Update vault-stored tokens on a schedule
 
 ## See Also
@@ -407,3 +402,7 @@ If checksum verification fails:
 - [User Guide](user-guide.md) - CLI usage and server administration
 - [Authentik Integration](authentik-setup.md) - SSO for browser access
 - [Design Document](design.md) - Architecture and design decisions
+
+---
+
+*This documentation was created with AI assistance (Claude Code w/ Opus 4.5).*

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -50,7 +50,8 @@ Magpie supports two authentication methods:
    - Does not affect CLI or API access
 
 This guide focuses on CLI usage with bearer tokens. For Authentik SSO setup,
-see the [Authentik Integration Guide](authentik-setup.md).
+see the [Authentik Integration Guide](authentik-setup.md). For using Magpie
+with Ansible playbooks, see the [Ansible Integration Guide](ansible-integration.md).
 
 ## Client Setup
 


### PR DESCRIPTION
## Summary

- Add comprehensive `docs/ansible-integration.md` documenting how to use Magpie artifacts from Ansible playbooks
- Cover secure bearer token handling with Ansible Vault
- Provide examples using `ansible.builtin.get_url` module with proper authentication headers
- Include checksum verification patterns for integrity validation
- Add reusable role example and troubleshooting guide
- Update `docs/user-guide.md` with cross-reference to new guide

Closes #202

## Test plan

- [ ] Review documentation for accuracy and completeness
- [ ] Verify YAML examples are syntactically correct
- [ ] Test example patterns in a development environment

---

(AI-generated via Claude Code w/ Opus 4.5)