### PR TITLE
docs(installer): improve UX and messaging clarity

### DIFF
--- a/scripts/magpie-deploy.sh
+++ b/scripts/magpie-deploy.sh
@@ -984,6 +984,11 @@ cmd_uninstall() {
     if [[ "$PURGE" != "true" ]]; then
         echo "  Data directory preserved at: ${DATA_DIR}"
         echo "  Use --purge to remove data as well."
+        echo ""
+        echo "  NOTE: If you reinstall with different settings (e.g., different UID/GID"
+        echo "  in container configuration), you may encounter permission issues with"
+        echo "  the preserved data directory. In that case, you may need to manually"
+        echo "  adjust ownership: chown -R <new-uid>:<new-gid> ${DATA_DIR}"
     fi
 }
 
@@ -1047,7 +1052,7 @@ Commands:
   status      Show service status
   logs        View container logs
 
-Install options:
+Install options (only used with 'install' command):
   --install-dir PATH      Installation directory (default: $DEFAULT_INSTALL_DIR)
   --data-dir PATH         Data storage directory (default: INSTALL_DIR/data)
                           Must be an absolute path. Paths under /home are not
@@ -1061,7 +1066,7 @@ Install options:
   --http-port PORT        HTTP port (default: $DEFAULT_HTTP_PORT)
   --https-port PORT       HTTPS port (default: $DEFAULT_HTTPS_PORT)
   --trusted-proxies CIDR  Trusted proxy CIDRs (default: RFC1918 ranges)
-  --noninteractive        Skip interactive prompts
+  --noninteractive        Skip interactive prompts (use defaults for all config)
   --force                 Overwrite existing installation
   --from-source           Build image from source instead of pulling from ghcr.io
 
@@ -1069,8 +1074,10 @@ Update options:
   --from-source           Rebuild image from source instead of pulling from ghcr.io
 
 Uninstall options:
-  --yes, -y               Skip confirmation prompts
-  --purge                 Also remove data directory
+  --yes, -y               Skip confirmation prompts (auto-confirm uninstall)
+  --purge                 Also remove data directory (requires --yes for non-interactive)
+                          Without --purge: preserves data directory for reinstallation
+                          With --purge: permanently deletes all artifacts and data
 
 Logs options:
   -f, --follow            Follow log output


### PR DESCRIPTION
## Summary
This PR addresses issue #162 by implementing three UX and documentation improvements to the installer script:

- **Help text organization**: Clarified that install-specific options (--tls-mode, --domain, etc.) only apply to the install command by updating the section header
- **Uninstall messaging**: Enhanced --purge and --yes option descriptions to clearly explain what happens in each mode
- **Data directory warning**: Added a note when uninstalling without --purge about potential permission issues if reinstalling with different container UID/GID settings

## Changes
- Updated help text header from "Install options:" to "Install options (only used with 'install' command):"
- Enhanced uninstall option descriptions to explain:
  - --yes: auto-confirms uninstall
  - --purge: permanently deletes data (requires --yes for non-interactive use)
  - Without --purge: preserves data directory for reinstallation
- Added permission warning note to uninstall completion message with guidance on using chown if needed

## Test plan
- [x] Read the modified help text to verify clarity
- [x] Ran shellcheck on scripts/magpie-deploy.sh (pre-existing warning not related to changes)
- [x] Verified changes don't affect script functionality (documentation only)

Addresses #162

---
(AI-generated via Claude Code w/ Opus 4.5)