### PR TITLE
feat: add sync gc-s3 command for S3 garbage collection

### DIFF
--- a/src/magpie/ctl/commands/sync.py
+++ b/src/magpie/ctl/commands/sync.py
@@ -1352,10 +1352,8 @@ def _find_orphaned_blobs(
     if not quiet and not is_json_output():
         click.echo("Scanning S3 for manifests...")
 
-    manifest_paths = list_files(bucket, prefix, "*.magpie", debug)
-    # Also try pattern that matches nested paths
-    if not manifest_paths:
-        manifest_paths = list_files(bucket, prefix, "**/.magpie", debug)
+    # Use **/.magpie pattern to match hidden .magpie files in artifact directories
+    manifest_paths = list_files(bucket, prefix, "**/.magpie", debug)
 
     # Filter to only .magpie files (AWS CLI pattern matching is different)
     manifest_paths = [p for p in manifest_paths if p.endswith(".magpie")]
@@ -1448,7 +1446,6 @@ def gc_s3(ctx: CTLContext, dry_run: bool, execute: bool, quiet: bool) -> None:
 
     # If --execute is provided, disable dry_run
     if execute:
-        dry_run = True  # Will be flipped to False below
         dry_run = False
 
     # Check S3 configuration

--- a/src/magpie/ctl/commands/sync.py
+++ b/src/magpie/ctl/commands/sync.py
@@ -854,3 +854,727 @@ def from_s3(
             for error in all_errors:
                 click.echo(f"  - {error}", err=True)
             raise SystemExit(1)
+
+
+def _list_s3_files_rclone(bucket: str, prefix: str, pattern: str, debug: bool) -> list[str]:
+    """List files in S3 matching a pattern using rclone.
+
+    Args:
+        bucket: S3 bucket name.
+        prefix: S3 key prefix.
+        pattern: Glob pattern to filter files (e.g., "*.magpie" or "*/blobs/*").
+        debug: If True, show debug output.
+
+    Returns:
+        List of relative paths matching the pattern.
+    """
+    # Build source path
+    src_base = f"s3://{bucket}"
+    if prefix:
+        src_base = f"{src_base}/{prefix.strip('/')}"
+
+    cmd = [
+        RCLONE_CMD,
+        "lsf",
+        src_base,
+        "--recursive",
+        "--files-only",
+        "--include",
+        pattern,
+    ]
+
+    if debug:
+        click.echo(f"Running: {' '.join(cmd)}", err=True)
+
+    try:
+        result = subprocess.run(  # nosec B603 - cmd args are validated config values
+            cmd,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            if debug:
+                click.echo(f"rclone lsf failed: {result.stderr}", err=True)
+            return []
+
+        # Parse output - one file per line
+        return [line.strip() for line in result.stdout.strip().split("\n") if line.strip()]
+    except Exception as e:
+        if debug:
+            click.echo(f"Error running rclone: {e}", err=True)
+        return []
+
+
+def _list_s3_files_aws(bucket: str, prefix: str, pattern: str, debug: bool) -> list[str]:
+    """List files in S3 matching a pattern using AWS CLI.
+
+    Args:
+        bucket: S3 bucket name.
+        prefix: S3 key prefix.
+        pattern: Glob pattern to filter files (e.g., "*.magpie" or "*/blobs/*").
+        debug: If True, show debug output.
+
+    Returns:
+        List of relative paths matching the pattern.
+    """
+    import fnmatch
+
+    # Build S3 prefix for listing
+    s3_prefix = prefix.strip("/") + "/" if prefix else ""
+
+    cmd = [
+        AWS_CMD,
+        "s3",
+        "ls",
+        f"s3://{bucket}/{s3_prefix}",
+        "--recursive",
+    ]
+
+    if debug:
+        click.echo(f"Running: {' '.join(cmd)}", err=True)
+
+    try:
+        result = subprocess.run(  # nosec B603 - cmd args are validated config values
+            cmd,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            if debug:
+                click.echo(f"aws s3 ls failed: {result.stderr}", err=True)
+            return []
+
+        # Parse output - format is: date time size key
+        # Example: 2024-01-01 12:00:00  1234 prefix/path/file.txt
+        files = []
+        for line in result.stdout.strip().split("\n"):
+            if not line.strip():
+                continue
+            # Split on whitespace, key is the last part
+            parts = line.split()
+            if len(parts) >= 4:
+                # Key is everything after date, time, size
+                key = " ".join(parts[3:])
+                # Remove the prefix to get relative path
+                if s3_prefix and key.startswith(s3_prefix):
+                    relative_path = key[len(s3_prefix) :]
+                else:
+                    relative_path = key
+
+                # Filter by pattern using fnmatch
+                if fnmatch.fnmatch(relative_path, pattern):
+                    files.append(relative_path)
+
+        return files
+    except Exception as e:
+        if debug:
+            click.echo(f"Error running aws cli: {e}", err=True)
+        return []
+
+
+def _get_s3_file_content_rclone(bucket: str, prefix: str, path: str, debug: bool) -> str | None:
+    """Get file content from S3 using rclone.
+
+    Args:
+        bucket: S3 bucket name.
+        prefix: S3 key prefix.
+        path: Relative path within the prefix.
+        debug: If True, show debug output.
+
+    Returns:
+        File content as string, or None on error.
+    """
+    # Build full S3 path
+    s3_path = _build_s3_path(bucket, prefix, path)
+
+    cmd = [
+        RCLONE_CMD,
+        "cat",
+        s3_path,
+    ]
+
+    if debug:
+        click.echo(f"Running: {' '.join(cmd)}", err=True)
+
+    try:
+        result = subprocess.run(  # nosec B603 - cmd args are validated config values
+            cmd,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            if debug:
+                click.echo(f"rclone cat failed: {result.stderr}", err=True)
+            return None
+        return result.stdout
+    except Exception as e:
+        if debug:
+            click.echo(f"Error running rclone: {e}", err=True)
+        return None
+
+
+def _get_s3_file_content_aws(bucket: str, prefix: str, path: str, debug: bool) -> str | None:
+    """Get file content from S3 using AWS CLI.
+
+    Args:
+        bucket: S3 bucket name.
+        prefix: S3 key prefix.
+        path: Relative path within the prefix.
+        debug: If True, show debug output.
+
+    Returns:
+        File content as string, or None on error.
+    """
+    import tempfile
+
+    # Build full S3 key
+    s3_key = f"{prefix.strip('/')}/{path}" if prefix else path
+
+    # Create temp file to download to
+    with tempfile.NamedTemporaryFile(delete=False) as tmp:
+        tmp_path = tmp.name
+
+    try:
+        cmd = [
+            AWS_CMD,
+            "s3",
+            "cp",
+            f"s3://{bucket}/{s3_key}",
+            tmp_path,
+            "--quiet",
+        ]
+
+        if debug:
+            click.echo(f"Running: {' '.join(cmd)}", err=True)
+
+        result = subprocess.run(  # nosec B603 - cmd args are validated config values
+            cmd,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            if debug:
+                click.echo(f"aws s3 cp failed: {result.stderr}", err=True)
+            return None
+
+        # Read content from temp file
+        with open(tmp_path, encoding="utf-8") as f:
+            return f.read()
+    except Exception as e:
+        if debug:
+            click.echo(f"Error running aws cli: {e}", err=True)
+        return None
+    finally:
+        # Clean up temp file
+        Path(tmp_path).unlink(missing_ok=True)
+
+
+def _delete_s3_file_rclone(bucket: str, prefix: str, path: str, debug: bool) -> bool:
+    """Delete a file from S3 using rclone.
+
+    Args:
+        bucket: S3 bucket name.
+        prefix: S3 key prefix.
+        path: Relative path within the prefix.
+        debug: If True, show debug output.
+
+    Returns:
+        True if deleted successfully, False otherwise.
+    """
+    s3_path = _build_s3_path(bucket, prefix, path)
+
+    cmd = [
+        RCLONE_CMD,
+        "deletefile",
+        s3_path,
+    ]
+
+    if debug:
+        click.echo(f"Running: {' '.join(cmd)}", err=True)
+
+    try:
+        result = subprocess.run(  # nosec B603 - cmd args are validated config values
+            cmd,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        return result.returncode == 0
+    except Exception as e:
+        if debug:
+            click.echo(f"Error running rclone: {e}", err=True)
+        return False
+
+
+def _delete_s3_file_aws(bucket: str, prefix: str, path: str, debug: bool) -> bool:
+    """Delete a file from S3 using AWS CLI.
+
+    Args:
+        bucket: S3 bucket name.
+        prefix: S3 key prefix.
+        path: Relative path within the prefix.
+        debug: If True, show debug output.
+
+    Returns:
+        True if deleted successfully, False otherwise.
+    """
+    s3_key = f"{prefix.strip('/')}/{path}" if prefix else path
+
+    cmd = [
+        AWS_CMD,
+        "s3",
+        "rm",
+        f"s3://{bucket}/{s3_key}",
+    ]
+
+    if debug:
+        click.echo(f"Running: {' '.join(cmd)}", err=True)
+
+    try:
+        result = subprocess.run(  # nosec B603 - cmd args are validated config values
+            cmd,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        return result.returncode == 0
+    except Exception as e:
+        if debug:
+            click.echo(f"Error running aws cli: {e}", err=True)
+        return False
+
+
+def _get_s3_file_size_rclone(
+    bucket: str, prefix: str, paths: list[str], debug: bool
+) -> dict[str, int]:
+    """Get file sizes from S3 using rclone.
+
+    Args:
+        bucket: S3 bucket name.
+        prefix: S3 key prefix.
+        paths: List of relative paths to get sizes for.
+        debug: If True, show debug output.
+
+    Returns:
+        Dict mapping path to size in bytes.
+    """
+    if not paths:
+        return {}
+
+    # Build source path
+    src_base = f"s3://{bucket}"
+    if prefix:
+        src_base = f"{src_base}/{prefix.strip('/')}"
+
+    # Use rclone lsl to get sizes (long listing)
+    cmd = [
+        RCLONE_CMD,
+        "lsl",
+        src_base,
+        "--recursive",
+        "--files-only",
+    ]
+
+    if debug:
+        click.echo(f"Running: {' '.join(cmd)}", err=True)
+
+    try:
+        result = subprocess.run(  # nosec B603 - cmd args are validated config values
+            cmd,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            return {}
+
+        # Parse output - format: size date time path
+        sizes = {}
+        paths_set = set(paths)
+        for line in result.stdout.strip().split("\n"):
+            if not line.strip():
+                continue
+            parts = line.split()
+            if len(parts) >= 4:
+                try:
+                    size = int(parts[0])
+                    # Path is the rest after size, date, time
+                    path = " ".join(parts[3:])
+                    if path in paths_set:
+                        sizes[path] = size
+                except (ValueError, IndexError):
+                    continue
+        return sizes
+    except Exception as e:
+        if debug:
+            click.echo(f"Error running rclone: {e}", err=True)
+        return {}
+
+
+def _get_s3_file_size_aws(
+    bucket: str, prefix: str, paths: list[str], debug: bool
+) -> dict[str, int]:
+    """Get file sizes from S3 using AWS CLI.
+
+    Args:
+        bucket: S3 bucket name.
+        prefix: S3 key prefix.
+        paths: List of relative paths to get sizes for.
+        debug: If True, show debug output.
+
+    Returns:
+        Dict mapping path to size in bytes.
+    """
+    if not paths:
+        return {}
+
+    # Build S3 prefix for listing
+    s3_prefix = prefix.strip("/") + "/" if prefix else ""
+
+    cmd = [
+        AWS_CMD,
+        "s3",
+        "ls",
+        f"s3://{bucket}/{s3_prefix}",
+        "--recursive",
+    ]
+
+    if debug:
+        click.echo(f"Running: {' '.join(cmd)}", err=True)
+
+    try:
+        result = subprocess.run(  # nosec B603 - cmd args are validated config values
+            cmd,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            return {}
+
+        # Parse output - format: date time size key
+        sizes = {}
+        paths_set = set(paths)
+        for line in result.stdout.strip().split("\n"):
+            if not line.strip():
+                continue
+            parts = line.split()
+            if len(parts) >= 4:
+                try:
+                    size = int(parts[2])
+                    key = " ".join(parts[3:])
+                    if s3_prefix and key.startswith(s3_prefix):
+                        relative_path = key[len(s3_prefix) :]
+                    else:
+                        relative_path = key
+                    if relative_path in paths_set:
+                        sizes[relative_path] = size
+                except (ValueError, IndexError):
+                    continue
+        return sizes
+    except Exception as e:
+        if debug:
+            click.echo(f"Error running aws cli: {e}", err=True)
+        return {}
+
+
+def _parse_manifest_content(content: str) -> set[str]:
+    """Parse manifest JSON and extract tagged blob hashes.
+
+    Args:
+        content: JSON content of the manifest file.
+
+    Returns:
+        Set of blob hash names (8-char prefixes, without @ symbol).
+    """
+    import json
+
+    try:
+        data = json.loads(content)
+        tags = data.get("tags", {})
+        # Extract blob names from hash refs (e.g., "@abc12345" -> "abc12345")
+        return {hash_ref.lstrip("@")[:8] for hash_ref in tags.values() if hash_ref}
+    except (json.JSONDecodeError, KeyError, TypeError):
+        return set()
+
+
+def _extract_blob_name_from_path(path: str) -> str | None:
+    """Extract blob name from a blob path.
+
+    Args:
+        path: Path like "artifact/blobs/abc12345" or "proj/artifact/blobs/def67890".
+
+    Returns:
+        Blob name (e.g., "abc12345") or None if path doesn't look like a blob.
+    """
+    parts = path.split("/")
+    # Find "blobs" in the path and get the next part
+    for i, part in enumerate(parts):
+        if part == "blobs" and i + 1 < len(parts):
+            return parts[i + 1]
+    return None
+
+
+def _find_orphaned_blobs(
+    bucket: str,
+    prefix: str,
+    sync_tool: str,
+    debug: bool,
+    quiet: bool,
+) -> tuple[list[str], int, int, int, list[str]]:
+    """Find orphaned blobs in S3 that are not referenced by any manifest.
+
+    Args:
+        bucket: S3 bucket name.
+        prefix: S3 key prefix.
+        sync_tool: Either "rclone" or "aws".
+        debug: If True, show debug output.
+        quiet: If True, suppress progress output.
+
+    Returns:
+        Tuple of (orphaned_blob_paths, manifest_count, tagged_blob_count, total_blob_count, errors).
+    """
+    errors: list[str] = []
+
+    # Choose list function based on sync tool
+    if sync_tool == RCLONE_CMD:
+        list_files = _list_s3_files_rclone
+        get_content = _get_s3_file_content_rclone
+    else:
+        list_files = _list_s3_files_aws
+        get_content = _get_s3_file_content_aws
+
+    # Step 1: List all manifest files
+    if not quiet and not is_json_output():
+        click.echo("Scanning S3 for manifests...")
+
+    manifest_paths = list_files(bucket, prefix, "*.magpie", debug)
+    # Also try pattern that matches nested paths
+    if not manifest_paths:
+        manifest_paths = list_files(bucket, prefix, "**/.magpie", debug)
+
+    # Filter to only .magpie files (AWS CLI pattern matching is different)
+    manifest_paths = [p for p in manifest_paths if p.endswith(".magpie")]
+
+    if debug:
+        click.echo(f"Found {len(manifest_paths)} manifest files", err=True)
+
+    # Step 2: Parse manifests and build set of tagged blob hashes
+    if not quiet and not is_json_output():
+        click.echo("Parsing manifests...")
+
+    tagged_blobs: set[str] = set()
+    for manifest_path in manifest_paths:
+        content = get_content(bucket, prefix, manifest_path, debug)
+        if content:
+            hashes = _parse_manifest_content(content)
+            tagged_blobs.update(hashes)
+        else:
+            errors.append(f"Failed to read manifest: {manifest_path}")
+
+    if debug:
+        click.echo(f"Found {len(tagged_blobs)} unique tagged blob hashes", err=True)
+
+    # Step 3: List all blob files in S3
+    if not quiet and not is_json_output():
+        click.echo("Scanning S3 for blobs...")
+
+    blob_paths = list_files(bucket, prefix, "*/blobs/*", debug)
+    # Filter to actual blob files (not directories or other files)
+    blob_paths = [p for p in blob_paths if "/blobs/" in p]
+
+    if debug:
+        click.echo(f"Found {len(blob_paths)} blob files", err=True)
+
+    # Step 4: Find orphaned blobs (not referenced by any manifest)
+    orphaned_paths: list[str] = []
+    for blob_path in blob_paths:
+        blob_name = _extract_blob_name_from_path(blob_path)
+        if blob_name and blob_name not in tagged_blobs:
+            orphaned_paths.append(blob_path)
+
+    return orphaned_paths, len(manifest_paths), len(tagged_blobs), len(blob_paths), errors
+
+
+@sync.command("gc-s3")
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=True,
+    help="Show what would be deleted without deleting (default).",
+)
+@click.option(
+    "--execute",
+    is_flag=True,
+    default=False,
+    help="Actually delete orphaned blobs. Required to perform deletion.",
+)
+@click.option(
+    "--quiet",
+    "-q",
+    is_flag=True,
+    help="Suppress progress output.",
+)
+@click.pass_obj
+def gc_s3(ctx: CTLContext, dry_run: bool, execute: bool, quiet: bool) -> None:
+    """Garbage collect orphaned blobs from S3 backup.
+
+    This command identifies and removes blobs in S3 that are not referenced
+    by any manifest file. This prevents S3 storage from growing unbounded
+    when local GC removes blobs that have been synced to S3.
+
+    The command uses S3's own manifests as the source of truth, meaning it
+    can run independently of local storage state.
+
+    SAFE BY DEFAULT: This command only previews deletions unless --execute
+    is explicitly provided. Always review the preview before executing.
+
+    Examples:
+
+        # Preview what would be deleted (default behavior)
+        magpie-ctl sync gc-s3
+
+        # Actually delete orphaned blobs
+        magpie-ctl sync gc-s3 --execute
+
+        # With explicit bucket
+        MAGPIE_S3_BUCKET=my-bucket magpie-ctl sync gc-s3
+    """
+    settings = ctx.settings
+
+    # If --execute is provided, disable dry_run
+    if execute:
+        dry_run = True  # Will be flipped to False below
+        dry_run = False
+
+    # Check S3 configuration
+    if not settings.s3_bucket:
+        msg = "MAGPIE_S3_BUCKET environment variable is required"
+        if is_json_output():
+            output_error(ErrorCode.CONFIG_ERROR, msg)
+        else:
+            raise click.ClickException(msg)
+
+    # Find sync tool
+    sync_tool = _find_sync_tool()
+    if not sync_tool:
+        msg = "Neither rclone nor aws CLI found. Please install one of them."
+        if is_json_output():
+            output_error(ErrorCode.CONFIG_ERROR, msg)
+        else:
+            raise click.ClickException(msg)
+
+    if ctx.debug:
+        click.echo(f"Using sync tool: {sync_tool}", err=True)
+        click.echo(f"S3 bucket: {settings.s3_bucket}", err=True)
+        click.echo(f"S3 prefix: {settings.s3_prefix or '(none)'}", err=True)
+        click.echo(f"Dry run: {dry_run}", err=True)
+
+    # Find orphaned blobs
+    orphaned_paths, manifest_count, tagged_count, total_blobs, errors = _find_orphaned_blobs(
+        settings.s3_bucket,
+        settings.s3_prefix,
+        sync_tool,
+        ctx.debug,
+        quiet or is_json_output(),
+    )
+
+    # Get sizes of orphaned blobs
+    if sync_tool == RCLONE_CMD:
+        sizes = _get_s3_file_size_rclone(
+            settings.s3_bucket, settings.s3_prefix, orphaned_paths, ctx.debug
+        )
+    else:
+        sizes = _get_s3_file_size_aws(
+            settings.s3_bucket, settings.s3_prefix, orphaned_paths, ctx.debug
+        )
+
+    total_orphaned_bytes = sum(sizes.get(p, 0) for p in orphaned_paths)
+
+    # Delete orphaned blobs if not dry-run
+    deleted_count = 0
+    deleted_bytes = 0
+    if not dry_run and orphaned_paths:
+        if sync_tool == RCLONE_CMD:
+            delete_fn = _delete_s3_file_rclone
+        else:
+            delete_fn = _delete_s3_file_aws
+
+        if not quiet and not is_json_output():
+            click.echo(f"Deleting {len(orphaned_paths)} orphaned blob(s)...")
+
+        with count_progress(
+            "Deleting orphaned blobs", len(orphaned_paths), quiet=quiet or is_json_output()
+        ) as (progress, task_id):
+            for blob_path in orphaned_paths:
+                if delete_fn(settings.s3_bucket, settings.s3_prefix, blob_path, ctx.debug):
+                    deleted_count += 1
+                    deleted_bytes += sizes.get(blob_path, 0)
+                else:
+                    errors.append(f"Failed to delete: {blob_path}")
+
+                if progress and task_id is not None:
+                    progress.update(task_id, advance=1)
+
+    # Output results
+    if is_json_output():
+        output_result(
+            CommandResult(
+                data={
+                    "dry_run": dry_run,
+                    "sync_tool": sync_tool,
+                    "manifests_found": manifest_count,
+                    "tagged_blobs": tagged_count,
+                    "total_blobs": total_blobs,
+                    "orphaned_count": len(orphaned_paths),
+                    "orphaned_bytes": total_orphaned_bytes,
+                    "orphaned_paths": orphaned_paths if dry_run else [],
+                    "deleted_count": deleted_count,
+                    "deleted_bytes": deleted_bytes,
+                    "errors": errors,
+                },
+                human_output="",
+            )
+        )
+    else:
+        click.echo("")
+        if dry_run:
+            click.echo("S3 Garbage Collection Preview:")
+        else:
+            click.echo("S3 Garbage Collection Complete:")
+
+        click.echo(f"  Sync tool: {sync_tool}")
+        click.echo(f"  Manifests found: {manifest_count}")
+        click.echo(f"  Tagged blobs: {tagged_count}")
+        click.echo(f"  Total blobs in S3: {total_blobs}")
+        click.echo(f"  Orphaned blobs: {len(orphaned_paths)} ({format_size(total_orphaned_bytes)})")
+
+        if dry_run:
+            if orphaned_paths:
+                click.echo("")
+                click.echo("Orphaned blobs that would be deleted:")
+                for path in orphaned_paths[:20]:  # Show first 20
+                    size_str = format_size(sizes.get(path, 0))
+                    click.echo(f"  - {path} ({size_str})")
+                if len(orphaned_paths) > 20:
+                    click.echo(f"  ... and {len(orphaned_paths) - 20} more")
+                click.echo("")
+                click.echo(
+                    f"Would delete {len(orphaned_paths)} blob(s). Run with --execute to proceed."
+                )
+            else:
+                click.echo("")
+                click.echo("No orphaned blobs found. S3 storage is clean.")
+        else:
+            click.echo(f"  Deleted: {deleted_count} blob(s) ({format_size(deleted_bytes)})")
+
+        if errors:
+            click.echo("")
+            click.echo("Errors:")
+            for error in errors:
+                click.echo(f"  - {error}", err=True)
+            raise SystemExit(1)

--- a/tests/unit/test_sync_gc_s3.py
+++ b/tests/unit/test_sync_gc_s3.py
@@ -1,0 +1,496 @@
+"""Unit tests for magpie-ctl sync gc-s3 command."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from magpie.config import MagpieSettings
+from magpie.ctl import cli as ctl_cli
+from magpie.ctl.commands.sync import (
+    _extract_blob_name_from_path,
+    _find_orphaned_blobs,
+    _parse_manifest_content,
+)
+
+
+class TestParseManifestContent:
+    """Tests for _parse_manifest_content function."""
+
+    def test_parses_valid_manifest(self) -> None:
+        """Should extract blob hashes from valid manifest JSON."""
+        content = json.dumps(
+            {
+                "version": 1,
+                "tags": {
+                    "latest": "@abc12345",
+                    "v1.0": "@def67890",
+                },
+            }
+        )
+        result = _parse_manifest_content(content)
+        assert result == {"abc12345", "def67890"}
+
+    def test_handles_empty_tags(self) -> None:
+        """Should return empty set for manifest with no tags."""
+        content = json.dumps({"version": 1, "tags": {}})
+        result = _parse_manifest_content(content)
+        assert result == set()
+
+    def test_handles_missing_tags_key(self) -> None:
+        """Should return empty set when tags key is missing."""
+        content = json.dumps({"version": 1})
+        result = _parse_manifest_content(content)
+        assert result == set()
+
+    def test_handles_invalid_json(self) -> None:
+        """Should return empty set for invalid JSON."""
+        result = _parse_manifest_content("not valid json{")
+        assert result == set()
+
+    def test_handles_empty_string(self) -> None:
+        """Should return empty set for empty string."""
+        result = _parse_manifest_content("")
+        assert result == set()
+
+    def test_handles_null_hash_refs(self) -> None:
+        """Should skip null hash refs."""
+        content = json.dumps(
+            {
+                "version": 1,
+                "tags": {
+                    "latest": "@abc12345",
+                    "empty": None,
+                },
+            }
+        )
+        result = _parse_manifest_content(content)
+        assert result == {"abc12345"}
+
+    def test_truncates_long_hashes(self) -> None:
+        """Should truncate hash refs to 8 characters."""
+        content = json.dumps(
+            {
+                "version": 1,
+                "tags": {
+                    "latest": "@abc12345extralongchars",
+                },
+            }
+        )
+        result = _parse_manifest_content(content)
+        assert result == {"abc12345"}
+
+    def test_deduplicates_hashes(self) -> None:
+        """Should deduplicate when multiple tags point to same hash."""
+        content = json.dumps(
+            {
+                "version": 1,
+                "tags": {
+                    "latest": "@abc12345",
+                    "stable": "@abc12345",
+                    "v1.0": "@abc12345",
+                },
+            }
+        )
+        result = _parse_manifest_content(content)
+        assert result == {"abc12345"}
+
+
+class TestExtractBlobNameFromPath:
+    """Tests for _extract_blob_name_from_path function."""
+
+    def test_extracts_blob_name(self) -> None:
+        """Should extract blob name from standard path."""
+        result = _extract_blob_name_from_path("artifact/blobs/abc12345")
+        assert result == "abc12345"
+
+    def test_extracts_from_nested_path(self) -> None:
+        """Should extract blob name from deeply nested path."""
+        result = _extract_blob_name_from_path("project/subdir/artifact/blobs/def67890")
+        assert result == "def67890"
+
+    def test_returns_none_for_non_blob_path(self) -> None:
+        """Should return None for paths that don't contain blobs."""
+        result = _extract_blob_name_from_path("artifact/metadata/abc12345.json")
+        assert result is None
+
+    def test_returns_none_for_empty_path(self) -> None:
+        """Should return None for empty path."""
+        result = _extract_blob_name_from_path("")
+        assert result is None
+
+    def test_returns_none_when_blobs_is_last(self) -> None:
+        """Should return None when 'blobs' is the last component."""
+        result = _extract_blob_name_from_path("artifact/blobs")
+        assert result is None
+
+
+class TestFindOrphanedBlobs:
+    """Tests for _find_orphaned_blobs function."""
+
+    @patch("magpie.ctl.commands.sync._list_s3_files_rclone")
+    @patch("magpie.ctl.commands.sync._get_s3_file_content_rclone")
+    def test_finds_orphaned_blobs_rclone(
+        self,
+        mock_get_content: MagicMock,
+        mock_list_files: MagicMock,
+    ) -> None:
+        """Should identify blobs not referenced by any manifest using rclone."""
+
+        # Setup mock responses
+        def list_files_side_effect(bucket: str, prefix: str, pattern: str, debug: bool) -> list:
+            if ".magpie" in pattern:
+                return ["artifact/.magpie"]
+            elif "blobs" in pattern:
+                return [
+                    "artifact/blobs/abc12345",  # Tagged
+                    "artifact/blobs/orphaned1",  # Orphaned
+                    "artifact/blobs/orphaned2",  # Orphaned
+                ]
+            return []
+
+        mock_list_files.side_effect = list_files_side_effect
+        mock_get_content.return_value = json.dumps({"version": 1, "tags": {"latest": "@abc12345"}})
+
+        orphaned, manifests, tagged, total, errors = _find_orphaned_blobs(
+            "test-bucket", "", "rclone", False, True
+        )
+
+        assert orphaned == ["artifact/blobs/orphaned1", "artifact/blobs/orphaned2"]
+        assert manifests == 1
+        assert tagged == 1
+        assert total == 3
+        assert errors == []
+
+    @patch("magpie.ctl.commands.sync._list_s3_files_aws")
+    @patch("magpie.ctl.commands.sync._get_s3_file_content_aws")
+    def test_finds_orphaned_blobs_aws(
+        self,
+        mock_get_content: MagicMock,
+        mock_list_files: MagicMock,
+    ) -> None:
+        """Should identify blobs not referenced by any manifest using aws cli."""
+
+        def list_files_side_effect(bucket: str, prefix: str, pattern: str, debug: bool) -> list:
+            if ".magpie" in pattern:
+                return ["proj/artifact/.magpie"]
+            elif "blobs" in pattern:
+                return [
+                    "proj/artifact/blobs/def67890",  # Tagged
+                    "proj/artifact/blobs/orphan",  # Orphaned
+                ]
+            return []
+
+        mock_list_files.side_effect = list_files_side_effect
+        mock_get_content.return_value = json.dumps({"version": 1, "tags": {"v1": "@def67890"}})
+
+        orphaned, manifests, tagged, total, errors = _find_orphaned_blobs(
+            "test-bucket", "backup", "aws", False, True
+        )
+
+        assert orphaned == ["proj/artifact/blobs/orphan"]
+        assert manifests == 1
+        assert tagged == 1
+        assert total == 2
+
+    @patch("magpie.ctl.commands.sync._list_s3_files_rclone")
+    @patch("magpie.ctl.commands.sync._get_s3_file_content_rclone")
+    def test_no_orphans_when_all_tagged(
+        self,
+        mock_get_content: MagicMock,
+        mock_list_files: MagicMock,
+    ) -> None:
+        """Should return empty list when all blobs are tagged."""
+
+        def list_files_side_effect(bucket: str, prefix: str, pattern: str, debug: bool) -> list:
+            if ".magpie" in pattern:
+                return ["artifact/.magpie"]
+            elif "blobs" in pattern:
+                return ["artifact/blobs/abc12345"]
+            return []
+
+        mock_list_files.side_effect = list_files_side_effect
+        mock_get_content.return_value = json.dumps({"version": 1, "tags": {"latest": "@abc12345"}})
+
+        orphaned, _, _, _, errors = _find_orphaned_blobs("test-bucket", "", "rclone", False, True)
+
+        assert orphaned == []
+        assert errors == []
+
+    @patch("magpie.ctl.commands.sync._list_s3_files_rclone")
+    @patch("magpie.ctl.commands.sync._get_s3_file_content_rclone")
+    def test_handles_multiple_manifests(
+        self,
+        mock_get_content: MagicMock,
+        mock_list_files: MagicMock,
+    ) -> None:
+        """Should aggregate tags from multiple manifests."""
+
+        def list_files_side_effect(bucket: str, prefix: str, pattern: str, debug: bool) -> list:
+            if ".magpie" in pattern:
+                return ["art1/.magpie", "art2/.magpie"]
+            elif "blobs" in pattern:
+                return [
+                    "art1/blobs/hash1111",
+                    "art1/blobs/hash2222",
+                    "art2/blobs/hash3333",
+                    "art2/blobs/orphaned",
+                ]
+            return []
+
+        manifest_contents = {
+            "art1/.magpie": json.dumps(
+                {"version": 1, "tags": {"v1": "@hash1111", "v2": "@hash2222"}}
+            ),
+            "art2/.magpie": json.dumps({"version": 1, "tags": {"latest": "@hash3333"}}),
+        }
+
+        def get_content_side_effect(bucket: str, prefix: str, path: str, debug: bool) -> str:
+            return manifest_contents.get(path, "")
+
+        mock_list_files.side_effect = list_files_side_effect
+        mock_get_content.side_effect = get_content_side_effect
+
+        orphaned, manifests, tagged, total, errors = _find_orphaned_blobs(
+            "test-bucket", "", "rclone", False, True
+        )
+
+        assert orphaned == ["art2/blobs/orphaned"]
+        assert manifests == 2
+        assert tagged == 3  # hash1111, hash2222, hash3333
+        assert total == 4
+
+    @patch("magpie.ctl.commands.sync._list_s3_files_rclone")
+    @patch("magpie.ctl.commands.sync._get_s3_file_content_rclone")
+    def test_reports_manifest_read_errors(
+        self,
+        mock_get_content: MagicMock,
+        mock_list_files: MagicMock,
+    ) -> None:
+        """Should report errors when manifest cannot be read."""
+
+        def list_files_side_effect(bucket: str, prefix: str, pattern: str, debug: bool) -> list:
+            if ".magpie" in pattern:
+                return ["artifact/.magpie"]
+            return []
+
+        mock_list_files.side_effect = list_files_side_effect
+        mock_get_content.return_value = None  # Simulate read failure
+
+        _, _, _, _, errors = _find_orphaned_blobs("test-bucket", "", "rclone", False, True)
+
+        assert len(errors) == 1
+        assert "Failed to read manifest" in errors[0]
+
+
+class TestGcS3Command:
+    """Integration tests for sync gc-s3 command."""
+
+    @pytest.fixture
+    def cli_runner(self) -> CliRunner:
+        """Create Click CLI test runner."""
+        return CliRunner()
+
+    def test_requires_s3_bucket(self, cli_runner: CliRunner, tmp_path: Path) -> None:
+        """Should fail when S3 bucket is not configured."""
+        result = cli_runner.invoke(
+            ctl_cli,
+            ["sync", "gc-s3"],
+            env={"MAGPIE_STORAGE_PATH": str(tmp_path)},
+        )
+
+        assert result.exit_code != 0
+        assert "MAGPIE_S3_BUCKET" in result.output
+
+    def test_requires_sync_tool(self, cli_runner: CliRunner, tmp_path: Path) -> None:
+        """Should fail when no sync tool is available."""
+        settings = MagpieSettings(storage_path=tmp_path, s3_bucket="test-bucket", s3_prefix="")
+
+        with patch("magpie.ctl.commands.sync.shutil.which", return_value=None):
+            with patch("magpie.ctl.get_settings", return_value=settings):
+                result = cli_runner.invoke(
+                    ctl_cli,
+                    ["sync", "gc-s3"],
+                )
+
+                assert result.exit_code != 0
+                assert "rclone" in result.output.lower() or "aws" in result.output.lower()
+
+    @patch("magpie.ctl.commands.sync._find_orphaned_blobs")
+    @patch("magpie.ctl.commands.sync._get_s3_file_size_rclone")
+    def test_dry_run_is_default(
+        self,
+        mock_get_sizes: MagicMock,
+        mock_find_orphaned: MagicMock,
+        cli_runner: CliRunner,
+        tmp_path: Path,
+    ) -> None:
+        """Should run in dry-run mode by default (safe by default)."""
+        mock_find_orphaned.return_value = (
+            ["artifact/blobs/orphan1"],  # orphaned paths
+            1,  # manifest count
+            1,  # tagged count
+            2,  # total blobs
+            [],  # errors
+        )
+        mock_get_sizes.return_value = {"artifact/blobs/orphan1": 1024}
+
+        settings = MagpieSettings(storage_path=tmp_path, s3_bucket="test-bucket", s3_prefix="")
+
+        with patch("magpie.ctl.commands.sync.shutil.which", return_value="/usr/bin/rclone"):
+            with patch("magpie.ctl.get_settings", return_value=settings):
+                result = cli_runner.invoke(
+                    ctl_cli,
+                    ["sync", "gc-s3"],
+                )
+
+                assert result.exit_code == 0, f"Output: {result.output}"
+                assert "Preview" in result.output
+                assert "Would delete" in result.output or "Run with --execute" in result.output
+
+    @patch("magpie.ctl.commands.sync._find_orphaned_blobs")
+    @patch("magpie.ctl.commands.sync._get_s3_file_size_rclone")
+    @patch("magpie.ctl.commands.sync._delete_s3_file_rclone")
+    def test_execute_actually_deletes(
+        self,
+        mock_delete: MagicMock,
+        mock_get_sizes: MagicMock,
+        mock_find_orphaned: MagicMock,
+        cli_runner: CliRunner,
+        tmp_path: Path,
+    ) -> None:
+        """Should actually delete blobs when --execute is provided."""
+        mock_find_orphaned.return_value = (
+            ["artifact/blobs/orphan1", "artifact/blobs/orphan2"],
+            1,
+            1,
+            3,
+            [],
+        )
+        mock_get_sizes.return_value = {
+            "artifact/blobs/orphan1": 1024,
+            "artifact/blobs/orphan2": 2048,
+        }
+        mock_delete.return_value = True
+
+        settings = MagpieSettings(storage_path=tmp_path, s3_bucket="test-bucket", s3_prefix="")
+
+        with patch("magpie.ctl.commands.sync.shutil.which", return_value="/usr/bin/rclone"):
+            with patch("magpie.ctl.get_settings", return_value=settings):
+                result = cli_runner.invoke(
+                    ctl_cli,
+                    ["sync", "gc-s3", "--execute"],
+                )
+
+                assert result.exit_code == 0, f"Output: {result.output}"
+                assert "Complete" in result.output
+                assert "Deleted: 2" in result.output
+                assert mock_delete.call_count == 2
+
+    @patch("magpie.ctl.commands.sync._find_orphaned_blobs")
+    @patch("magpie.ctl.commands.sync._get_s3_file_size_rclone")
+    def test_no_orphans_message(
+        self,
+        mock_get_sizes: MagicMock,
+        mock_find_orphaned: MagicMock,
+        cli_runner: CliRunner,
+        tmp_path: Path,
+    ) -> None:
+        """Should show appropriate message when no orphans found."""
+        mock_find_orphaned.return_value = ([], 2, 5, 5, [])
+        mock_get_sizes.return_value = {}
+
+        settings = MagpieSettings(storage_path=tmp_path, s3_bucket="test-bucket", s3_prefix="")
+
+        with patch("magpie.ctl.commands.sync.shutil.which", return_value="/usr/bin/rclone"):
+            with patch("magpie.ctl.get_settings", return_value=settings):
+                result = cli_runner.invoke(
+                    ctl_cli,
+                    ["sync", "gc-s3"],
+                )
+
+                assert result.exit_code == 0
+                assert (
+                    "No orphaned blobs found" in result.output
+                    or "Orphaned blobs: 0" in result.output
+                )
+
+
+class TestGcS3JsonOutput:
+    """Tests for JSON output mode."""
+
+    @pytest.fixture
+    def cli_runner(self) -> CliRunner:
+        """Create Click CLI test runner."""
+        return CliRunner()
+
+    @patch("magpie.ctl.commands.sync._find_orphaned_blobs")
+    @patch("magpie.ctl.commands.sync._get_s3_file_size_rclone")
+    def test_json_output_dry_run(
+        self,
+        mock_get_sizes: MagicMock,
+        mock_find_orphaned: MagicMock,
+        cli_runner: CliRunner,
+        tmp_path: Path,
+    ) -> None:
+        """Should output valid JSON in dry-run mode."""
+        mock_find_orphaned.return_value = (["artifact/blobs/orphan1"], 2, 3, 4, [])
+        mock_get_sizes.return_value = {"artifact/blobs/orphan1": 1024}
+
+        settings = MagpieSettings(storage_path=tmp_path, s3_bucket="test-bucket", s3_prefix="")
+
+        with patch("magpie.ctl.commands.sync.shutil.which", return_value="/usr/bin/rclone"):
+            with patch("magpie.ctl.get_settings", return_value=settings):
+                result = cli_runner.invoke(
+                    ctl_cli,
+                    ["--format", "json", "sync", "gc-s3"],
+                )
+
+                assert result.exit_code == 0, f"Output: {result.output}"
+                data = json.loads(result.output)
+                assert data["status"] == "ok"
+                assert data["data"]["dry_run"] is True
+                assert data["data"]["manifests_found"] == 2
+                assert data["data"]["tagged_blobs"] == 3
+                assert data["data"]["total_blobs"] == 4
+                assert data["data"]["orphaned_count"] == 1
+                assert data["data"]["orphaned_bytes"] == 1024
+                assert data["data"]["orphaned_paths"] == ["artifact/blobs/orphan1"]
+
+    @patch("magpie.ctl.commands.sync._find_orphaned_blobs")
+    @patch("magpie.ctl.commands.sync._get_s3_file_size_rclone")
+    @patch("magpie.ctl.commands.sync._delete_s3_file_rclone")
+    def test_json_output_execute(
+        self,
+        mock_delete: MagicMock,
+        mock_get_sizes: MagicMock,
+        mock_find_orphaned: MagicMock,
+        cli_runner: CliRunner,
+        tmp_path: Path,
+    ) -> None:
+        """Should output valid JSON after execution."""
+        mock_find_orphaned.return_value = (["artifact/blobs/orphan1"], 1, 2, 3, [])
+        mock_get_sizes.return_value = {"artifact/blobs/orphan1": 2048}
+        mock_delete.return_value = True
+
+        settings = MagpieSettings(storage_path=tmp_path, s3_bucket="test-bucket", s3_prefix="")
+
+        with patch("magpie.ctl.commands.sync.shutil.which", return_value="/usr/bin/rclone"):
+            with patch("magpie.ctl.get_settings", return_value=settings):
+                result = cli_runner.invoke(
+                    ctl_cli,
+                    ["--format", "json", "sync", "gc-s3", "--execute"],
+                )
+
+                assert result.exit_code == 0, f"Output: {result.output}"
+                data = json.loads(result.output)
+                assert data["status"] == "ok"
+                assert data["data"]["dry_run"] is False
+                assert data["data"]["deleted_count"] == 1
+                assert data["data"]["deleted_bytes"] == 2048
+                # After execution, orphaned_paths should be empty
+                assert data["data"]["orphaned_paths"] == []


### PR DESCRIPTION
## Summary

- Add new `gc-s3` subcommand to the `sync` command group for garbage collecting orphaned blobs from S3 backup storage
- The command uses S3's own manifests as the source of truth, allowing it to run independently of local storage state
- Safe by default: `--dry-run` is the default behavior, requiring explicit `--execute` flag to delete
- Supports both rclone and aws CLI, consistent with existing sync commands

## Implementation Details

The gc-s3 command:
1. Lists all `.magpie` manifest files in S3
2. Parses each manifest to build a set of all tagged blob hashes
3. Lists all blob files in S3 (`*/blobs/*`)
4. Identifies blobs not referenced by any manifest
5. Optionally deletes orphaned blobs (with `--execute`)

New helper functions added:
- `_list_s3_files_rclone` / `_list_s3_files_aws` - List files matching patterns
- `_get_s3_file_content_rclone` / `_get_s3_file_content_aws` - Read file content
- `_delete_s3_file_rclone` / `_delete_s3_file_aws` - Delete files
- `_get_s3_file_size_rclone` / `_get_s3_file_size_aws` - Get file sizes
- `_parse_manifest_content` - Parse manifest JSON for blob hashes
- `_extract_blob_name_from_path` - Extract blob name from S3 path
- `_find_orphaned_blobs` - Core algorithm to identify orphans

## Test Plan

- [x] Added 25 unit tests covering:
  - Manifest parsing edge cases (empty, null values, deduplication)
  - Blob path extraction
  - Orphan detection with mocked S3 operations
  - CLI behavior (dry-run default, execute mode, JSON output)
- [x] All existing unit tests pass (796 total)
- [x] Linting passes (`ruff check` and `ruff format`)

Closes #226

---

Generated with [Claude Code](https://claude.ai/code) w/ Opus 4.5