### PR TITLE
fix: expose /api/v1/status endpoint in Caddyfile routing

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -35,6 +35,7 @@
 #
 # PUBLIC ROUTES (no authentication required):
 #   - GET    /api/v1/auth/validate         - Auth validation endpoint
+#   - GET    /api/v1/status                - Server status, version, storage stats
 #   - GET    /health                       - Health check
 #   - GET    /artifacts/public/*           - Public static file downloads
 #

--- a/Caddyfile
+++ b/Caddyfile
@@ -102,6 +102,11 @@
 		reverse_proxy magpie:8000
 	}
 
+	# Status endpoint - server health, version, storage stats
+	handle /api/v1/status {
+		reverse_proxy magpie:8000
+	}
+
 	# Auth validation endpoint - must be public (used by forward_auth itself)
 	handle /api/v1/auth/validate {
 		reverse_proxy magpie:8000

--- a/Caddyfile.prod
+++ b/Caddyfile.prod
@@ -76,6 +76,7 @@
 #
 # PUBLIC ROUTES (no authentication required):
 #   - GET    /api/v1/auth/validate         - Auth validation endpoint
+#   - GET    /api/v1/status                - Server status, version, storage stats
 #   - GET    /health                       - Health check
 #   - GET    /artifacts/public/*           - Public static file downloads
 #

--- a/Caddyfile.prod
+++ b/Caddyfile.prod
@@ -226,6 +226,11 @@
 		reverse_proxy magpie:8000
 	}
 
+	# Status endpoint - server health, version, storage stats
+	handle /api/v1/status {
+		reverse_proxy magpie:8000
+	}
+
 	# Auth validation endpoint - must be public (used by forward_auth itself)
 	handle /api/v1/auth/validate {
 		reverse_proxy magpie:8000


### PR DESCRIPTION
## Summary

- Added `/api/v1/status` route handler to both `Caddyfile` and `Caddyfile.prod`
- Placed in PUBLIC ROUTES section after `/health` endpoint
- No authentication required (endpoint supports optional auth internally)

## Changes

**Caddyfile** (development):
- Added status endpoint handler at line 105-108

**Caddyfile.prod** (production):
- Added status endpoint handler at line 229-232

## Test Plan

- Verify endpoint is accessible without authentication
- Verify endpoint returns proper status response
- Verify CI passes with updated Caddyfile configuration

Fixes #291

(AI-generated via Claude Code w/ Opus 4.5)