### PR TITLE
Add release workflow for container publishing and GitHub releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Validate pyproject.toml version matches tag
         run: |
           TAG_VERSION=${GITHUB_REF#refs/tags/v}
-          PYPROJECT_VERSION=$(grep -Po '(?<=^version = ")[^"]+' pyproject.toml)
+          PYPROJECT_VERSION=$(grep -Po '^version\s*=\s*"\K[^"]+' pyproject.toml)
 
           if [ "$TAG_VERSION" != "$PYPROJECT_VERSION" ]; then
             echo "::error::Version mismatch! Tag: v$TAG_VERSION, pyproject.toml: $PYPROJECT_VERSION"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,114 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  validate:
+    name: Validate version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.get_version.outputs.version }}
+      is_prerelease: ${{ steps.get_version.outputs.is_prerelease }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get version from tag
+        id: get_version
+        run: |
+          TAG=${GITHUB_REF#refs/tags/v}
+          echo "version=$TAG" >> $GITHUB_OUTPUT
+
+          # Check if prerelease (contains -, e.g., v1.0.0-rc1)
+          if [[ "$TAG" == *-* ]]; then
+            echo "is_prerelease=true" >> $GITHUB_OUTPUT
+          else
+            echo "is_prerelease=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Validate pyproject.toml version matches tag
+        run: |
+          TAG_VERSION=${GITHUB_REF#refs/tags/v}
+          PYPROJECT_VERSION=$(grep -Po '(?<=^version = ")[^"]+' pyproject.toml)
+
+          if [ "$TAG_VERSION" != "$PYPROJECT_VERSION" ]; then
+            echo "::error::Version mismatch! Tag: v$TAG_VERSION, pyproject.toml: $PYPROJECT_VERSION"
+            echo "Please update pyproject.toml version to match the tag."
+            exit 1
+          fi
+
+          echo "Version validated: $TAG_VERSION"
+
+  build-and-push:
+    name: Build and push container
+    runs-on: ubuntu-latest
+    needs: validate
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            # Tag with version (v1.0.0 -> 1.0.0)
+            type=semver,pattern={{version}}
+            # Tag with major.minor (v1.0.0 -> 1.0)
+            type=semver,pattern={{major}}.{{minor}}
+            # Tag with major (v1.0.0 -> 1)
+            type=semver,pattern={{major}}
+            # Tag latest only for stable releases (not prereleases)
+            type=raw,value=latest,enable=${{ needs.validate.outputs.is_prerelease == 'false' }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    needs: [validate, build-and-push]
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: v${{ needs.validate.outputs.version }}
+          draft: false
+          prerelease: ${{ needs.validate.outputs.is_prerelease == 'true' }}
+          generate_release_notes: true
+          files: |
+            scripts/install.sh

--- a/README.md
+++ b/README.md
@@ -144,3 +144,46 @@ uv run pytest --cov=magpie
 uv run ruff check .
 uv run ruff format --check .
 ```
+
+## Releases
+
+Releases are automated via GitHub Actions when a version tag is pushed.
+
+### Release Process
+
+1. Update version in `pyproject.toml`
+2. Commit the change:
+   ```bash
+   git add pyproject.toml
+   git commit -m "Release v1.0.0"
+   ```
+3. Create and push the tag:
+   ```bash
+   git tag v1.0.0
+   git push origin default --tags
+   ```
+
+The release workflow will:
+- Validate the tag matches `pyproject.toml` version
+- Build multi-arch container images (amd64, arm64)
+- Push to `ghcr.io/southwestccdc/magpie`
+- Create a GitHub Release with auto-generated changelog
+- Attach `scripts/install.sh` as a release asset
+
+### Container Tags
+
+| Git Tag | Container Tags |
+|---------|----------------|
+| `v1.0.0` | `1.0.0`, `1.0`, `1`, `latest` |
+| `v1.0.1` | `1.0.1`, `1.0`, `1`, `latest` |
+| `v2.0.0-rc1` | `2.0.0-rc1` (no `latest`) |
+
+### Installing from Release
+
+```bash
+# Server: Use container from registry
+docker pull ghcr.io/southwestccdc/magpie:latest
+
+# Client: Install from git tag
+uv pip install git+https://github.com/SouthwestCCDC/magpie@v1.0.0
+```

--- a/README.md
+++ b/README.md
@@ -178,6 +178,17 @@ The release workflow will:
 | `v1.0.1` | `1.0.1`, `1.0`, `1`, `latest` |
 | `v2.0.0-rc1` | `2.0.0-rc1` (no `latest`) |
 
+**Note on tag mutability**
+
+- Full version tags (`MAJOR.MINOR.PATCH`, e.g. `1.0.1`) are immutable and always point to the
+  exact release that created them.
+- Major/minor tags (`MAJOR`, `MAJOR.MINOR`, e.g. `1`, `1.0`) are **mutable** and will be moved
+  to the latest patch release in that series (e.g. `1.0` and `1` move from `1.0.0` to `1.0.1`).
+- `latest` is also **mutable** and always points to the most recent stable release.
+
+If you require a non-changing reference for deployments, pin to the full version tag
+(e.g. `ghcr.io/southwestccdc/magpie:1.0.1`).
+
 ### Installing from Release
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -187,3 +187,6 @@ docker pull ghcr.io/southwestccdc/magpie:latest
 # Client: Install from git tag
 uv pip install git+https://github.com/SouthwestCCDC/magpie@v1.0.0
 ```
+
+---
+*Release documentation generated with AI assistance (Claude Code w/ Opus 4.5).*


### PR DESCRIPTION
## Summary

- Adds automated release workflow triggered by version tags (v*)
- Validates version match between git tag and pyproject.toml
- Builds multi-arch container images (amd64 + arm64)
- Pushes to GHCR with semantic version tags
- Creates GitHub Release with auto-generated changelog

## Changes

- New `.github/workflows/release.yml`
- Updated `README.md` with release process documentation

## Release Process

```bash
# 1. Update version in pyproject.toml
# 2. Commit
git commit -am "Release v1.0.0"
# 3. Tag and push
git tag v1.0.0
git push origin default --tags
```

## Container Tagging

| Git Tag | Container Tags |
|---------|----------------|
| `v1.0.0` | `1.0.0`, `1.0`, `1`, `latest` |
| `v2.0.0-rc1` | `2.0.0-rc1` (no `latest`) |

## Test Plan

- [ ] Verify workflow syntax with `act` or wait for first real tag
- [ ] Test with a pre-release tag (v0.2.0-rc1) to validate prerelease handling

Closes #181

---
(AI-generated via Claude Code w/ Opus 4.5)