### PR TITLE
chore: bump version to 0.1.0-rc5

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -61,17 +61,17 @@ Install the magpie CLI using pip or uv:
 
 ```bash
 # With uv (recommended)
-uv pip install git+https://github.com/SouthwestCCDC/magpie.git@v0.1.0-rc4
+uv pip install git+https://github.com/SouthwestCCDC/magpie.git@v0.1.0-rc5
 
 # With pip
-pip install git+https://github.com/SouthwestCCDC/magpie.git@v0.1.0-rc4
+pip install git+https://github.com/SouthwestCCDC/magpie.git@v0.1.0-rc5
 
 # For development (from local clone)
 cd magpie
 uv pip install -e .
 ```
 
-To install a specific version, replace the tag (e.g., `@v0.1.0-rc4`) with the desired
+To install a specific version, replace the tag (e.g., `@v0.1.0-rc5`) with the desired
 release tag. Check [GitHub releases](https://github.com/SouthwestCCDC/magpie/releases)
 for available versions.
 

--- a/myartifact
+++ b/myartifact
@@ -1,0 +1,1 @@
+test content v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "magpie"
-version = "0.1.0-rc4"
+version = "0.1.0-rc5"
 description = "Content-addressed artifact storage with mutable tags"
 authors = [{ name = "SWCCDC Team" }]
 readme = "README.md"

--- a/scripts/magpie-deploy.sh
+++ b/scripts/magpie-deploy.sh
@@ -23,7 +23,7 @@ SCRIPT_NAME="$(basename "$0")"
 GITHUB_REPO="SouthwestCCDC/magpie"
 GITHUB_BRANCH="default"
 GHCR_IMAGE="ghcr.io/southwestccdc/magpie"
-MAGPIE_VERSION="0.1.0-rc4"
+MAGPIE_VERSION="0.1.0-rc5"
 
 # Default configuration
 DEFAULT_INSTALL_DIR="/opt/magpie"

--- a/src/magpie/__init__.py
+++ b/src/magpie/__init__.py
@@ -2,6 +2,6 @@
 
 from magpie.config import MagpieSettings, get_settings
 
-__version__ = "0.1.0-rc4"
+__version__ = "0.1.0-rc5"
 
 __all__ = ["MagpieSettings", "get_settings", "__version__"]

--- a/src/magpie/server/app.py
+++ b/src/magpie/server/app.py
@@ -37,7 +37,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 app = FastAPI(
     title="Magpie Artifacts API",
     description="Content-addressed artifact storage with mutable tags",
-    version="0.1.0-rc4",
+    version="0.1.0-rc5",
     lifespan=lifespan,
 )
 

--- a/tests/integration/test_cli_status.py
+++ b/tests/integration/test_cli_status.py
@@ -115,7 +115,7 @@ class TestStatusCommand:
 
         assert result.exit_code == 0
         assert "Version:" in result.output
-        assert "0.1.0-rc4" in result.output
+        assert "0.1.0-rc5" in result.output
 
     def test_status_shows_auth_no_token(
         self, cli_runner_no_config: CliRunner, api_client: TestClient
@@ -192,7 +192,7 @@ class TestStatusCommand:
         assert "data" in data
         assert data["data"]["server"] == "http://test"
         assert data["data"]["status"] == "ok"
-        assert data["data"]["version"] == "0.1.0-rc4"
+        assert data["data"]["version"] == "0.1.0-rc5"
         assert "auth" in data["data"]
         assert "storage" in data["data"]
 

--- a/tests/integration/test_status_endpoint.py
+++ b/tests/integration/test_status_endpoint.py
@@ -72,7 +72,7 @@ class TestStatusEndpoint:
         assert response.status_code == 200
         data = response.json()
         assert "version" in data
-        assert data["version"] == "0.1.0-rc4"
+        assert data["version"] == "0.1.0-rc5"
 
     def test_status_returns_auth_info_without_token(self, api_client: TestClient) -> None:
         """Status endpoint returns auth info showing no valid token."""

--- a/uv.lock
+++ b/uv.lock
@@ -382,7 +382,7 @@ wheels = [
 
 [[package]]
 name = "magpie"
-version = "0.1.0rc4"
+version = "0.1.0rc5"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary
Version bump for release v0.1.0-rc5

## Changes since rc4
- #231: Protect artifact downloads with auth and IP allow-listing
- #228: Add gc-s3 command for S3 garbage collection  
- #233: Improve version extraction robustness in release workflow
- #234: Add root landing page redirect to /artifacts/
- #235: Rename install.sh to magpie-deploy.sh

---
(AI-generated via Claude Code w/ Opus 4.5)