### PR TITLE
fix(deploy): use awk for Caddyfile extraction to handle nested braces

### DIFF
--- a/scripts/magpie-deploy.sh
+++ b/scripts/magpie-deploy.sh
@@ -472,9 +472,32 @@ EOF
 
             # Extract route definitions from Caddyfile.prod (skip global block and site address)
             # Start after the site block opening, end before final closing brace
-            sed -n '/^{\$MAGPIE_DOMAIN}/,/^}$/p' "$source_caddyfile" | \
-                sed '1d;$d' | \
-                sed '/Strict-Transport-Security/d' >> "$dest_caddyfile"
+            # Use awk to properly track brace nesting depth (issue #273)
+            awk '
+                /^{\$MAGPIE_DOMAIN}/ {
+                    in_site_block = 1
+                    depth = 0
+                    next
+                }
+                in_site_block {
+                    # Count opening and closing braces
+                    for (i = 1; i <= length($0); i++) {
+                        c = substr($0, i, 1)
+                        if (c == "{") depth++
+                        if (c == "}") depth--
+                    }
+
+                    # If depth returns to -1, we found the final closing brace
+                    if (depth == -1) {
+                        exit
+                    }
+
+                    # Skip HSTS header (not applicable to HTTP-only mode)
+                    if ($0 !~ /Strict-Transport-Security/) {
+                        print
+                    }
+                }
+            ' "$source_caddyfile" >> "$dest_caddyfile"
 
             echo "}" >> "$dest_caddyfile"
             ;;

--- a/scripts/magpie-deploy.sh
+++ b/scripts/magpie-deploy.sh
@@ -473,6 +473,20 @@ EOF
             # Extract route definitions from Caddyfile.prod (skip global block and site address)
             # Start after the site block opening, end before final closing brace
             # Use awk to properly track brace nesting depth (issue #273)
+            #
+            # Depth tracking explanation:
+            # - The site block line "{$MAGPIE_DOMAIN} {" is SKIPPED with 'next', so we never count
+            #   its opening brace. This is intentional: we want the CONTENT inside the block.
+            # - We start at depth=0 (inside the site block, but before any nested blocks)
+            # - Each nested block (header {}, handle {}, etc.) increments/decrements depth
+            # - The internal content is balanced (each { has a matching }), so depth returns to 0
+            # - The final closing brace of the site block (line 398) has no matching opener
+            #   (since we skipped line 136), so it decrements depth to -1
+            # - depth==-1 signals we've found the site block's closing brace
+            #
+            # Known limitation: Braces inside quoted strings (e.g., JSON responses) would be
+            # counted. The current Caddyfile.prod has no such cases. If this becomes an issue,
+            # a more sophisticated parser would be needed.
             awk '
                 /^{\$MAGPIE_DOMAIN}/ {
                     in_site_block = 1

--- a/scripts/test_caddyfile_extraction.sh
+++ b/scripts/test_caddyfile_extraction.sh
@@ -12,7 +12,7 @@ NC='\033[0m' # No Color
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="${SCRIPT_DIR}/.."
 CADDYFILE_PROD="${REPO_ROOT}/Caddyfile.prod"
-TEST_OUTPUT="/tmp/test_caddyfile_extraction_$$.txt"
+TEST_OUTPUT="$(mktemp "${TMPDIR:-/tmp}/test_caddyfile_extraction_XXXXXX.txt")"
 
 cleanup() {
     rm -f "$TEST_OUTPUT"
@@ -75,12 +75,12 @@ fi
 echo -n "Test 3: Checking for route handlers... "
 if grep -q "handle /health" "$TEST_OUTPUT" && \
    grep -q "handle /artifacts" "$TEST_OUTPUT" && \
-   grep -q "handle /" "$TEST_OUTPUT"; then
+   grep -qE '^[[:space:]]*handle / \{' "$TEST_OUTPUT"; then
     echo -e "${GREEN}PASS${NC}"
 else
     echo -e "${RED}FAIL${NC}"
     echo "ERROR: Route handlers not found"
-    echo "Expected: handle /health, handle /artifacts, handle /"
+    echo "Expected: handle /health, handle /artifacts, handle / {"
     exit 1
 fi
 

--- a/scripts/test_caddyfile_extraction.sh
+++ b/scripts/test_caddyfile_extraction.sh
@@ -10,7 +10,8 @@ GREEN='\033[0;32m'
 NC='\033[0m' # No Color
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-CADDYFILE_PROD="${SCRIPT_DIR}/Caddyfile.prod"
+REPO_ROOT="${SCRIPT_DIR}/.."
+CADDYFILE_PROD="${REPO_ROOT}/Caddyfile.prod"
 TEST_OUTPUT="/tmp/test_caddyfile_extraction_$$.txt"
 
 cleanup() {

--- a/test_caddyfile_extraction.sh
+++ b/test_caddyfile_extraction.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+# Test script for Caddyfile extraction in TLS mode: off
+# Verifies fix for issue #273
+
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m' # No Color
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CADDYFILE_PROD="${SCRIPT_DIR}/Caddyfile.prod"
+TEST_OUTPUT="/tmp/test_caddyfile_extraction_$$.txt"
+
+cleanup() {
+    rm -f "$TEST_OUTPUT"
+}
+trap cleanup EXIT
+
+echo "Testing Caddyfile extraction (issue #273 fix)..."
+echo "Source: ${CADDYFILE_PROD}"
+echo "Output: ${TEST_OUTPUT}"
+echo ""
+
+# Extract site block using the new awk-based method
+awk '
+    /^{\$MAGPIE_DOMAIN}/ {
+        in_site_block = 1
+        depth = 0
+        next
+    }
+    in_site_block {
+        # Count opening and closing braces
+        for (i = 1; i <= length($0); i++) {
+            c = substr($0, i, 1)
+            if (c == "{") depth++
+            if (c == "}") depth--
+        }
+
+        # If depth returns to -1, we found the final closing brace
+        if (depth == -1) {
+            exit
+        }
+
+        # Skip HSTS header (not applicable to HTTP-only mode)
+        if ($0 !~ /Strict-Transport-Security/) {
+            print
+        }
+    }
+' "$CADDYFILE_PROD" > "$TEST_OUTPUT"
+
+# Test 1: Verify we have content
+echo -n "Test 1: Checking if extraction produced output... "
+if [[ -s "$TEST_OUTPUT" ]]; then
+    echo -e "${GREEN}PASS${NC}"
+else
+    echo -e "${RED}FAIL${NC}"
+    echo "ERROR: No output produced"
+    exit 1
+fi
+
+# Test 2: Verify we have the header block
+echo -n "Test 2: Checking for header block... "
+if grep -q "header {" "$TEST_OUTPUT"; then
+    echo -e "${GREEN}PASS${NC}"
+else
+    echo -e "${RED}FAIL${NC}"
+    echo "ERROR: header block not found"
+    exit 1
+fi
+
+# Test 3: Verify we have route handlers (not just the header block)
+echo -n "Test 3: Checking for route handlers... "
+if grep -q "handle /health" "$TEST_OUTPUT" && \
+   grep -q "handle /artifacts" "$TEST_OUTPUT" && \
+   grep -q "handle /" "$TEST_OUTPUT"; then
+    echo -e "${GREEN}PASS${NC}"
+else
+    echo -e "${RED}FAIL${NC}"
+    echo "ERROR: Route handlers not found"
+    echo "Expected: handle /health, handle /artifacts, handle /"
+    exit 1
+fi
+
+# Test 4: Verify root redirect is present
+echo -n "Test 4: Checking for root redirect... "
+if grep -q "redir /artifacts/ permanent" "$TEST_OUTPUT"; then
+    echo -e "${GREEN}PASS${NC}"
+else
+    echo -e "${RED}FAIL${NC}"
+    echo "ERROR: Root redirect not found"
+    exit 1
+fi
+
+# Test 5: Verify fallback handler is present
+echo -n "Test 5: Checking for fallback handler... "
+if grep -q 'respond "Not Found" 404' "$TEST_OUTPUT"; then
+    echo -e "${GREEN}PASS${NC}"
+else
+    echo -e "${RED}FAIL${NC}"
+    echo "ERROR: Fallback handler not found"
+    exit 1
+fi
+
+# Test 6: Verify HSTS header is removed
+echo -n "Test 6: Checking HSTS header is removed... "
+if ! grep -q "Strict-Transport-Security" "$TEST_OUTPUT"; then
+    echo -e "${GREEN}PASS${NC}"
+else
+    echo -e "${RED}FAIL${NC}"
+    echo "ERROR: HSTS header should be removed in HTTP-only mode"
+    exit 1
+fi
+
+# Test 7: Verify we have a reasonable amount of content (should be ~260 lines)
+echo -n "Test 7: Checking output length... "
+line_count=$(wc -l < "$TEST_OUTPUT")
+if [[ $line_count -gt 200 ]]; then
+    echo -e "${GREEN}PASS${NC} ($line_count lines)"
+else
+    echo -e "${RED}FAIL${NC} ($line_count lines)"
+    echo "ERROR: Output too short (expected >200 lines, got $line_count)"
+    echo "This suggests the extraction stopped too early"
+    exit 1
+fi
+
+# Test 8: Verify specific API endpoints are present
+echo -n "Test 8: Checking for API endpoint handlers... "
+if grep -q "@artifacts_read" "$TEST_OUTPUT" && \
+   grep -q "@artifacts_tags" "$TEST_OUTPUT" && \
+   grep -q "handle /api/v1/tokens" "$TEST_OUTPUT" && \
+   grep -q "handle /api/v1/gc" "$TEST_OUTPUT"; then
+    echo -e "${GREEN}PASS${NC}"
+else
+    echo -e "${RED}FAIL${NC}"
+    echo "ERROR: Not all API endpoint handlers found"
+    exit 1
+fi
+
+echo ""
+echo -e "${GREEN}All tests passed!${NC}"
+echo ""
+echo "Sample of extracted content (first 20 lines):"
+head -20 "$TEST_OUTPUT"
+echo "..."
+echo ""
+echo "Sample of extracted content (last 20 lines):"
+tail -20 "$TEST_OUTPUT"


### PR DESCRIPTION
## Summary

Fixes #273: The sed-based extraction in `magpie-deploy.sh --tls-mode off` was matching the first closing brace (line 179, end of header block) instead of the final closing brace (line 398, end of site block), causing the generated HTTP-only Caddyfile to be truncated.

### Changes

- Replaced sed with awk that properly tracks brace nesting depth
- The awk script counts opening/closing braces and stops at the final closing brace
- Added `test_caddyfile_extraction.sh` to verify the fix

### Technical Details

The old sed pattern:
```bash
sed -n '/^{\$MAGPIE_DOMAIN}/,/^}$/p' "$source_caddyfile"
```

Matched `/^}$/` (a line with just `}`) which occurs at:
- Line 132: end of global options block
- Line 398: end of site block (the one we want)

The new awk-based approach:
```awk
/^{\$MAGPIE_DOMAIN}/ {
    in_site_block = 1
    depth = 0
    next
}
in_site_block {
    # Count opening and closing braces
    for (i = 1; i <= length($0); i++) {
        c = substr($0, i, 1)
        if (c == "{") depth++
        if (c == "}") depth--
    }

    # If depth returns to -1, we found the final closing brace
    if (depth == -1) {
        exit
    }

    # Skip HSTS header (not applicable to HTTP-only mode)
    if ($0 !~ /Strict-Transport-Security/) {
        print
    }
}
```

This properly tracks nesting and stops at the correct closing brace.

## Test Plan

- [x] Run test script: `./test_caddyfile_extraction.sh` (all 8 tests pass)
- [x] Verify extraction produces ~260 lines (not just 47)
- [x] Verify all route handlers are present (health, artifacts, API endpoints, root redirect, fallback)
- [x] Verify HSTS header is removed
- [x] Shellcheck passes on both scripts
- [x] Ruff linting passes

### Test Output

```
Test 1: Checking if extraction produced output... PASS
Test 2: Checking for header block... PASS
Test 3: Checking for route handlers... PASS
Test 4: Checking for root redirect... PASS
Test 5: Checking for fallback handler... PASS
Test 6: Checking HSTS header is removed... PASS
Test 7: Checking output length... PASS (260 lines)
Test 8: Checking for API endpoint handlers... PASS
```

---
(AI-generated via Claude Code w/ Opus 4.5)