### PR TITLE
docs: add test failure accountability rule

### DIFF
--- a/.claude/agents/magpie-developer.md
+++ b/.claude/agents/magpie-developer.md
@@ -151,6 +151,7 @@ tests/
    ```bash
    uv run bandit -r src/
    ```
+4. **Handle failures correctly**: If tests fail after your changes, assume YOUR CHANGE caused it. Do not blame infrastructure, flaky tests, or pre-existing issues without evidence (e.g., showing the test fails on the base branch).
 
 ## PR Comment Handling
 

--- a/.claude/agents/magpie-pr-reviewer.md
+++ b/.claude/agents/magpie-pr-reviewer.md
@@ -78,6 +78,13 @@ gh pr diff {N} --repo SouthwestCCDC/magpie
 - [ ] Tests are readable and maintainable
 - [ ] Mocks are appropriate (not over-mocking)
 
+**Test Failure Accountability:**
+If tests were modified as part of this PR:
+- [ ] Test changes are justified (not just "making tests pass")
+- [ ] Any claims of "pre-existing failures" have evidence (test fails on base branch)
+- [ ] Any claims of "infrastructure issues" have evidence (unrelated to code paths)
+- [ ] New code isn't breaking existing behavior that tests were validating
+
 **Documentation:**
 - [ ] Code is self-documenting or has appropriate comments
 - [ ] Public APIs have docstrings

--- a/.claude/docs/orchestrator-prompt.md
+++ b/.claude/docs/orchestrator-prompt.md
@@ -18,7 +18,7 @@ You are the **orchestrator** coordinating subagents that implement features, fix
 
 ## Critical Rules (READ FIRST)
 
-These seven rules are non-negotiable:
+These eight rules are non-negotiable:
 
 ### 1. Isolated Worktrees - Always
 
@@ -59,6 +59,30 @@ GitHub is the canonical state for project work. On session startup, always check
 - Recent review comments on active PRs
 
 This ensures new sessions can pick up where previous work left off. When reporting status, always include full GitHub URLs.
+
+### 8. Test Failure Accountability
+
+**When a test or CI check fails after a code change, the default assumption is that the code change caused the failure.**
+
+This is non-negotiable:
+1. **Burden of proof is on the agent** - Must demonstrate with evidence that a failure is NOT caused by their change before blaming tests, CI, infrastructure, or network issues
+2. **Valid evidence includes:**
+   - Showing the same test fails on the base branch (pre-existing)
+   - Showing network/infrastructure errors unrelated to code paths
+   - Showing the test makes invalid assumptions that contradict documented behavior
+3. **Invalid reasoning includes:**
+   - "This looks like an infrastructure issue" (without proof)
+   - "The test is probably flaky" (without history showing flakiness)
+   - "My code is correct so the test must be wrong" (circular reasoning)
+   - Immediately modifying tests to pass without understanding why they failed
+
+When tests fail, subagents must:
+1. **First**: Understand what the test is checking and why it failed
+2. **Second**: Determine if the code change could have caused this
+3. **Third**: If they believe it's not their change, gather evidence
+4. **Fourth**: Present the evidence and conclusion
+
+Never accept "infrastructure issue" or "pre-existing failure" as a conclusion without supporting evidence.
 
 ---
 
@@ -269,10 +293,11 @@ gh pr list --repo SouthwestCCDC/magpie --state open --json number,title,headRefN
 When beginning a new orchestrator session:
 
 1. **Read this prompt** - You're doing it now
-2. **Check open PRs** - `gh pr list --repo SouthwestCCDC/magpie --state open --json number,title,headRefName`
-3. **List worktrees** - `git worktree list` - Remove stale ones from merged PRs
-4. **Check open issues** - `gh issue list --repo SouthwestCCDC/magpie --state open --limit 30`
-5. **Review subagent definitions** - Scan `.claude/agents/*.md` files if launching agents
+2. **Verify subagent access** - Confirm you can see all expected subagents (magpie-developer, magpie-pr-reviewer, magpie-api-researcher, magpie-e2e-tester, magpie-docs-writer)
+3. **Check open PRs** - `gh pr list --repo SouthwestCCDC/magpie --state open --json number,title,headRefName`
+4. **List worktrees** - `git worktree list` - Remove stale ones from merged PRs
+5. **Check open issues** - `gh issue list --repo SouthwestCCDC/magpie --state open --limit 30`
+6. **Review subagent definitions** - Scan `.claude/agents/*.md` files if launching agents
 
 ## Key Documents
 


### PR DESCRIPTION
## Summary
- Add Rule 8 (Test Failure Accountability) to orchestrator prompt
- Add subagent access verification step to startup checklist
- Add test failure handling step to magpie-developer quality standards
- Add test failure accountability checklist to magpie-pr-reviewer

This rule ensures agents assume their code changes caused test failures rather than blaming infrastructure or pre-existing issues without evidence.

## Changes
- `.claude/docs/orchestrator-prompt.md`: Add Rule 8, update rule count to 8, add startup checklist item
- `.claude/agents/magpie-developer.md`: Add failure handling step to quality standards
- `.claude/agents/magpie-pr-reviewer.md`: Add test failure accountability checklist

---
(AI-generated via Claude Code w/ Opus 4.5)