### PR TITLE
Security fix: Restrict MAGPIE_ALLOWED_CIDRS to read-only access

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -104,15 +104,21 @@
 # MAGPIE_OTEL_SERVICE_NAME=magpie
 
 # =============================================================================
-# IP Allow-listing (Optional)
+# IP Allow-listing (Optional) - READ-ONLY ACCESS
 # =============================================================================
 
 # Comma-separated list of CIDR ranges allowed to bypass bearer token authentication
-# Requests from these IP addresses can access protected routes without auth
-# Useful for internal infrastructure, monitoring systems, and CI/CD pipelines
+# for READ-ONLY operations (GET /api/v1/artifacts*, GET /artifacts/*).
 #
-# SECURITY WARNING: Only add trusted network ranges. Any IP in the allowed list
-# can access all protected endpoints without authentication.
+# Requests from these IP addresses can READ artifacts without authentication.
+# WRITE and ADMIN operations (uploads, tag mutations, token management, GC) still
+# require a valid bearer token even from allowed IPs.
+#
+# Useful for internal infrastructure, monitoring systems, and CI/CD pipelines that
+# need to download artifacts on trusted networks.
+#
+# SECURITY WARNING: Only add trusted network ranges. IPs in the allowed list
+# can read all artifacts without authentication.
 #
 # DEPLOYMENT NOTE: If Caddy is behind a reverse proxy (load balancer, CloudFlare, etc.),
 # you must configure trusted_proxies in Caddy so it reads the real client IP.

--- a/Caddyfile
+++ b/Caddyfile
@@ -19,16 +19,19 @@
 # =============================================================================
 #
 # PROTECTED ROUTES (require valid Bearer token):
-#   - POST   /api/v1/upload/*              - Artifact uploads
-#   - GET    /api/v1/artifacts/*           - List artifacts, get info
-#   - POST   /api/v1/artifacts/*/tags      - Create/update tags
-#   - DELETE /api/v1/artifacts/*/tags/*    - Remove tags
-#   - POST   /api/v1/tags/*/flush          - Flush tags globally
-#   - GET    /api/v1/tokens                - List tokens (admin)
-#   - POST   /api/v1/tokens                - Create tokens (admin)
-#   - DELETE /api/v1/tokens/*              - Revoke tokens (admin)
-#   - POST   /api/v1/gc                    - Garbage collection (admin)
-#   - GET    /artifacts/*                  - Static file downloads (except /artifacts/public/*)
+#   - POST   /api/v1/upload/*                            - Artifact uploads
+#   - GET    /api/v1/artifacts/*                         - List artifacts, get info
+#   - POST   /api/v1/artifacts/{path}/tags               - Add tags to artifact
+#   - DELETE /api/v1/artifacts/{path}/tags/{tag_name}    - Remove tags from artifact
+#   - POST   /api/v1/tags/{tag_name}/flush               - Flush tags globally
+#   - GET    /api/v1/tokens                              - List tokens (admin)
+#   - POST   /api/v1/tokens                              - Create tokens (admin)
+#   - DELETE /api/v1/tokens/*                            - Revoke tokens (admin)
+#   - POST   /api/v1/gc                                  - Garbage collection (admin)
+#   - GET    /artifacts/*                                - Static file downloads (except /artifacts/public/*)
+#
+# Note: GET routes may bypass authentication for IPs in MAGPIE_ALLOWED_CIDRS
+# (see IP ALLOW-LISTING section below)
 #
 # PUBLIC ROUTES (no authentication required):
 #   - GET    /api/v1/auth/validate         - Auth validation endpoint
@@ -62,12 +65,13 @@
 #
 # WRITE and ADMIN operations ALWAYS require a valid bearer token, even from
 # allowed IPs:
-#   - POST /api/v1/upload/*              (uploads)
-#   - PATCH /api/v1/artifacts/*          (metadata amendments)
-#   - POST/DELETE /api/v1/artifacts/*/tags (tag management)
-#   - POST /api/v1/tags/*                (tag operations)
-#   - POST/DELETE /api/v1/tokens*        (token management)
-#   - POST /api/v1/gc                    (garbage collection)
+#   - POST /api/v1/upload/*                            (uploads)
+#   - PATCH /api/v1/artifacts/*                        (metadata amendments)
+#   - POST /api/v1/artifacts/{path}/tags               (add tags)
+#   - DELETE /api/v1/artifacts/{path}/tags/{tag_name}  (remove tags)
+#   - POST /api/v1/tags/{tag_name}/flush               (tag flushing)
+#   - POST/DELETE /api/v1/tokens*                      (token management)
+#   - POST /api/v1/gc                                  (garbage collection)
 #
 # This is useful for:
 #   - Internal monitoring and alerting systems

--- a/Caddyfile
+++ b/Caddyfile
@@ -46,22 +46,36 @@
 # The FastAPI backend can use these headers for authorization decisions.
 #
 # =============================================================================
-# IP ALLOW-LISTING
+# IP ALLOW-LISTING (READ-ONLY ACCESS)
 # =============================================================================
 #
 # Environment variable configuration:
 #   MAGPIE_ALLOWED_CIDRS - Comma-separated list of CIDR ranges allowed to bypass
-#                          bearer token authentication (e.g., "10.0.0.0/8,192.168.1.0/24")
+#                          bearer token authentication for READ-ONLY operations
+#                          (e.g., "10.0.0.0/8,192.168.1.0/24")
 #                          Default: empty (no IP exemptions)
 #
 # When MAGPIE_ALLOWED_CIDRS is set, requests from these IP ranges can access
-# protected routes without a bearer token. This is useful for:
-#   - Internal infrastructure tools
-#   - Monitoring systems
-#   - CI/CD pipelines on trusted networks
+# READ operations without a bearer token:
+#   - GET /api/v1/artifacts*  (list artifacts, get metadata)
+#   - GET /artifacts/*        (download artifact files)
 #
-# SECURITY NOTE: Only add trusted network ranges. Any IP in the allowed list
-# can access all protected endpoints without authentication.
+# WRITE and ADMIN operations ALWAYS require a valid bearer token, even from
+# allowed IPs:
+#   - POST /api/v1/upload/*              (uploads)
+#   - PATCH /api/v1/artifacts/*          (metadata amendments)
+#   - POST/DELETE /api/v1/artifacts/*/tags (tag management)
+#   - POST /api/v1/tags/*                (tag operations)
+#   - POST/DELETE /api/v1/tokens*        (token management)
+#   - POST /api/v1/gc                    (garbage collection)
+#
+# This is useful for:
+#   - Internal monitoring and alerting systems
+#   - CI/CD pipelines downloading artifacts on trusted networks
+#   - Read-only infrastructure tools
+#
+# SECURITY NOTE: Only add trusted network ranges. IPs in the allowed list
+# can read all artifacts without authentication.
 #
 # =============================================================================
 
@@ -135,19 +149,16 @@
 		file_server browse
 	}
 
-	# Upload endpoint - requires write or admin scope OR allowed IP
+	# Upload endpoint - requires write or admin scope
 	handle /api/v1/upload/* {
-		@require_auth {
-			not remote_ip {$MAGPIE_ALLOWED_CIDRS:255.255.255.255/32}
-		}
-		forward_auth @require_auth magpie:8000 {
+		forward_auth magpie:8000 {
 			uri /api/v1/auth/validate
 			copy_headers X-Magpie-User X-Magpie-Scope
 		}
 		reverse_proxy magpie:8000
 	}
 
-	# Artifact metadata amendment - requires write or admin scope OR allowed IP
+	# Artifact metadata amendment - requires write or admin scope
 	# Matches: PATCH /api/v1/artifacts/{path}/{ref}
 	# Note: Uses path_regexp because artifact paths can have multiple segments
 	@artifacts_amend {
@@ -155,17 +166,14 @@
 		path_regexp ^/api/v1/artifacts/.+
 	}
 	handle @artifacts_amend {
-		@require_auth {
-			not remote_ip {$MAGPIE_ALLOWED_CIDRS:255.255.255.255/32}
-		}
-		forward_auth @require_auth magpie:8000 {
+		forward_auth magpie:8000 {
 			uri /api/v1/auth/validate
 			copy_headers X-Magpie-User X-Magpie-Scope
 		}
 		reverse_proxy magpie:8000
 	}
 
-	# Tag mutation endpoints - requires write or admin scope OR allowed IP
+	# Tag mutation endpoints - requires write or admin scope
 	# Matches: POST /api/v1/artifacts/{path}/{ref}/tags
 	#          DELETE /api/v1/artifacts/{path}/tags/{tag_name}
 	# Note: Uses path_regexp because artifact paths can have multiple segments
@@ -175,46 +183,34 @@
 		path_regexp ^/api/v1/artifacts/.+/tags
 	}
 	handle @artifacts_tags {
-		@require_auth {
-			not remote_ip {$MAGPIE_ALLOWED_CIDRS:255.255.255.255/32}
-		}
-		forward_auth @require_auth magpie:8000 {
+		forward_auth magpie:8000 {
 			uri /api/v1/auth/validate
 			copy_headers X-Magpie-User X-Magpie-Scope
 		}
 		reverse_proxy magpie:8000
 	}
 
-	# Flush tag endpoint - requires admin scope OR allowed IP
+	# Flush tag endpoint - requires admin scope
 	handle /api/v1/tags/* {
-		@require_auth {
-			not remote_ip {$MAGPIE_ALLOWED_CIDRS:255.255.255.255/32}
-		}
-		forward_auth @require_auth magpie:8000 {
+		forward_auth magpie:8000 {
 			uri /api/v1/auth/validate
 			copy_headers X-Magpie-User X-Magpie-Scope
 		}
 		reverse_proxy magpie:8000
 	}
 
-	# Token management endpoints - requires admin scope OR allowed IP
+	# Token management endpoints - requires admin scope
 	handle /api/v1/tokens* {
-		@require_auth {
-			not remote_ip {$MAGPIE_ALLOWED_CIDRS:255.255.255.255/32}
-		}
-		forward_auth @require_auth magpie:8000 {
+		forward_auth magpie:8000 {
 			uri /api/v1/auth/validate
 			copy_headers X-Magpie-User X-Magpie-Scope
 		}
 		reverse_proxy magpie:8000
 	}
 
-	# GC endpoint - requires admin scope OR allowed IP
+	# GC endpoint - requires admin scope
 	handle /api/v1/gc {
-		@require_auth {
-			not remote_ip {$MAGPIE_ALLOWED_CIDRS:255.255.255.255/32}
-		}
-		forward_auth @require_auth magpie:8000 {
+		forward_auth magpie:8000 {
 			uri /api/v1/auth/validate
 			copy_headers X-Magpie-User X-Magpie-Scope
 		}

--- a/Caddyfile
+++ b/Caddyfile
@@ -21,7 +21,7 @@
 # PROTECTED ROUTES (require valid Bearer token):
 #   - POST   /api/v1/upload/*                            - Artifact uploads
 #   - GET    /api/v1/artifacts/*                         - List artifacts, get info
-#   - POST   /api/v1/artifacts/{path}/tags               - Add tags to artifact
+#   - POST   /api/v1/artifacts/{path}/{ref}/tags         - Add tags to artifact
 #   - DELETE /api/v1/artifacts/{path}/tags/{tag_name}    - Remove tags from artifact
 #   - POST   /api/v1/tags/{tag_name}/flush               - Flush tags globally
 #   - GET    /api/v1/tokens                              - List tokens (admin)
@@ -67,7 +67,7 @@
 # allowed IPs:
 #   - POST /api/v1/upload/*                            (uploads)
 #   - PATCH /api/v1/artifacts/*                        (metadata amendments)
-#   - POST /api/v1/artifacts/{path}/tags               (add tags)
+#   - POST /api/v1/artifacts/{path}/{ref}/tags         (add tags)
 #   - DELETE /api/v1/artifacts/{path}/tags/{tag_name}  (remove tags)
 #   - POST /api/v1/tags/{tag_name}/flush               (tag flushing)
 #   - POST/DELETE /api/v1/tokens*                      (token management)

--- a/Caddyfile.prod
+++ b/Caddyfile.prod
@@ -12,9 +12,10 @@
 # Environment variable configuration:
 #   MAGPIE_DOMAIN - The domain name for the service (REQUIRED - no default)
 #   MAGPIE_ALLOWED_CIDRS - Comma-separated list of CIDR ranges allowed to bypass
-#                          bearer token authentication (OPTIONAL)
+#                          bearer token authentication for READ-ONLY operations (OPTIONAL)
 #     Example: 10.0.0.0/8,192.168.1.0/24
-#     When set, requests from these IP ranges can access protected routes without auth
+#     When set, requests from these IP ranges can access read operations without auth
+#     (GET /api/v1/artifacts*, GET /artifacts/*). Write and admin operations still require auth.
 #   AUTHENTIK_HOST - Authentik server hostname (OPTIONAL)
 #     Example: authentik.example.com
 #     When set (and SSO block uncommented), enables Authentik SSO for /artifacts/* browsing
@@ -93,22 +94,36 @@
 # The FastAPI backend can use these headers for authorization decisions and logging.
 #
 # =============================================================================
-# IP ALLOW-LISTING
+# IP ALLOW-LISTING (READ-ONLY ACCESS)
 # =============================================================================
 #
 # Environment variable configuration:
 #   MAGPIE_ALLOWED_CIDRS - Comma-separated list of CIDR ranges allowed to bypass
-#                          bearer token authentication (e.g., "10.0.0.0/8,192.168.1.0/24")
+#                          bearer token authentication for READ-ONLY operations
+#                          (e.g., "10.0.0.0/8,192.168.1.0/24")
 #                          Default: empty (no IP exemptions)
 #
 # When MAGPIE_ALLOWED_CIDRS is set, requests from these IP ranges can access
-# protected routes without a bearer token. This is useful for:
-#   - Internal infrastructure tools
-#   - Monitoring systems
-#   - CI/CD pipelines on trusted networks
+# READ operations without a bearer token:
+#   - GET /api/v1/artifacts*  (list artifacts, get metadata)
+#   - GET /artifacts/*        (download artifact files)
 #
-# SECURITY NOTE: Only add trusted network ranges. Any IP in the allowed list
-# can access all protected endpoints without authentication.
+# WRITE and ADMIN operations ALWAYS require a valid bearer token, even from
+# allowed IPs:
+#   - POST /api/v1/upload/*              (uploads)
+#   - PATCH /api/v1/artifacts/*          (metadata amendments)
+#   - POST/DELETE /api/v1/artifacts/*/tags (tag management)
+#   - POST /api/v1/tags/*/flush          (tag flushing)
+#   - POST/DELETE /api/v1/tokens*        (token management)
+#   - POST /api/v1/gc                    (garbage collection)
+#
+# This is useful for:
+#   - Internal monitoring and alerting systems
+#   - CI/CD pipelines downloading artifacts on trusted networks
+#   - Read-only infrastructure tools
+#
+# SECURITY NOTE: Only add trusted network ranges. IPs in the allowed list
+# can read all artifacts without authentication.
 #
 # =============================================================================
 
@@ -281,19 +296,16 @@
 		file_server browse
 	}
 
-	# Upload endpoint - requires write or admin scope OR allowed IP
+	# Upload endpoint - requires write or admin scope
 	handle /api/v1/upload/* {
-		@require_auth {
-			not remote_ip {$MAGPIE_ALLOWED_CIDRS:255.255.255.255/32}
-		}
-		forward_auth @require_auth magpie:8000 {
+		forward_auth magpie:8000 {
 			uri /api/v1/auth/validate
 			copy_headers X-Magpie-User X-Magpie-Scope
 		}
 		reverse_proxy magpie:8000
 	}
 
-	# Artifact metadata amendment - requires write or admin scope OR allowed IP
+	# Artifact metadata amendment - requires write or admin scope
 	# Matches: PATCH /api/v1/artifacts/{path}/{ref}
 	# Note: Uses path_regexp because artifact paths can have multiple segments
 	@artifacts_amend {
@@ -301,17 +313,14 @@
 		path_regexp ^/api/v1/artifacts/.+
 	}
 	handle @artifacts_amend {
-		@require_auth {
-			not remote_ip {$MAGPIE_ALLOWED_CIDRS:255.255.255.255/32}
-		}
-		forward_auth @require_auth magpie:8000 {
+		forward_auth magpie:8000 {
 			uri /api/v1/auth/validate
 			copy_headers X-Magpie-User X-Magpie-Scope
 		}
 		reverse_proxy magpie:8000
 	}
 
-	# Tag mutation endpoints - requires write or admin scope OR allowed IP
+	# Tag mutation endpoints - requires write or admin scope
 	# Matches: POST /api/v1/artifacts/{path}/{ref}/tags
 	#          DELETE /api/v1/artifacts/{path}/tags/{tag_name}
 	# Note: Uses path_regexp because artifact paths can have multiple segments
@@ -321,17 +330,14 @@
 		path_regexp ^/api/v1/artifacts/.+/tags
 	}
 	handle @artifacts_tags {
-		@require_auth {
-			not remote_ip {$MAGPIE_ALLOWED_CIDRS:255.255.255.255/32}
-		}
-		forward_auth @require_auth magpie:8000 {
+		forward_auth magpie:8000 {
 			uri /api/v1/auth/validate
 			copy_headers X-Magpie-User X-Magpie-Scope
 		}
 		reverse_proxy magpie:8000
 	}
 
-	# Flush tag endpoint - requires admin scope OR allowed IP
+	# Flush tag endpoint - requires admin scope
 	# Matches: POST /api/v1/tags/{tag_name}/flush
 	#
 	# NOTE: This route is more specific than the dev Caddyfile which uses
@@ -344,34 +350,25 @@
 		path /api/v1/tags/*/flush
 	}
 	handle @tags_flush {
-		@require_auth {
-			not remote_ip {$MAGPIE_ALLOWED_CIDRS:255.255.255.255/32}
-		}
-		forward_auth @require_auth magpie:8000 {
+		forward_auth magpie:8000 {
 			uri /api/v1/auth/validate
 			copy_headers X-Magpie-User X-Magpie-Scope
 		}
 		reverse_proxy magpie:8000
 	}
 
-	# Token management endpoints - requires admin scope OR allowed IP
+	# Token management endpoints - requires admin scope
 	handle /api/v1/tokens* {
-		@require_auth {
-			not remote_ip {$MAGPIE_ALLOWED_CIDRS:255.255.255.255/32}
-		}
-		forward_auth @require_auth magpie:8000 {
+		forward_auth magpie:8000 {
 			uri /api/v1/auth/validate
 			copy_headers X-Magpie-User X-Magpie-Scope
 		}
 		reverse_proxy magpie:8000
 	}
 
-	# GC endpoint - requires admin scope OR allowed IP
+	# GC endpoint - requires admin scope
 	handle /api/v1/gc {
-		@require_auth {
-			not remote_ip {$MAGPIE_ALLOWED_CIDRS:255.255.255.255/32}
-		}
-		forward_auth @require_auth magpie:8000 {
+		forward_auth magpie:8000 {
 			uri /api/v1/auth/validate
 			copy_headers X-Magpie-User X-Magpie-Scope
 		}

--- a/Caddyfile.prod
+++ b/Caddyfile.prod
@@ -60,16 +60,19 @@
 # =============================================================================
 #
 # PROTECTED ROUTES (require valid Bearer token):
-#   - POST   /api/v1/upload/*              - Artifact uploads
-#   - GET    /api/v1/artifacts/*           - List artifacts, get info
-#   - POST   /api/v1/artifacts/*/tags      - Create/update tags
-#   - DELETE /api/v1/artifacts/*/tags/*    - Remove tags
-#   - POST   /api/v1/tags/*/flush          - Flush tags globally
-#   - GET    /api/v1/tokens                - List tokens (admin)
-#   - POST   /api/v1/tokens                - Create tokens (admin)
-#   - DELETE /api/v1/tokens/*              - Revoke tokens (admin)
-#   - POST   /api/v1/gc                    - Garbage collection (admin)
-#   - GET    /artifacts/*                  - Static file downloads (except /artifacts/public/*)
+#   - POST   /api/v1/upload/*                            - Artifact uploads
+#   - GET    /api/v1/artifacts/*                         - List artifacts, get info
+#   - POST   /api/v1/artifacts/{path}/tags               - Add tags to artifact
+#   - DELETE /api/v1/artifacts/{path}/tags/{tag_name}    - Remove tags from artifact
+#   - POST   /api/v1/tags/{tag_name}/flush               - Flush tags globally
+#   - GET    /api/v1/tokens                              - List tokens (admin)
+#   - POST   /api/v1/tokens                              - Create tokens (admin)
+#   - DELETE /api/v1/tokens/*                            - Revoke tokens (admin)
+#   - POST   /api/v1/gc                                  - Garbage collection (admin)
+#   - GET    /artifacts/*                                - Static file downloads (except /artifacts/public/*)
+#
+# Note: GET routes may bypass authentication for IPs in MAGPIE_ALLOWED_CIDRS
+# (see IP ALLOW-LISTING section below)
 #
 # PUBLIC ROUTES (no authentication required):
 #   - GET    /api/v1/auth/validate         - Auth validation endpoint
@@ -110,12 +113,13 @@
 #
 # WRITE and ADMIN operations ALWAYS require a valid bearer token, even from
 # allowed IPs:
-#   - POST /api/v1/upload/*              (uploads)
-#   - PATCH /api/v1/artifacts/*          (metadata amendments)
-#   - POST/DELETE /api/v1/artifacts/*/tags (tag management)
-#   - POST /api/v1/tags/*/flush          (tag flushing)
-#   - POST/DELETE /api/v1/tokens*        (token management)
-#   - POST /api/v1/gc                    (garbage collection)
+#   - POST /api/v1/upload/*                            (uploads)
+#   - PATCH /api/v1/artifacts/*                        (metadata amendments)
+#   - POST /api/v1/artifacts/{path}/tags               (add tags)
+#   - DELETE /api/v1/artifacts/{path}/tags/{tag_name}  (remove tags)
+#   - POST /api/v1/tags/{tag_name}/flush               (tag flushing)
+#   - POST/DELETE /api/v1/tokens*                      (token management)
+#   - POST /api/v1/gc                                  (garbage collection)
 #
 # This is useful for:
 #   - Internal monitoring and alerting systems

--- a/Caddyfile.prod
+++ b/Caddyfile.prod
@@ -62,7 +62,7 @@
 # PROTECTED ROUTES (require valid Bearer token):
 #   - POST   /api/v1/upload/*                            - Artifact uploads
 #   - GET    /api/v1/artifacts/*                         - List artifacts, get info
-#   - POST   /api/v1/artifacts/{path}/tags               - Add tags to artifact
+#   - POST   /api/v1/artifacts/{path}/{ref}/tags         - Add tags to artifact
 #   - DELETE /api/v1/artifacts/{path}/tags/{tag_name}    - Remove tags from artifact
 #   - POST   /api/v1/tags/{tag_name}/flush               - Flush tags globally
 #   - GET    /api/v1/tokens                              - List tokens (admin)
@@ -115,7 +115,7 @@
 # allowed IPs:
 #   - POST /api/v1/upload/*                            (uploads)
 #   - PATCH /api/v1/artifacts/*                        (metadata amendments)
-#   - POST /api/v1/artifacts/{path}/tags               (add tags)
+#   - POST /api/v1/artifacts/{path}/{ref}/tags         (add tags)
 #   - DELETE /api/v1/artifacts/{path}/tags/{tag_name}  (remove tags)
 #   - POST /api/v1/tags/{tag_name}/flush               (tag flushing)
 #   - POST/DELETE /api/v1/tokens*                      (token management)


### PR DESCRIPTION
## Summary

Fixes a critical security vulnerability where `MAGPIE_ALLOWED_CIDRS` was granting full access to all protected routes instead of read-only access.

Previously, any IP in the allowed CIDR ranges could perform write and admin operations without authentication, including:
- Uploading arbitrary artifacts
- Modifying/deleting tags
- Managing tokens (creating admin access)
- Triggering garbage collection

This PR restricts `MAGPIE_ALLOWED_CIDRS` to **read-only operations only**:
- GET /api/v1/artifacts* (list/query artifacts)
- GET /artifacts/* (download artifact files)

Write and admin operations now **always require** a valid bearer token, even from allowed IPs.

## Changes Made

### Caddyfile.prod and Caddyfile
- Removed `@require_auth` matcher with IP exemption from:
  - POST /api/v1/upload/* (artifact uploads)
  - PATCH /api/v1/artifacts/* (metadata amendments)
  - POST/DELETE /api/v1/artifacts/*/tags (tag management)
  - POST /api/v1/tags/*/flush (tag flushing)
  - POST/DELETE /api/v1/tokens* (token management)
  - POST /api/v1/gc (garbage collection)

- Kept IP allow-listing for read operations:
  - GET /api/v1/artifacts* (artifact queries)
  - GET /artifacts/* (file downloads)

### Documentation Updates
- Updated .env.example to clearly document read-only nature of IP allow-listing
- Updated Caddyfile and Caddyfile.prod header comments to explain the security model
- Updated IP ALLOW-LISTING section to list which operations require auth

## Security Impact

**High Priority** - This fix prevents:
- Unauthorized uploads from allowed networks
- Unauthorized tag manipulation
- Unauthorized token creation/revocation
- Unauthorized garbage collection triggers

After this fix, only read operations can bypass authentication via IP allow-listing.

## Validation

- Caddy syntax validation: Both Caddyfiles validate successfully with `caddy validate`
- Unit tests: All 809 unit tests pass
- Linting: Passes `ruff check` and `ruff format`
- Existing E2E tests verify authentication is enforced by default

## Related Issue

Fixes #279

---
(AI-generated via Claude Code w/ Opus 4.5)