### PR TITLE
docs: update user guide and add documentation index

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,106 @@
+# Magpie Documentation
+
+Welcome to the Magpie documentation. Magpie is a content-addressed artifact storage system with mutable tags, designed for distributing build artifacts, container images, and other binary assets across infrastructure.
+
+## Getting Started
+
+New to Magpie? Start here:
+
+1. **[User Guide](user-guide.md)** - Complete guide to using the Magpie CLI and API
+   - Installation and setup
+   - Core concepts (blobs, tags, hash refs)
+   - Authentication with bearer tokens
+   - CLI commands (push, get, ls, tag, etc.)
+   - Common use cases and examples
+
+2. **[Design Document](design.md)** - Architecture and design rationale
+   - Current state and migration from S3-based artifacts
+   - Requirements and design decisions
+   - Storage architecture and content-addressing
+   - Implementation phases and roadmap
+
+## Integration Guides
+
+- **[Ansible Integration](ansible-integration.md)** - Download artifacts from Ansible playbooks
+  - Basic download patterns with `get_url`
+  - Checksum verification
+  - Secure token handling with Ansible Vault
+  - Example playbooks for common scenarios
+
+- **[Authentik SSO Setup](authentik-setup.md)** - Configure Authentik SSO for browser access
+  - Forward auth provider configuration
+  - Application setup in Authentik
+  - Caddy configuration for SSO
+  - Troubleshooting SSO issues
+
+- **[Authentik Testing Guide](authentik-testing-guide.md)** - Manual testing procedures for SSO integration
+  - Test plan overview
+  - Bearer token authentication tests
+  - Browser-based SSO verification
+  - Session persistence testing
+
+## Operations
+
+- **[Backup and Restore Guide](backup-restore.md)** - Backup procedures and disaster recovery
+  - What to back up (storage, metadata, database)
+  - Backup procedures (manual and automated)
+  - Restore procedures for various scenarios
+  - Verification and testing backups
+
+## Observability
+
+- **[Structured Logging](structured-logging.md)** - Structured logging implementation with structlog
+  - Configuration (JSON vs console format)
+  - Standard log fields and request correlation
+  - OpenTelemetry integration
+  - Log aggregation setup
+
+- **[Sentry Verification Guide](sentry-verification.md)** - Verify Sentry error tracking
+  - Setup and configuration
+  - Verification tests
+  - Troubleshooting integration issues
+
+## Additional Resources
+
+- **[README](../README.md)** - Quick start and project overview
+- **[GitHub Repository](https://github.com/SouthwestCCDC/magpie)** - Source code and issue tracker
+- **[Release Notes](https://github.com/SouthwestCCDC/magpie/releases)** - Version history and changelog
+
+## Quick Reference
+
+### Common Commands
+
+```bash
+# Upload an artifact
+magpie push myfile.tar.gz --to images/ubuntu
+
+# Download an artifact
+magpie get images/ubuntu:latest
+
+# List versions
+magpie ls images/ubuntu
+
+# Create a tag
+magpie tag images/ubuntu:latest --as stable
+
+# Run garbage collection
+magpie-ctl gc --retention-days 30
+```
+
+### Authentication
+
+Magpie supports two authentication methods:
+
+1. **Bearer Tokens** - For CLI, API, and automation (required for uploads and tag management)
+2. **Authentik SSO** - For human browser access to artifacts (optional, see [Authentik Setup](authentik-setup.md))
+
+### Environment Variables
+
+```bash
+export MAGPIE_SERVER=https://magpie.example.com
+export MAGPIE_TOKEN=mgp_your_token_here
+```
+
+## Contributing
+
+For information on contributing to Magpie, see the [GitHub repository](https://github.com/SouthwestCCDC/magpie) and check open issues.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -312,6 +312,33 @@ magpie amend images/ubuntu:latest --source-uri https://github.com/example/repo
 magpie amend images/ubuntu:latest --source-uri ""
 ```
 
+### Check Server Status
+
+```bash
+# Check server health and connection
+magpie status
+
+# Output as JSON
+magpie --format json status
+```
+
+Output:
+```
+Server:    https://magpie.example.com
+Status:    HEALTHY
+Version:   0.1.0-rc5
+Auth:      Token valid (write scope, name: deployer)
+Storage:   15.2 GB used
+Artifacts: 42 total
+Blobs:     156 total
+```
+
+The `status` command displays:
+- Server URL and availability
+- Server version
+- Authentication status (token validity, scope, name)
+- Storage statistics (total size, artifact count, blob count)
+
 ## Server Setup
 
 ### Docker Compose Deployment
@@ -436,10 +463,20 @@ docker compose exec magpie magpie-ctl token revoke ci-reader
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `MAGPIE_STORAGE_PATH` | `/data/artifacts` | Root directory for artifact storage |
+| `MAGPIE_TEMP_PATH` | `{storage_path}/.tmp` | Temporary file storage during uploads |
+| `MAGPIE_DATABASE_PATH` | `{storage_path}/.magpie.db` | SQLite database location for tokens |
 | `MAGPIE_RETENTION_DAYS` | `90` | Days before untagged blobs can be GC'd |
+| `MAGPIE_GC_LOCK_PATH` | `/var/run/magpie-gc.lock` | Lock file path to prevent concurrent GC |
+| `MAGPIE_MAX_UPLOAD_SIZE` | (none) | Maximum upload size in bytes (None = unlimited) |
 | `MAGPIE_DEBUG` | `false` | Enable debug logging |
+| `MAGPIE_LOG_FORMAT` | `json` | Log format: `json` or `console` |
 | `MAGPIE_SENTRY_DSN` | (none) | Sentry DSN for error tracking |
 | `MAGPIE_OTEL_ENABLED` | `false` | Enable OpenTelemetry tracing |
+| `MAGPIE_OTEL_ENDPOINT` | (none) | OpenTelemetry collector endpoint |
+| `MAGPIE_OTEL_SERVICE_NAME` | `magpie` | Service name for OpenTelemetry traces |
+| `MAGPIE_S3_BUCKET` | (none) | S3 bucket for backup/restore operations |
+| `MAGPIE_S3_PREFIX` | `""` | Optional prefix for S3 keys |
+| `MAGPIE_ALLOWED_CIDRS` | `""` | Comma-separated CIDR ranges for IP allow-listing (used by Caddy) |
 
 ### TLS Configuration
 
@@ -551,6 +588,107 @@ For backup procedures, restore operations, and disaster recovery scenarios, see 
 - Step-by-step restore procedures
 - Recovery scenarios (corrupted manifests, lost database, partial data loss)
 
+#### S3 Sync Commands
+
+Magpie includes `magpie-ctl sync` commands for backing up and restoring artifacts to/from S3.
+
+**Prerequisites:**
+- Set `MAGPIE_S3_BUCKET` environment variable
+- Optionally set `MAGPIE_S3_PREFIX` to add a prefix to all S3 keys
+- Configure AWS credentials via environment variables (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`) or IAM role
+- Install either `rclone` (preferred) or AWS CLI
+
+**Backup to S3:**
+
+```bash
+# Preview what would be synced
+docker compose exec magpie magpie-ctl sync to-s3 --dry-run
+
+# Sync tagged artifacts to S3
+docker compose exec magpie magpie-ctl sync to-s3
+
+# With custom bucket
+MAGPIE_S3_BUCKET=my-backup-bucket docker compose exec magpie magpie-ctl sync to-s3
+
+# Suppress progress output
+docker compose exec magpie magpie-ctl sync to-s3 --quiet
+```
+
+Only artifacts with at least one tag are synced. Untagged blobs are not backed up.
+Sync is incremental - only changed files are uploaded.
+
+**Restore from S3:**
+
+```bash
+# Preview what would be restored
+docker compose exec magpie magpie-ctl sync from-s3 --dry-run
+
+# Restore from S3 (fails if data exists)
+docker compose exec magpie magpie-ctl sync from-s3
+
+# Force restore even if data exists (may overwrite)
+docker compose exec magpie magpie-ctl sync from-s3 --force
+
+# Skip integrity verification after restore
+docker compose exec magpie magpie-ctl sync from-s3 --skip-verify
+
+# Suppress progress output
+docker compose exec magpie magpie-ctl sync from-s3 --quiet
+```
+
+By default, refuses to restore if data already exists to prevent accidental overwrites.
+Use `--force` to override this check.
+
+**Garbage collect S3 backup:**
+
+```bash
+# Preview orphaned blobs in S3 (default, safe)
+docker compose exec magpie magpie-ctl sync gc-s3
+
+# Actually delete orphaned blobs
+docker compose exec magpie magpie-ctl sync gc-s3 --execute
+
+# Suppress progress output
+docker compose exec magpie magpie-ctl sync gc-s3 --quiet
+```
+
+This command identifies and removes blobs in S3 that are not referenced by any manifest file.
+It prevents S3 storage from growing unbounded when local GC removes blobs that have been synced to S3.
+
+**Note:** The command is safe by default - it only previews deletions unless `--execute` is explicitly provided.
+
+### Exit Codes and Error Handling
+
+**CLI Exit Codes:**
+
+The `magpie` CLI uses standard Unix exit codes:
+
+- `0` - Success
+- `1` - Error (any failure condition)
+
+**API Error Response Format:**
+
+All API errors return JSON with a `detail` field:
+
+```json
+{
+  "detail": "Error message describing what went wrong"
+}
+```
+
+HTTP status codes follow REST conventions:
+
+| Status | Meaning | Example |
+|--------|---------|---------|
+| 200 | Success | Artifact retrieved successfully |
+| 400 | Bad Request | Invalid artifact path or malformed request |
+| 401 | Unauthorized | Missing or invalid authentication token |
+| 403 | Forbidden | Valid token but insufficient permissions |
+| 404 | Not Found | Artifact or tag does not exist |
+| 409 | Conflict | Tag already exists (on create), data exists (on restore) |
+| 413 | Payload Too Large | Upload exceeds `MAGPIE_MAX_UPLOAD_SIZE` |
+| 500 | Internal Server Error | Server-side error (check logs) |
+
 ### Troubleshooting
 
 #### "No server configured"
@@ -606,6 +744,7 @@ The artifact was already stored; the existing hash was returned.
 | `magpie untag PATH TAG` | Remove tag |
 | `magpie flush-tag TAG` | Remove tag from all artifacts globally |
 | `magpie amend PATH:REF --source-uri URI` | Update metadata |
+| `magpie status` | Check server health and connectivity |
 | `magpie config [--server URL] [--token TOKEN]` | Manage configuration |
 | `magpie gc [--dry-run]` | Run garbage collection |
 | `magpie version` | Show version |
@@ -628,7 +767,19 @@ The artifact was already stored; the existing hash was returned.
 | `MAGPIE_HTTP_PORT` | Deploy | External HTTP port (default: 8080) |
 | `MAGPIE_HTTPS_PORT` | Deploy | External HTTPS port (default: 8443) |
 | `MAGPIE_STORAGE_PATH` | Server | Storage directory |
+| `MAGPIE_TEMP_PATH` | Server | Temporary file storage during uploads |
+| `MAGPIE_DATABASE_PATH` | Server | SQLite database location for tokens |
 | `MAGPIE_RETENTION_DAYS` | Server | GC retention period |
+| `MAGPIE_GC_LOCK_PATH` | Server | Lock file path to prevent concurrent GC |
+| `MAGPIE_MAX_UPLOAD_SIZE` | Server | Maximum upload size in bytes (None = unlimited) |
+| `MAGPIE_LOG_FORMAT` | Server | Log format: json or console |
+| `MAGPIE_SENTRY_DSN` | Server | Sentry DSN for error tracking |
+| `MAGPIE_OTEL_ENABLED` | Server | Enable OpenTelemetry tracing |
+| `MAGPIE_OTEL_ENDPOINT` | Server | OpenTelemetry collector endpoint |
+| `MAGPIE_OTEL_SERVICE_NAME` | Server | Service name for OpenTelemetry traces |
+| `MAGPIE_S3_BUCKET` | Server | S3 bucket for backup/restore operations |
+| `MAGPIE_S3_PREFIX` | Server | Optional prefix for S3 keys |
+| `MAGPIE_ALLOWED_CIDRS` | Server | Comma-separated CIDR ranges for IP allow-listing |
 | `MAGPIE_DEBUG` | Both | Enable debug mode |
 
 ### API Endpoints


### PR DESCRIPTION
## Summary

This PR addresses multiple documentation issues:

**#252 - Documentation Index:**
- Created `docs/index.md` as a comprehensive documentation table of contents
- Provides clear navigation and suggested reading order for new users
- Organized by category: Getting Started, Integration Guides, Operations, Observability

**#248 - Status Command:**
- Document `magpie status` command with usage examples and output format

**#249 - S3 Sync Commands:**
- Document S3 sync commands (`magpie-ctl sync to-s3`, `from-s3`, `gc-s3`)
- Include prerequisites, examples, and safety notes

**#250 - Environment Variables:**
- Add missing environment variables to server configuration table
  - MAGPIE_TEMP_PATH, MAGPIE_DATABASE_PATH, MAGPIE_GC_LOCK_PATH
  - MAGPIE_MAX_UPLOAD_SIZE, MAGPIE_LOG_FORMAT
  - MAGPIE_SENTRY_DSN, MAGPIE_OTEL_*, MAGPIE_S3_*, MAGPIE_ALLOWED_CIDRS

**#253 - Exit Codes:**
- Document exit codes (0=success, 1=error) and API error response format

## Changes

### docs/index.md (new file)
- Comprehensive documentation navigation
- Quick reference section
- Organized by user journey

### docs/user-guide.md
- Added "Check Server Status" section under Basic Usage with `magpie status` examples
- Added "S3 Sync Commands" subsection under Backup and Disaster Recovery
- Expanded Server Environment Variables table with all missing variables
- Added "Exit Codes and Error Handling" section with CLI exit codes and API error formats
- Updated Quick Reference sections to include new commands and variables

## Test Plan

- [x] Read source files to understand features (status.py, sync.py, config.py)
- [x] Verify documentation accurately reflects implementation
- [x] Run linting (ruff check)
- [x] Review diff to ensure all changes are correct
- [x] Commit with Co-Authored-By

## Related Issues

Closes #248
Closes #249
Closes #250
Closes #252
Closes #253

---
(AI-generated via Claude Code w/ Opus 4.5)