### PR TITLE
docs: reference CONTRIBUTING.md in copilot-instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -19,6 +19,12 @@ For full context, read these documents in `deployment/docs/docs/projects/active/
 | `proposal.md` | One-pager summary with progress checklist |
 | `index.md` | Project overview |
 
+Also in the repo root:
+
+| Document | Description |
+|----------|-------------|
+| `CONTRIBUTING.md` | Labels, milestones, triage guidelines, PR workflow |
+
 ## Architecture Summary
 
 - **Caddy** serves static files directly from filesystem


### PR DESCRIPTION
## Summary

- Add CONTRIBUTING.md to Key Documentation table in copilot-instructions.md
- Ensures AI assistants know to consult it for labels, milestones, and triage guidelines

## Test plan

- [ ] Verify the markdown renders correctly

(AI-generated via Claude Code w/ Opus 4.5)