### PR TITLE
fix: grep -F for installer validation, release 0.1.0-rc4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "magpie"
-version = "0.1.0-rc3"
+version = "0.1.0-rc4"
 description = "Content-addressed artifact storage with mutable tags"
 authors = [{ name = "SWCCDC Team" }]
 readme = "README.md"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -23,7 +23,7 @@ SCRIPT_NAME="$(basename "$0")"
 GITHUB_REPO="SouthwestCCDC/magpie"
 GITHUB_BRANCH="default"
 GHCR_IMAGE="ghcr.io/southwestccdc/magpie"
-MAGPIE_VERSION="0.1.0-rc3"
+MAGPIE_VERSION="0.1.0-rc4"
 
 # Default configuration
 DEFAULT_INSTALL_DIR="/opt/magpie"
@@ -639,7 +639,8 @@ patch_compose_for_caddyfile() {
     local pattern="./Caddyfile:/etc/caddy/Caddyfile:ro"
 
     # Validate that the pattern exists before patching
-    if ! grep -q "$pattern" "$compose_file"; then
+    # Use -F for fixed string matching (. is literal, not regex wildcard)
+    if ! grep -qF "$pattern" "$compose_file"; then
         die "Cannot patch docker-compose.yml: expected Caddyfile mount pattern not found.\nExpected: $pattern"
     fi
 
@@ -648,11 +649,11 @@ patch_compose_for_caddyfile() {
         "$compose_file"
 
     # Validate that the replacement succeeded
-    if grep -q "$pattern" "$compose_file"; then
+    if grep -qF "$pattern" "$compose_file"; then
         die "Failed to patch docker-compose.yml: Caddyfile mount pattern was not replaced"
     fi
 
-    if ! grep -q "${INSTALL_DIR}/etc/Caddyfile:/etc/caddy/Caddyfile:ro" "$compose_file"; then
+    if ! grep -qF "${INSTALL_DIR}/etc/Caddyfile:/etc/caddy/Caddyfile:ro" "$compose_file"; then
         die "Failed to patch docker-compose.yml: new Caddyfile mount path not found after replacement"
     fi
 }

--- a/src/magpie/__init__.py
+++ b/src/magpie/__init__.py
@@ -2,6 +2,6 @@
 
 from magpie.config import MagpieSettings, get_settings
 
-__version__ = "0.1.0-rc3"
+__version__ = "0.1.0-rc4"
 
 __all__ = ["MagpieSettings", "get_settings", "__version__"]

--- a/src/magpie/server/app.py
+++ b/src/magpie/server/app.py
@@ -37,7 +37,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 app = FastAPI(
     title="Magpie Artifacts API",
     description="Content-addressed artifact storage with mutable tags",
-    version="0.1.0-rc3",
+    version="0.1.0-rc4",
     lifespan=lifespan,
 )
 

--- a/tests/integration/test_cli_status.py
+++ b/tests/integration/test_cli_status.py
@@ -115,7 +115,7 @@ class TestStatusCommand:
 
         assert result.exit_code == 0
         assert "Version:" in result.output
-        assert "0.1.0-rc3" in result.output
+        assert "0.1.0-rc4" in result.output
 
     def test_status_shows_auth_no_token(
         self, cli_runner_no_config: CliRunner, api_client: TestClient
@@ -192,7 +192,7 @@ class TestStatusCommand:
         assert "data" in data
         assert data["data"]["server"] == "http://test"
         assert data["data"]["status"] == "ok"
-        assert data["data"]["version"] == "0.1.0-rc3"
+        assert data["data"]["version"] == "0.1.0-rc4"
         assert "auth" in data["data"]
         assert "storage" in data["data"]
 

--- a/tests/integration/test_status_endpoint.py
+++ b/tests/integration/test_status_endpoint.py
@@ -72,7 +72,7 @@ class TestStatusEndpoint:
         assert response.status_code == 200
         data = response.json()
         assert "version" in data
-        assert data["version"] == "0.1.0-rc3"
+        assert data["version"] == "0.1.0-rc4"
 
     def test_status_returns_auth_info_without_token(self, api_client: TestClient) -> None:
         """Status endpoint returns auth info showing no valid token."""

--- a/uv.lock
+++ b/uv.lock
@@ -382,7 +382,7 @@ wheels = [
 
 [[package]]
 name = "magpie"
-version = "0.1.0rc3"
+version = "0.1.0rc4"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary
- Fix: Use `grep -qF` instead of `grep -q` for fixed string matching in installer
- Bump version to `0.1.0-rc4`

## Bug Fixed
The validation in `patch_compose_for_caddyfile` used regex grep where `.` matches any character. After patching `./Caddyfile` to `/opt/magpie/etc/Caddyfile`, the pattern `./Caddyfile` still matched because `.` matched the `t` in `etc`.

## Test plan
- [x] Tested fresh install on 10.3.1.2 with fixed script - works

---
(AI-generated via Claude Code w/ Opus 4.5)