### PR TITLE
release: 0.1.0-rc2 with ghcr.io installer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "magpie"
-version = "0.1.0-rc1"
+version = "0.1.0-rc2"
 description = "Content-addressed artifact storage with mutable tags"
 authors = [{ name = "SWCCDC Team" }]
 readme = "README.md"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -18,10 +18,12 @@ set -euo pipefail
 # Constants
 # =============================================================================
 
-SCRIPT_VERSION="1.0.0"
+SCRIPT_VERSION="1.1.0"
 SCRIPT_NAME="$(basename "$0")"
 GITHUB_REPO="SouthwestCCDC/magpie"
 GITHUB_BRANCH="default"
+GHCR_IMAGE="ghcr.io/southwestccdc/magpie"
+MAGPIE_VERSION="0.1.0-rc2"
 
 # Default configuration
 DEFAULT_INSTALL_DIR="/opt/magpie"
@@ -49,6 +51,7 @@ PURGE="false"
 YES="false"
 FOLLOW="false"
 LINES="100"
+FROM_SOURCE="false"
 
 # =============================================================================
 # Helper functions
@@ -685,20 +688,29 @@ patch_compose_for_tls_certs() {
     log "TLS certificate mount added to docker-compose.yml"
 }
 
-build_images() {
-    log "Building magpie Docker image (this may take a few minutes)..."
-
-    cd "${INSTALL_DIR}/repo"
-
-    if ! docker build --pull -t magpie:latest .; then
-        die "Failed to build magpie image"
+pull_or_build_image() {
+    if [[ "$FROM_SOURCE" == "true" ]]; then
+        log "Building magpie Docker image from source (this may take a few minutes)..."
+        cd "${INSTALL_DIR}/repo"
+        if ! docker build --pull -t magpie:latest .; then
+            die "Failed to build magpie image"
+        fi
+        log "Image built successfully"
+    else
+        local image_tag="${GHCR_IMAGE}:${MAGPIE_VERSION}"
+        log "Pulling magpie image from container registry..."
+        log "  Image: ${image_tag}"
+        if ! docker pull "$image_tag"; then
+            die "Failed to pull magpie image from ${image_tag}"
+        fi
+        # Tag as magpie:latest for compose compatibility
+        docker tag "$image_tag" magpie:latest
+        log "Image pulled successfully"
     fi
-
-    log "Image built successfully"
 }
 
 patch_compose_for_local_image() {
-    # Replace 'build: .' with 'image: magpie:latest' so we use our pre-built image
+    # Replace 'build: .' with 'image: magpie:latest' so we use our pre-built/pulled image
     log "Configuring Docker Compose to use local image..."
 
     sed -i 's|build: \.|image: magpie:latest|g' "${INSTALL_DIR}/docker-compose.yml"
@@ -834,8 +846,8 @@ cmd_install() {
     generate_systemd_service
     generate_gc_units
 
-    # Build image and configure compose
-    build_images
+    # Pull or build image and configure compose
+    pull_or_build_image
     patch_compose_for_caddyfile
     patch_compose_for_tls_certs
     patch_compose_for_local_image
@@ -884,17 +896,27 @@ cmd_update() {
         die "Repository directory not found at ${INSTALL_DIR}/repo\nThe installation may be corrupted. Try reinstalling with 'install --force'."
     fi
 
-    log "Pulling latest repository code..."
-    if ! git -C "${INSTALL_DIR}/repo" fetch --depth 1 origin "$GITHUB_BRANCH"; then
-        die "Failed to fetch latest repository code"
-    fi
-    if ! git -C "${INSTALL_DIR}/repo" reset --hard "origin/$GITHUB_BRANCH"; then
-        die "Failed to reset repository to latest code"
-    fi
+    if [[ "$FROM_SOURCE" == "true" ]]; then
+        log "Pulling latest repository code..."
+        if ! git -C "${INSTALL_DIR}/repo" fetch --depth 1 origin "$GITHUB_BRANCH"; then
+            die "Failed to fetch latest repository code"
+        fi
+        if ! git -C "${INSTALL_DIR}/repo" reset --hard "origin/$GITHUB_BRANCH"; then
+            die "Failed to reset repository to latest code"
+        fi
 
-    log "Rebuilding magpie image..."
-    if ! docker build --pull -t magpie:latest "${INSTALL_DIR}/repo"; then
-        die "Failed to rebuild magpie image"
+        log "Rebuilding magpie image from source..."
+        if ! docker build --pull -t magpie:latest "${INSTALL_DIR}/repo"; then
+            die "Failed to rebuild magpie image"
+        fi
+    else
+        local image_tag="${GHCR_IMAGE}:${MAGPIE_VERSION}"
+        log "Pulling latest magpie image from container registry..."
+        log "  Image: ${image_tag}"
+        if ! docker pull "$image_tag"; then
+            die "Failed to pull magpie image from ${image_tag}"
+        fi
+        docker tag "$image_tag" magpie:latest
     fi
 
     log "Pulling external images..."
@@ -1039,6 +1061,10 @@ Install options:
   --trusted-proxies CIDR  Trusted proxy CIDRs (default: RFC1918 ranges)
   --noninteractive        Skip interactive prompts
   --force                 Overwrite existing installation
+  --from-source           Build image from source instead of pulling from ghcr.io
+
+Update options:
+  --from-source           Rebuild image from source instead of pulling from ghcr.io
 
 Uninstall options:
   --yes, -y               Skip confirmation prompts
@@ -1131,6 +1157,10 @@ parse_args() {
                 ;;
             --force)
                 FORCE="true"
+                shift
+                ;;
+            --from-source)
+                FROM_SOURCE="true"
                 shift
                 ;;
             --purge)

--- a/src/magpie/__init__.py
+++ b/src/magpie/__init__.py
@@ -2,6 +2,6 @@
 
 from magpie.config import MagpieSettings, get_settings
 
-__version__ = "0.1.0-rc1"
+__version__ = "0.1.0-rc2"
 
 __all__ = ["MagpieSettings", "get_settings", "__version__"]

--- a/src/magpie/server/app.py
+++ b/src/magpie/server/app.py
@@ -37,7 +37,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 app = FastAPI(
     title="Magpie Artifacts API",
     description="Content-addressed artifact storage with mutable tags",
-    version="0.1.0-rc1",
+    version="0.1.0-rc2",
     lifespan=lifespan,
 )
 

--- a/tests/integration/test_cli_status.py
+++ b/tests/integration/test_cli_status.py
@@ -115,7 +115,7 @@ class TestStatusCommand:
 
         assert result.exit_code == 0
         assert "Version:" in result.output
-        assert "0.1.0-rc1" in result.output
+        assert "0.1.0-rc2" in result.output
 
     def test_status_shows_auth_no_token(
         self, cli_runner_no_config: CliRunner, api_client: TestClient
@@ -192,7 +192,7 @@ class TestStatusCommand:
         assert "data" in data
         assert data["data"]["server"] == "http://test"
         assert data["data"]["status"] == "ok"
-        assert data["data"]["version"] == "0.1.0-rc1"
+        assert data["data"]["version"] == "0.1.0-rc2"
         assert "auth" in data["data"]
         assert "storage" in data["data"]
 

--- a/tests/integration/test_status_endpoint.py
+++ b/tests/integration/test_status_endpoint.py
@@ -72,7 +72,7 @@ class TestStatusEndpoint:
         assert response.status_code == 200
         data = response.json()
         assert "version" in data
-        assert data["version"] == "0.1.0-rc1"
+        assert data["version"] == "0.1.0-rc2"
 
     def test_status_returns_auth_info_without_token(self, api_client: TestClient) -> None:
         """Status endpoint returns auth info showing no valid token."""

--- a/uv.lock
+++ b/uv.lock
@@ -382,7 +382,7 @@ wheels = [
 
 [[package]]
 name = "magpie"
-version = "0.1.0rc1"
+version = "0.1.0rc2"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary
- Installer now pulls pre-built image from `ghcr.io/southwestccdc/magpie` by default
- Add `--from-source` flag for those who want to build locally
- Bump version to `0.1.0-rc2` across all locations

## Changes
- `scripts/install.sh`: Pull from ghcr.io instead of building, add `--from-source` flag
- Version bump in pyproject.toml, __init__.py, app.py, tests, uv.lock

## Test plan
- [ ] CI passes
- [ ] After merge and tag, verify install script works with the published image

## Related
- #219 tracks consolidating version strings to single source of truth

---
(AI-generated via Claude Code w/ Opus 4.5)