### PR TITLE
fix: installer update pull bug, release 0.1.0-rc3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "magpie"
-version = "0.1.0-rc2"
+version = "0.1.0-rc3"
 description = "Content-addressed artifact storage with mutable tags"
 authors = [{ name = "SWCCDC Team" }]
 readme = "README.md"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -23,7 +23,7 @@ SCRIPT_NAME="$(basename "$0")"
 GITHUB_REPO="SouthwestCCDC/magpie"
 GITHUB_BRANCH="default"
 GHCR_IMAGE="ghcr.io/southwestccdc/magpie"
-MAGPIE_VERSION="0.1.0-rc2"
+MAGPIE_VERSION="0.1.0-rc3"
 
 # Default configuration
 DEFAULT_INSTALL_DIR="/opt/magpie"
@@ -920,7 +920,8 @@ cmd_update() {
     fi
 
     log "Pulling external images..."
-    docker compose --env-file "${INSTALL_DIR}/etc/.env" pull
+    # Only pull caddy - magpie image is already handled above
+    docker compose --env-file "${INSTALL_DIR}/etc/.env" pull caddy
 
     log "Restarting services..."
     systemctl restart magpie.service

--- a/src/magpie/__init__.py
+++ b/src/magpie/__init__.py
@@ -2,6 +2,6 @@
 
 from magpie.config import MagpieSettings, get_settings
 
-__version__ = "0.1.0-rc2"
+__version__ = "0.1.0-rc3"
 
 __all__ = ["MagpieSettings", "get_settings", "__version__"]

--- a/src/magpie/server/app.py
+++ b/src/magpie/server/app.py
@@ -37,7 +37,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 app = FastAPI(
     title="Magpie Artifacts API",
     description="Content-addressed artifact storage with mutable tags",
-    version="0.1.0-rc2",
+    version="0.1.0-rc3",
     lifespan=lifespan,
 )
 

--- a/tests/integration/test_cli_status.py
+++ b/tests/integration/test_cli_status.py
@@ -115,7 +115,7 @@ class TestStatusCommand:
 
         assert result.exit_code == 0
         assert "Version:" in result.output
-        assert "0.1.0-rc2" in result.output
+        assert "0.1.0-rc3" in result.output
 
     def test_status_shows_auth_no_token(
         self, cli_runner_no_config: CliRunner, api_client: TestClient
@@ -192,7 +192,7 @@ class TestStatusCommand:
         assert "data" in data
         assert data["data"]["server"] == "http://test"
         assert data["data"]["status"] == "ok"
-        assert data["data"]["version"] == "0.1.0-rc2"
+        assert data["data"]["version"] == "0.1.0-rc3"
         assert "auth" in data["data"]
         assert "storage" in data["data"]
 

--- a/tests/integration/test_status_endpoint.py
+++ b/tests/integration/test_status_endpoint.py
@@ -72,7 +72,7 @@ class TestStatusEndpoint:
         assert response.status_code == 200
         data = response.json()
         assert "version" in data
-        assert data["version"] == "0.1.0-rc2"
+        assert data["version"] == "0.1.0-rc3"
 
     def test_status_returns_auth_info_without_token(self, api_client: TestClient) -> None:
         """Status endpoint returns auth info showing no valid token."""

--- a/uv.lock
+++ b/uv.lock
@@ -382,7 +382,7 @@ wheels = [
 
 [[package]]
 name = "magpie"
-version = "0.1.0rc2"
+version = "0.1.0rc3"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary
- Fix: `update` command only pulls caddy image (not magpie which is a local tag)
- Bump version to `0.1.0-rc3`

## Bug Fixed
The update command ran `docker compose pull` which tried to pull `magpie:latest` from Docker Hub. Since that's a local tag pointing to the ghcr.io image, it failed with "repository does not exist".

## Test plan
- [x] Tested on 10.3.1.2 - update succeeded despite error, service runs rc2
- [ ] After rc3 release, verify clean update works

---
(AI-generated via Claude Code w/ Opus 4.5)