### PR TITLE
feat(docker): add AWS CLI v2 for S3 sync operations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,10 +25,17 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
     gosu nobody true && gosu 1000:1000 true  # verify it works
 
-# Install AWS CLI v2 for S3 sync operations
-RUN apt-get update && \
+# Install AWS CLI v2 for S3 sync operations (multi-arch support)
+RUN set -eux; \
+    apt-get update && \
     apt-get install -y --no-install-recommends curl unzip && \
-    curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+    arch="$(dpkg --print-architecture)"; \
+    case "$arch" in \
+        amd64) aws_arch="x86_64" ;; \
+        arm64) aws_arch="aarch64" ;; \
+        *) echo "Unsupported architecture for AWS CLI: $arch" >&2; exit 1 ;; \
+    esac; \
+    curl "https://awscli.amazonaws.com/awscli-exe-linux-${aws_arch}.zip" -o "awscliv2.zip" && \
     unzip awscliv2.zip && \
     ./aws/install && \
     rm -rf awscliv2.zip aws && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,17 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
     gosu nobody true && gosu 1000:1000 true  # verify it works
 
+# Install AWS CLI v2 for S3 sync operations
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends curl unzip && \
+    curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+    unzip awscliv2.zip && \
+    ./aws/install && \
+    rm -rf awscliv2.zip aws && \
+    apt-get purge -y curl unzip && \
+    apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/*
+
 COPY src/ ./src/
 COPY pyproject.toml uv.lock README.md ./
 


### PR DESCRIPTION
## Summary

- Install AWS CLI v2 in the Docker container to enable S3 sync operations
- Resolves the "Neither rclone nor aws CLI found" error when running `magpie-ctl sync` commands inside the container

## Implementation Details

The AWS CLI v2 is installed using the official AWS installation method:
- Downloads the awscli v2 binary distribution for Linux x86_64
- Installs to `/usr/local/bin/aws`
- Cleans up installation artifacts (zip file, temp directory)
- Removes curl and unzip after installation to reduce attack surface
- Adds approximately 100-150MB to the image size (image is now 472MB)

## Testing

1. Built Docker image successfully
2. Verified AWS CLI installation: `aws --version` returns `aws-cli/2.33.4`
3. Tested `magpie-ctl sync to-s3 --dry-run` - successfully finds AWS CLI and no longer errors
4. All 809 unit tests pass
5. Linting passes (ruff check)
6. Code formatting correct (ruff format)
7. Security scan clean (bandit)

## Test Plan

- [x] Docker image builds successfully
- [x] AWS CLI is installed and accessible at `/usr/local/bin/aws`
- [x] `magpie-ctl sync to-s3 --dry-run` no longer fails with "Neither rclone nor aws CLI found"
- [x] Unit tests pass
- [x] Linting passes
- [x] Security scan passes

Addresses #274

---
(AI-generated via Claude Code w/ Opus 4.5)