### PR TITLE
docs: verify and improve CLI --help documentation

### DIFF
--- a/src/magpie/ctl/commands/init.py
+++ b/src/magpie/ctl/commands/init.py
@@ -44,12 +44,6 @@ def init(ctx: CTLContext, reset_admin_token: bool, admin_token: str | None) -> N
     Use --admin-token to specify a custom token instead of generating
     a random one. The token must start with 'mgp_ADMIN_'.
 
-    Args:
-        ctx: Click context containing settings and debug flag.
-        reset_admin_token: If True, revokes existing admin token before creating new one.
-        admin_token: Optional custom token to use instead of generating random one.
-            Must start with 'mgp_ADMIN_' and have content after the prefix.
-
     Examples:
 
         magpie-ctl init
@@ -58,6 +52,11 @@ def init(ctx: CTLContext, reset_admin_token: bool, admin_token: str | None) -> N
 
         magpie-ctl init --admin-token mgp_ADMIN_custom_token_here
     """
+    # Args (for developers):
+    #   ctx: Click context containing settings and debug flag.
+    #   reset_admin_token: If True, revokes existing admin token before creating new one.
+    #   admin_token: Optional custom token to use instead of generating random one.
+    #       Must start with 'mgp_ADMIN_' and have content after the prefix.
     settings = ctx.settings
 
     # Create storage directories


### PR DESCRIPTION
## Summary

Verified all help documentation for both `magpie` CLI and `magpie-ctl` admin tools. Fixed one issue where internal documentation (Args section) was appearing in user-facing help output.

### Changes Made

- Reviewed all 13 `magpie` client commands
- Reviewed all 9 `magpie-ctl` admin commands  
- Fixed `magpie-ctl init` help text by converting Args section from docstring to code comment
- All commands now have clean, complete help text with examples

### Commands Verified

**magpie CLI (client):**
- `push`, `get`, `ls`, `tag`, `info`, `status`, `version`, `url`, `untag`, `amend`, `gc`, `flush-tag`, `config`

**magpie-ctl (admin):**
- `init`, `token` (with subcommands: `list`, `create`, `revoke`), `gc`, `sync` (with subcommands: `to-s3`, `from-s3`, `gc-s3`), `flush-tag`, `version`

All commands include:
- Clear synopsis showing usage patterns
- Descriptions explaining purpose
- Documented options with help text
- Examples demonstrating usage
- Environment variable documentation where applicable

## Test Plan

- [x] All unit tests pass (809 tests)
- [x] Linting passes (ruff check + format)
- [x] Security scan clean (bandit)
- [x] Manually verified all help output is complete and correct
- [x] Confirmed `magpie-ctl init --help` no longer shows internal Args section

Closes #277

---
(AI-generated via Claude Code w/ Opus 4.5)