### PR TITLE
fix(deploy): add localhost range to trusted proxies

### DIFF
--- a/scripts/magpie-deploy.sh
+++ b/scripts/magpie-deploy.sh
@@ -30,7 +30,7 @@ DEFAULT_INSTALL_DIR="/opt/magpie"
 DEFAULT_TLS_MODE="off"
 DEFAULT_HTTP_PORT="8080"
 DEFAULT_HTTPS_PORT="8443"
-DEFAULT_TRUSTED_PROXIES="10.0.0.0/8 172.16.0.0/12 192.168.0.0/16"
+DEFAULT_TRUSTED_PROXIES="127.0.0.0/8 10.0.0.0/8 172.16.0.0/12 192.168.0.0/16"
 
 # =============================================================================
 # Global variables (populated during config)


### PR DESCRIPTION
## Summary

- Add 127.0.0.0/8 to DEFAULT_TRUSTED_PROXIES in scripts/magpie-deploy.sh
- Allows local reverse proxies (like Caddy on localhost) to properly set X-Forwarded-For headers

## Changes

Changed line 33 in `scripts/magpie-deploy.sh` to include the localhost range:

```bash
DEFAULT_TRUSTED_PROXIES="127.0.0.0/8 10.0.0.0/8 172.16.0.0/12 192.168.0.0/16"
```

## Test plan

- Verify deployment script syntax is correct
- Verify CI checks pass

Closes #297

Generated with Claude Code (Sonnet 4.5)