### PR TITLE
test: add unit tests for GC exception handler

### DIFF
--- a/tests/unit/test_ctl_init_gc.py
+++ b/tests/unit/test_ctl_init_gc.py
@@ -1061,7 +1061,7 @@ class TestGCJsonOutput:
         This tests the intentional broad exception handler at gc.py:141-150.
         When called with --json-output by the server's GC endpoint, we must
         always output valid JSON so the server can parse the error. The broad
-        exception catch is deliberate - see issue #238 for context.
+        exception catch is deliberate - see issue #209 for context.
         """
         test_settings.storage_path.mkdir(parents=True, exist_ok=True)
         create_artifact_with_blobs(

--- a/tests/unit/test_ctl_init_gc.py
+++ b/tests/unit/test_ctl_init_gc.py
@@ -1050,7 +1050,7 @@ class TestGCJsonOutput:
         This tests the intentional broad exception handler at gc.py:141-150.
         When called with --json-output by the server's GC endpoint, we must
         always output valid JSON so the server can parse the error. The broad
-        exception catch is deliberate - see issue #209 for context.
+        exception catch is deliberate - see issue #238 for context.
         """
         test_settings.storage_path.mkdir(parents=True, exist_ok=True)
         create_artifact_with_blobs(

--- a/tests/unit/test_ctl_init_gc.py
+++ b/tests/unit/test_ctl_init_gc.py
@@ -1042,8 +1042,19 @@ class TestGCJsonOutput:
         assert "GC Summary:" not in result.output
         assert "Artifacts scanned:" not in result.output
 
+    @pytest.mark.parametrize(
+        ("exception_type", "error_message"),
+        [
+            pytest.param(RuntimeError, "Simulated storage failure", id="runtime-error"),
+            pytest.param(OSError, "Permission denied", id="os-error"),
+        ],
+    )
     def test_gc_json_output_exception_returns_json_error(
-        self, cli_runner: CliRunner, test_settings: MagpieSettings
+        self,
+        cli_runner: CliRunner,
+        test_settings: MagpieSettings,
+        exception_type: type[Exception],
+        error_message: str,
     ) -> None:
         """GC --json-output returns JSON error when run_gc raises exception.
 
@@ -1065,7 +1076,7 @@ class TestGCJsonOutput:
         with patch("magpie.ctl.get_settings", return_value=test_settings):
             with patch(
                 "magpie.ctl.commands.gc.run_gc",
-                side_effect=RuntimeError("Simulated storage failure"),
+                side_effect=exception_type(error_message),
             ):
                 result = cli_runner.invoke(cli, ["gc", "--json-output"])
 
@@ -1075,33 +1086,7 @@ class TestGCJsonOutput:
         # Output should be valid JSON with error message
         output = json.loads(result.output.strip())
         assert "error" in output
-        assert "Simulated storage failure" in output["error"]
-
-    def test_gc_json_output_oserror_returns_json_error(
-        self, cli_runner: CliRunner, test_settings: MagpieSettings
-    ) -> None:
-        """GC --json-output returns JSON error when run_gc raises OSError."""
-        test_settings.storage_path.mkdir(parents=True, exist_ok=True)
-        create_artifact_with_blobs(
-            test_settings.storage_path,
-            "test/artifact",
-            tagged_hashes={"latest": "tagged_hash_abc"},
-            untagged_hashes=[],
-            blob_ages_days={"tagged_hash_abc": 0},
-        )
-
-        # Mock run_gc to raise an OSError (e.g., permission denied)
-        with patch("magpie.ctl.get_settings", return_value=test_settings):
-            with patch(
-                "magpie.ctl.commands.gc.run_gc",
-                side_effect=OSError("Permission denied"),
-            ):
-                result = cli_runner.invoke(cli, ["gc", "--json-output"])
-
-        assert result.exit_code == 1
-        output = json.loads(result.output.strip())
-        assert "error" in output
-        assert "Permission denied" in output["error"]
+        assert error_message in output["error"]
 
 
 class TestFlushTagCommand:

--- a/tests/unit/test_ctl_init_gc.py
+++ b/tests/unit/test_ctl_init_gc.py
@@ -1042,6 +1042,67 @@ class TestGCJsonOutput:
         assert "GC Summary:" not in result.output
         assert "Artifacts scanned:" not in result.output
 
+    def test_gc_json_output_exception_returns_json_error(
+        self, cli_runner: CliRunner, test_settings: MagpieSettings
+    ) -> None:
+        """GC --json-output returns JSON error when run_gc raises exception.
+
+        This tests the intentional broad exception handler at gc.py:141-150.
+        When called with --json-output by the server's GC endpoint, we must
+        always output valid JSON so the server can parse the error. The broad
+        exception catch is deliberate - see issue #209 for context.
+        """
+        test_settings.storage_path.mkdir(parents=True, exist_ok=True)
+        create_artifact_with_blobs(
+            test_settings.storage_path,
+            "test/artifact",
+            tagged_hashes={"latest": "tagged_hash_abc"},
+            untagged_hashes=[],
+            blob_ages_days={"tagged_hash_abc": 0},
+        )
+
+        # Mock run_gc to raise an exception
+        with patch("magpie.ctl.get_settings", return_value=test_settings):
+            with patch(
+                "magpie.ctl.commands.gc.run_gc",
+                side_effect=RuntimeError("Simulated storage failure"),
+            ):
+                result = cli_runner.invoke(cli, ["gc", "--json-output"])
+
+        # Should exit with error code 1
+        assert result.exit_code == 1, f"Output: {result.output}"
+
+        # Output should be valid JSON with error message
+        output = json.loads(result.output.strip())
+        assert "error" in output
+        assert "Simulated storage failure" in output["error"]
+
+    def test_gc_json_output_oserror_returns_json_error(
+        self, cli_runner: CliRunner, test_settings: MagpieSettings
+    ) -> None:
+        """GC --json-output returns JSON error when run_gc raises OSError."""
+        test_settings.storage_path.mkdir(parents=True, exist_ok=True)
+        create_artifact_with_blobs(
+            test_settings.storage_path,
+            "test/artifact",
+            tagged_hashes={"latest": "tagged_hash_abc"},
+            untagged_hashes=[],
+            blob_ages_days={"tagged_hash_abc": 0},
+        )
+
+        # Mock run_gc to raise an OSError (e.g., permission denied)
+        with patch("magpie.ctl.get_settings", return_value=test_settings):
+            with patch(
+                "magpie.ctl.commands.gc.run_gc",
+                side_effect=OSError("Permission denied"),
+            ):
+                result = cli_runner.invoke(cli, ["gc", "--json-output"])
+
+        assert result.exit_code == 1
+        output = json.loads(result.output.strip())
+        assert "error" in output
+        assert "Permission denied" in output["error"]
+
 
 class TestFlushTagCommand:
     """Tests for flush-tag command."""


### PR DESCRIPTION
## Summary

Adds unit tests for the GC command's exception handler when using `--json-output` flag.

- Tests that `RuntimeError` exceptions are caught and output as JSON
- Tests that `OSError` exceptions are caught and output as JSON

## Context

The broad `except Exception` at `gc.py:141-150` is **intentional** for subprocess JSON output reliability (see #238 for analysis). These tests document and verify this design decision.

Closes #217

## Test plan

- [x] New tests pass locally
- [x] All 809 unit tests pass
- [x] Linting passes
- [ ] CI passes

---
(AI-generated via Claude Code w/ Opus 4.5)