### PR TITLE
docs: add missing environment variables to user guide

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -336,7 +336,6 @@ docker compose exec magpie magpie-ctl token revoke ci-reader
 | `MAGPIE_DATABASE_PATH` | `/data/artifacts/.magpie.db` | SQLite token database path (defaults under `MAGPIE_STORAGE_PATH`, derived if storage path is overridden) |
 | `MAGPIE_RETENTION_DAYS` | `90` | Days before untagged blobs can be GC'd |
 | `MAGPIE_DEBUG` | `false` | Enable debug logging |
-| `MAGPIE_GC_LOCK_PATH` | `/var/run/magpie-gc.lock` | Lock file for GC operations |
 | `MAGPIE_MAX_UPLOAD_SIZE` | (none) | Max upload size in bytes (none = unlimited) |
 | `MAGPIE_S3_BUCKET` | (none) | S3 bucket name for backups (required for sync commands) |
 | `MAGPIE_S3_PREFIX` | `""` | Optional prefix for S3 keys |

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -342,7 +342,7 @@ docker compose exec magpie magpie-ctl token revoke ci-reader
 | `MAGPIE_LOG_FORMAT` | `json` | Log format: `json` or `console` |
 | `MAGPIE_SENTRY_DSN` | (none) | Sentry DSN for error tracking |
 | `MAGPIE_OTEL_ENABLED` | `false` | Enable OpenTelemetry tracing |
-| `MAGPIE_OTEL_ENDPOINT` | (none) | OTEL collector endpoint |
+| `MAGPIE_OTEL_ENDPOINT` | (none) | OTEL collector endpoint (required when `MAGPIE_OTEL_ENABLED=true`) |
 | `MAGPIE_OTEL_SERVICE_NAME` | `magpie` | Service name for OTEL traces |
 | `MAGPIE_ALLOWED_CIDRS` | `""` | Comma-separated CIDR ranges for IP-based auth bypass (consumed by Caddy) |
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -355,10 +355,10 @@ docker compose exec magpie magpie-ctl token revoke ci-reader
 |----------|---------|-------------|
 | `MAGPIE_DOMAIN` | (none) | Domain name for Caddy TLS (required in production with Caddyfile.prod, consumed by Caddy not Python server) |
 
-For production, configure Caddy for automatic TLS:
+For production, configure Caddy for automatic TLS in `Caddyfile.prod`:
 
 ```caddyfile
-# Caddyfile
+# Caddyfile.prod
 {$MAGPIE_DOMAIN} {
     # Routes configured automatically
     import /etc/caddy/magpie-routes

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -359,7 +359,7 @@ For production, configure Caddy for automatic TLS:
 
 ```caddyfile
 # Caddyfile
-magpie.example.com {
+{$MAGPIE_DOMAIN} {
     # Routes configured automatically
     import /etc/caddy/magpie-routes
 }

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -332,10 +332,21 @@ docker compose exec magpie magpie-ctl token revoke ci-reader
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `MAGPIE_STORAGE_PATH` | `/data/artifacts` | Root directory for artifact storage |
+| `MAGPIE_TEMP_PATH` | `{storage_path}/.tmp` | Temporary upload directory (derived from storage_path) |
+| `MAGPIE_DATABASE_PATH` | `{storage_path}/.magpie.db` | SQLite token database path (derived from storage_path) |
 | `MAGPIE_RETENTION_DAYS` | `90` | Days before untagged blobs can be GC'd |
 | `MAGPIE_DEBUG` | `false` | Enable debug logging |
+| `MAGPIE_GC_LOCK_PATH` | `/var/run/magpie-gc.lock` | Lock file for GC operations |
+| `MAGPIE_MAX_UPLOAD_SIZE` | (none) | Max upload size in bytes (none = unlimited) |
+| `MAGPIE_S3_BUCKET` | (none) | S3 bucket name for backups (required for sync commands) |
+| `MAGPIE_S3_PREFIX` | `""` | Optional prefix for S3 keys |
+| `MAGPIE_LOG_FORMAT` | `json` | Log format: `json` or `console` |
 | `MAGPIE_SENTRY_DSN` | (none) | Sentry DSN for error tracking |
 | `MAGPIE_OTEL_ENABLED` | `false` | Enable OpenTelemetry tracing |
+| `MAGPIE_OTEL_ENDPOINT` | (none) | OTEL collector endpoint |
+| `MAGPIE_OTEL_SERVICE_NAME` | `magpie` | Service name for OTEL traces |
+| `MAGPIE_ALLOWED_CIDRS` | `""` | Comma-separated CIDR ranges for IP-based auth bypass (consumed by Caddy) |
+| `MAGPIE_DOMAIN` | (required) | Domain name for Caddy TLS (required in production, Caddyfile.prod only) |
 
 ### TLS Configuration
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -332,8 +332,8 @@ docker compose exec magpie magpie-ctl token revoke ci-reader
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `MAGPIE_STORAGE_PATH` | `/data/artifacts` | Root directory for artifact storage |
-| `MAGPIE_TEMP_PATH` | `{storage_path}/.tmp` | Temporary upload directory (derived from storage_path) |
-| `MAGPIE_DATABASE_PATH` | `{storage_path}/.magpie.db` | SQLite token database path (derived from storage_path) |
+| `MAGPIE_TEMP_PATH` | `/data/artifacts/.tmp` | Temporary upload directory (defaults under `MAGPIE_STORAGE_PATH`, derived if storage path is overridden) |
+| `MAGPIE_DATABASE_PATH` | `/data/artifacts/.magpie.db` | SQLite token database path (defaults under `MAGPIE_STORAGE_PATH`, derived if storage path is overridden) |
 | `MAGPIE_RETENTION_DAYS` | `90` | Days before untagged blobs can be GC'd |
 | `MAGPIE_DEBUG` | `false` | Enable debug logging |
 | `MAGPIE_GC_LOCK_PATH` | `/var/run/magpie-gc.lock` | Lock file for GC operations |
@@ -346,9 +346,14 @@ docker compose exec magpie magpie-ctl token revoke ci-reader
 | `MAGPIE_OTEL_ENDPOINT` | (none) | OTEL collector endpoint |
 | `MAGPIE_OTEL_SERVICE_NAME` | `magpie` | Service name for OTEL traces |
 | `MAGPIE_ALLOWED_CIDRS` | `""` | Comma-separated CIDR ranges for IP-based auth bypass (consumed by Caddy) |
-| `MAGPIE_DOMAIN` | (required) | Domain name for Caddy TLS (required in production, Caddyfile.prod only) |
 
 ### TLS Configuration
+
+**Caddy Environment Variables:**
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MAGPIE_DOMAIN` | (none) | Domain name for Caddy TLS (required in production with Caddyfile.prod, consumed by Caddy not Python server) |
 
 For production, configure Caddy for automatic TLS:
 


### PR DESCRIPTION
## Summary

Addresses #250 by documenting all missing environment variables in the Server Environment Variables table.

Changes:
- Added 9 missing server-side environment variables to docs/user-guide.md
- Added 1 Caddy-specific variable (MAGPIE_DOMAIN)
- All variables extracted via systematic grep of source code (config.py, cli/config.py, Caddyfile*)

## Variables Added

Server-side (9 new):
- MAGPIE_TEMP_PATH (derived path for temporary uploads)
- MAGPIE_DATABASE_PATH (derived path for SQLite database)
- MAGPIE_MAX_UPLOAD_SIZE (upload size limit configuration)
- MAGPIE_S3_BUCKET (S3 backup bucket name)
- MAGPIE_S3_PREFIX (optional S3 key prefix)
- MAGPIE_LOG_FORMAT (json or console logging)
- MAGPIE_OTEL_ENDPOINT (OpenTelemetry collector)
- MAGPIE_OTEL_SERVICE_NAME (service name for traces)
- MAGPIE_ALLOWED_CIDRS (IP-based auth bypass for Caddy)

Caddy (1 new):
- MAGPIE_DOMAIN (required for production TLS)

## Test plan

- [x] Built fact inventory by searching all source files
- [x] Verified existing documentation
- [x] Added only missing variables (no removals needed)
- [x] Confirmed table formatting is consistent
- [x] All variables have default values and descriptions

Generated with Claude Code w/ Opus 4.5