### PR TITLE
refactor: consolidate version string to single source of truth

### DIFF
--- a/src/magpie/__init__.py
+++ b/src/magpie/__init__.py
@@ -1,7 +1,13 @@
 """Magpie: Content-addressed artifact storage with mutable tags."""
 
+from importlib.metadata import PackageNotFoundError, version
+
 from magpie.config import MagpieSettings, get_settings
 
-__version__ = "0.1.0-rc5"
+try:
+    __version__ = version("magpie")
+except PackageNotFoundError:
+    # Fallback for development/editable installs
+    __version__ = "0.0.0-dev"
 
 __all__ = ["MagpieSettings", "get_settings", "__version__"]

--- a/src/magpie/server/app.py
+++ b/src/magpie/server/app.py
@@ -7,6 +7,7 @@ from typing import AsyncIterator
 
 from fastapi import FastAPI
 
+from magpie import __version__
 from magpie.config import get_settings
 from magpie.logging_config import configure_logging
 from magpie.server.errors import register_exception_handlers
@@ -37,7 +38,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 app = FastAPI(
     title="Magpie Artifacts API",
     description="Content-addressed artifact storage with mutable tags",
-    version="0.1.0-rc5",
+    version=__version__,
     lifespan=lifespan,
 )
 

--- a/tests/integration/test_cli_status.py
+++ b/tests/integration/test_cli_status.py
@@ -11,6 +11,7 @@ import pytest
 from click.testing import CliRunner
 from fastapi.testclient import TestClient
 
+from magpie import __version__
 from magpie.auth.service import TokenService
 from magpie.cli import cli
 from magpie.config import MagpieSettings
@@ -115,7 +116,7 @@ class TestStatusCommand:
 
         assert result.exit_code == 0
         assert "Version:" in result.output
-        assert "0.1.0-rc5" in result.output
+        assert __version__ in result.output
 
     def test_status_shows_auth_no_token(
         self, cli_runner_no_config: CliRunner, api_client: TestClient
@@ -192,7 +193,7 @@ class TestStatusCommand:
         assert "data" in data
         assert data["data"]["server"] == "http://test"
         assert data["data"]["status"] == "ok"
-        assert data["data"]["version"] == "0.1.0-rc5"
+        assert data["data"]["version"] == __version__
         assert "auth" in data["data"]
         assert "storage" in data["data"]
 

--- a/tests/integration/test_status_endpoint.py
+++ b/tests/integration/test_status_endpoint.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 from fastapi.testclient import TestClient
 
+from magpie import __version__
 from magpie.auth.models import TokenScope
 from magpie.auth.service import TokenService
 from magpie.config import MagpieSettings
@@ -72,7 +73,7 @@ class TestStatusEndpoint:
         assert response.status_code == 200
         data = response.json()
         assert "version" in data
-        assert data["version"] == "0.1.0-rc5"
+        assert data["version"] == __version__
 
     def test_status_returns_auth_info_without_token(self, api_client: TestClient) -> None:
         """Status endpoint returns auth info showing no valid token."""


### PR DESCRIPTION
## Summary
- Use `importlib.metadata.version()` to read version from `pyproject.toml` at runtime
- Eliminate duplicate version strings in `__init__.py`, `server/app.py`, and tests
- Add fallback to `"0.0.0-dev"` for development/editable installs
- Update all tests to import and use `__version__` instead of hardcoded strings

## Changes
- `src/magpie/__init__.py`: Read version from package metadata with fallback
- `src/magpie/server/app.py`: Import `__version__` from magpie package
- `tests/integration/test_cli_status.py`: Import and assert `__version__`
- `tests/integration/test_status_endpoint.py`: Import and assert `__version__`

## Test plan
- [x] Unit tests pass: `uv run pytest tests/unit/ -v`
- [x] Integration tests pass: `uv run pytest tests/integration/test_cli_status.py tests/integration/test_status_endpoint.py -v`
- [x] Linting passes: `uv run ruff check src/ tests/`
- [x] Security scan passes: `uv run bandit -r src/`

Addresses #219

---
(AI-generated via Claude Code w/ Opus 4.5)