### PR TITLE
chore: bump version to 0.1.0-rc1 for release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "magpie"
-version = "0.1.0"
+version = "0.1.0-rc1"
 description = "Content-addressed artifact storage with mutable tags"
 authors = [{ name = "SWCCDC Team" }]
 readme = "README.md"

--- a/src/magpie/__init__.py
+++ b/src/magpie/__init__.py
@@ -2,6 +2,6 @@
 
 from magpie.config import MagpieSettings, get_settings
 
-__version__ = "0.1.0"
+__version__ = "0.1.0-rc1"
 
 __all__ = ["MagpieSettings", "get_settings", "__version__"]

--- a/src/magpie/server/app.py
+++ b/src/magpie/server/app.py
@@ -37,7 +37,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 app = FastAPI(
     title="Magpie Artifacts API",
     description="Content-addressed artifact storage with mutable tags",
-    version="0.1.0",
+    version="0.1.0-rc1",
     lifespan=lifespan,
 )
 

--- a/tests/integration/test_cli_status.py
+++ b/tests/integration/test_cli_status.py
@@ -115,7 +115,7 @@ class TestStatusCommand:
 
         assert result.exit_code == 0
         assert "Version:" in result.output
-        assert "0.1.0" in result.output
+        assert "0.1.0-rc1" in result.output
 
     def test_status_shows_auth_no_token(
         self, cli_runner_no_config: CliRunner, api_client: TestClient
@@ -192,7 +192,7 @@ class TestStatusCommand:
         assert "data" in data
         assert data["data"]["server"] == "http://test"
         assert data["data"]["status"] == "ok"
-        assert data["data"]["version"] == "0.1.0"
+        assert data["data"]["version"] == "0.1.0-rc1"
         assert "auth" in data["data"]
         assert "storage" in data["data"]
 

--- a/tests/integration/test_status_endpoint.py
+++ b/tests/integration/test_status_endpoint.py
@@ -72,7 +72,7 @@ class TestStatusEndpoint:
         assert response.status_code == 200
         data = response.json()
         assert "version" in data
-        assert data["version"] == "0.1.0"
+        assert data["version"] == "0.1.0-rc1"
 
     def test_status_returns_auth_info_without_token(self, api_client: TestClient) -> None:
         """Status endpoint returns auth info showing no valid token."""

--- a/uv.lock
+++ b/uv.lock
@@ -382,7 +382,7 @@ wheels = [
 
 [[package]]
 name = "magpie"
-version = "0.1.0"
+version = "0.1.0rc1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary
- Updates pyproject.toml version to `0.1.0-rc1` to match the release tag

The release workflow validates that the pyproject.toml version matches the git tag exactly. The `v0.1.0-rc1` tag was created but the workflow failed because pyproject.toml still had `0.1.0`.

After this PR merges:
1. Delete the existing `v0.1.0-rc1` tag (local and remote)
2. Re-tag at the merge commit
3. Push the tag to trigger the release workflow

## Test plan
- [x] Version format is valid for PEP 440

---
(AI-generated via Claude Code w/ Opus 4.5)