### PR TITLE
fix(ci): improve version extraction robustness in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Validate pyproject.toml version matches tag
         run: |
           TAG_VERSION=${GITHUB_REF#refs/tags/v}
-          PYPROJECT_VERSION=$(grep -Po '^version\s*=\s*"\K[^"]+' pyproject.toml)
+          PYPROJECT_VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
 
           if [ "$TAG_VERSION" != "$PYPROJECT_VERSION" ]; then
             echo "::error::Version mismatch! Tag: v$TAG_VERSION, pyproject.toml: $PYPROJECT_VERSION"


### PR DESCRIPTION
## Summary
- Replace fragile grep-based regex with Python tomllib for parsing pyproject.toml version
- More robust handling of TOML structure with proper parsing
- Eliminates potential edge cases with whitespace or TOML syntax variations

## Test plan
- [x] Verified Python tomllib command extracts version correctly locally
- [x] Syntax is valid for GitHub Actions environment (Python 3.x with tomllib)
- [ ] CI passes

Fixes #210

---
(AI-generated via Claude Code w/ Sonnet 4.5)