### PR TITLE
fix(gc): resolve 500 error on GC endpoint and improve error handling

### DIFF
--- a/src/magpie/ctl/commands/gc.py
+++ b/src/magpie/ctl/commands/gc.py
@@ -115,14 +115,39 @@ def gc(
 
     # For subprocess --json-output, run without progress bars and return structured JSON
     if json_output:
-        result, _ = run_gc(
-            storage_path=storage_path,
-            retention_days=retention_days,
-            dry_run=dry_run,
-            reconcile_only=reconcile_only,
-            progress_callback=None,
+        # Suppress all structlog output when outputting JSON to keep stdout clean
+        # Use a processor that drops all log events
+        import structlog
+
+        def drop_all_logs(
+            logger: object, method_name: str, event_dict: dict
+        ) -> structlog.typing.WrappedLogger:
+            raise structlog.DropEvent
+
+        structlog.configure(
+            processors=[drop_all_logs],
+            cache_logger_on_first_use=False,
         )
-        _output_json(result, dry_run)
+
+        try:
+            result, _ = run_gc(
+                storage_path=storage_path,
+                retention_days=retention_days,
+                dry_run=dry_run,
+                reconcile_only=reconcile_only,
+                progress_callback=None,
+            )
+            _output_json(result, dry_run)
+        except Exception as e:
+            # Intentionally broad exception handler for subprocess integration:
+            # When called with --json-output by the server's GC endpoint, we must
+            # always output valid JSON so the server can parse the error. Without
+            # this, exceptions would cause Click to print a traceback which the
+            # server can't parse, resulting in an opaque "Garbage collection failed"
+            # error with no details. See issue #209.
+            error_data = {"error": str(e)}
+            click.echo(json.dumps(error_data))
+            raise SystemExit(1)
         return
 
     # Suppress progress output in JSON mode

--- a/src/magpie/ctl/commands/gc.py
+++ b/src/magpie/ctl/commands/gc.py
@@ -117,11 +117,11 @@ def gc(
     if json_output:
         # Suppress all structlog output when outputting JSON to keep stdout clean
         # Use a processor that drops all log events
+        from typing import NoReturn
+
         import structlog
 
-        def drop_all_logs(
-            logger: object, method_name: str, event_dict: dict
-        ) -> structlog.typing.WrappedLogger:
+        def drop_all_logs(logger: object, method_name: str, event_dict: dict) -> NoReturn:
             raise structlog.DropEvent
 
         structlog.configure(

--- a/src/magpie/logging_config.py
+++ b/src/magpie/logging_config.py
@@ -66,10 +66,11 @@ def configure_logging(settings: MagpieSettings) -> None:
     )
 
     # Configure stdlib logging to work with structlog
+    # Use stderr for log output (stdout is reserved for program output like JSON)
     # Use force=True to allow reconfiguration (important for tests)
     logging.basicConfig(
         format="%(message)s",
-        stream=sys.stdout,
+        stream=sys.stderr,
         level=logging.DEBUG if settings.debug else logging.INFO,
         force=True,
     )

--- a/src/magpie/server/routes/gc.py
+++ b/src/magpie/server/routes/gc.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import sys
 from typing import Annotated
 
 import structlog
@@ -72,8 +73,9 @@ async def trigger_gc(
             items_removed=0,
         )
 
-    # Build command
-    cmd = ["magpie-ctl", "gc", "--json-output"]
+    # Build command - use sys.executable to call Python directly instead of relying
+    # on the wrapper script being in PATH. This is more reliable for subprocess calls.
+    cmd = [sys.executable, "-m", "magpie.ctl", "gc", "--json-output"]
     if dry_run:
         cmd.append("--dry-run")
     if retention_days_override is not None:
@@ -82,10 +84,19 @@ async def trigger_gc(
     try:
         result = await run_ctl_command(cmd)
     except CtlCommandError as e:
-        logger.error("gc_command_failed", error=str(e), exc_info=True)
-        raise HTTPException(status_code=500, detail="Garbage collection failed") from e
+        logger.error(
+            "gc_command_failed",
+            error=str(e),
+            stderr=e.stderr,
+            command=cmd,
+        )
+        # Include error detail in debug mode for easier troubleshooting
+        detail = (
+            f"Garbage collection failed: {e}" if settings.debug else "Garbage collection failed"
+        )
+        raise HTTPException(status_code=500, detail=detail) from e
     except asyncio.TimeoutError:
-        logger.error("gc_timeout")
+        logger.error("gc_timeout", command=cmd)
         raise HTTPException(status_code=504, detail="Operation timed out")
 
     return GCResponse(

--- a/src/magpie/server/subprocess_utils.py
+++ b/src/magpie/server/subprocess_utils.py
@@ -87,4 +87,6 @@ async def run_ctl_command(cmd: list[str], timeout: float = 300.0) -> dict[str, A
     try:
         return json.loads(stdout_text)
     except json.JSONDecodeError as e:
-        raise CtlCommandError(f"Invalid JSON from magpie-ctl: {e}") from e
+        # Include first 200 chars of stdout for debugging JSON parse errors
+        preview = stdout_text[:200] + "..." if len(stdout_text) > 200 else stdout_text
+        raise CtlCommandError(f"Invalid JSON from magpie-ctl: {e}. Output: {preview!r}") from e

--- a/tests/e2e/test_edge_cases.py
+++ b/tests/e2e/test_edge_cases.py
@@ -224,7 +224,6 @@ class TestTagRemoval:
 class TestGarbageCollection:
     """Tests for garbage collection operations."""
 
-    @pytest.mark.xfail(reason="GC endpoint returns 500 - pre-existing bug to be fixed separately")
     def test_gc_cleans_expired_untagged_blobs(
         self,
         docker_services: dict[str, str],
@@ -261,7 +260,6 @@ class TestGarbageCollection:
         # GC should run without error (may not clean anything if not expired)
         assert result.returncode == 0, f"gc failed: {result.stderr}"
 
-    @pytest.mark.xfail(reason="GC endpoint returns 500 - pre-existing bug to be fixed separately")
     def test_gc_preserves_tagged_blobs(
         self,
         docker_services: dict[str, str],

--- a/tests/unit/test_logging_config.py
+++ b/tests/unit/test_logging_config.py
@@ -36,9 +36,9 @@ def test_configure_logging_json_format(monkeypatch):
     # Create settings with JSON format
     settings = MagpieSettings(log_format="json", debug=False)
 
-    # Capture logging output
+    # Capture logging output (logs go to stderr, not stdout)
     log_stream = StringIO()
-    monkeypatch.setattr("sys.stdout", log_stream)
+    monkeypatch.setattr("sys.stderr", log_stream)
 
     # Configure logging
     configure_logging(settings)
@@ -99,9 +99,9 @@ def test_structured_logging_with_context(monkeypatch):
     """Test that context variables work with structlog."""
     settings = MagpieSettings(log_format="json", debug=False)
 
-    # Capture logging output
+    # Capture logging output (logs go to stderr, not stdout)
     log_stream = StringIO()
-    monkeypatch.setattr("sys.stdout", log_stream)
+    monkeypatch.setattr("sys.stderr", log_stream)
 
     configure_logging(settings)
 


### PR DESCRIPTION
## Summary

- Fix GC endpoint returning HTTP 500 when called via API (#209)
- Improve error handling and code quality in GC route (#164)
- Use `sys.executable` for reliable subprocess invocation instead of relying on PATH
- Suppress structlog output during `--json-output` mode to keep stdout clean for JSON parsing
- Add proper exception handling to always return JSON errors when subprocess integration fails
- Include error details in response when debug mode is enabled
- Update logging to use stderr instead of stdout

## Test plan

- [x] Run `uv run ruff check src/ tests/` - linting passes
- [x] Run `uv run ruff format src/ tests/` - formatting passes
- [x] Run `uv run pytest tests/unit/ -x -v` - all 771 unit tests pass
- [x] Run `uv run pytest tests/e2e/test_edge_cases.py::TestGarbageCollection -v` - both GC tests pass (previously xfail)
- [x] Verify xfail markers removed from passing tests

Fixes #209
Refs #164

(AI-generated via Claude Code w/ Opus 4.5)