### PR TITLE
feat(api): require admin authentication for /api/v1/status endpoint

### DIFF
--- a/src/magpie/cli/commands/status.py
+++ b/src/magpie/cli/commands/status.py
@@ -22,10 +22,10 @@ from magpie.utils.formatting import format_size
 @click.command()
 @click.pass_obj
 def status(ctx: CLIContext) -> None:
-    """Check server health, connectivity, and status.
+    """Check server health, connectivity, and status (admin only).
 
-    Displays server connection information, authentication status,
-    and storage statistics.
+    Displays server connection information and storage statistics.
+    Requires an admin token.
 
     Examples:
 
@@ -73,7 +73,6 @@ def status(ctx: CLIContext) -> None:
                     "server": ctx.server,
                     "status": data["status"],
                     "version": data["version"],
-                    "auth": data["auth"],
                     "storage": data["storage"],
                 },
                 human_output="",
@@ -85,18 +84,6 @@ def status(ctx: CLIContext) -> None:
     click.echo(f"Server:    {ctx.server}")
     click.echo(f"Status:    {data['status'].upper()}")
     click.echo(f"Version:   {data['version']}")
-
-    # Auth status
-    auth = data["auth"]
-    if auth["valid"]:
-        scope = auth.get("scope", "unknown")
-        name = auth.get("name", "unknown")
-        click.echo(f"Auth:      Token valid ({scope} scope, name: {name})")
-    else:
-        if ctx.token:
-            click.echo("Auth:      Token invalid or expired")
-        else:
-            click.echo("Auth:      No token configured")
 
     # Storage stats
     storage = data["storage"]

--- a/src/magpie/cli/commands/status.py
+++ b/src/magpie/cli/commands/status.py
@@ -40,6 +40,13 @@ def status(ctx: CLIContext) -> None:
             return  # output_error never returns, but explicit for clarity
         raise click.ClickException(msg)
 
+    if not ctx.token:
+        msg = "No token configured. Use --token or set MAGPIE_TOKEN. Admin token required."
+        if is_json_output():
+            output_error(ErrorCode.CONFIG_ERROR, msg)
+            return  # output_error never returns, but explicit for clarity
+        raise click.ClickException(msg)
+
     with ctx.get_client() as client:
         if ctx.debug:
             click.echo(f"Checking status of {ctx.server}...", err=True)

--- a/src/magpie/server/routes/status.py
+++ b/src/magpie/server/routes/status.py
@@ -73,7 +73,7 @@ def _get_storage_stats(storage_service: StorageService) -> StorageStats:
 @router.get("/api/v1/status")
 async def get_status(
     storage_service: Annotated[StorageService, Depends(get_storage_service)],
-    admin: Annotated[TokenInfo, Depends(require_admin_scope)] = None,
+    admin: Annotated[TokenInfo, Depends(require_admin_scope)],
 ) -> StatusResponse:
     """Get server status including health, version, and storage stats (admin only).
 

--- a/src/magpie/server/routes/status.py
+++ b/src/magpie/server/routes/status.py
@@ -4,23 +4,15 @@ from __future__ import annotations
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, Header
+from fastapi import APIRouter, Depends
 from pydantic import BaseModel
 
 from magpie import __version__
-from magpie.auth.service import TokenService
-from magpie.server.deps import get_storage_service, get_token_service
+from magpie.auth.service import TokenInfo
+from magpie.server.deps import get_storage_service, require_admin_scope
 from magpie.storage.service import StorageService
 
 router = APIRouter()
-
-
-class AuthStatus(BaseModel):
-    """Token authentication status."""
-
-    valid: bool
-    scope: str | None = None
-    name: str | None = None
 
 
 class StorageStats(BaseModel):
@@ -36,40 +28,7 @@ class StatusResponse(BaseModel):
 
     status: str
     version: str
-    auth: AuthStatus
     storage: StorageStats
-
-
-def _get_auth_status(
-    authorization: str | None,
-    token_service: TokenService,
-) -> AuthStatus:
-    """Validate token and return auth status.
-
-    Args:
-        authorization: Authorization header value (Bearer <token>).
-        token_service: TokenService instance.
-
-    Returns:
-        AuthStatus with validation result.
-    """
-    if authorization is None:
-        return AuthStatus(valid=False)
-
-    if not authorization.startswith("Bearer "):
-        return AuthStatus(valid=False)
-
-    token = authorization[7:]  # Remove "Bearer " prefix
-    token_info = token_service.validate_token(token)
-
-    if token_info is None:
-        return AuthStatus(valid=False)
-
-    return AuthStatus(
-        valid=True,
-        scope=token_info.scope.value,
-        name=token_info.name,
-    )
 
 
 def _get_storage_stats(storage_service: StorageService) -> StorageStats:
@@ -114,34 +73,32 @@ def _get_storage_stats(storage_service: StorageService) -> StorageStats:
 @router.get("/api/v1/status")
 async def get_status(
     storage_service: Annotated[StorageService, Depends(get_storage_service)],
-    token_service: Annotated[TokenService, Depends(get_token_service)],
-    authorization: Annotated[str | None, Header()] = None,
+    admin: Annotated[TokenInfo, Depends(require_admin_scope)] = None,
 ) -> StatusResponse:
-    """Get server status including health, version, auth status, and storage stats.
+    """Get server status including health, version, and storage stats (admin only).
 
     This endpoint provides a comprehensive view of the server state:
     - Server health status (always "ok" if responding)
     - Server version
-    - Token authentication status (if Authorization header provided)
     - Storage usage statistics
 
-    The token validation is optional - if no Authorization header is provided,
-    auth status will show valid=False.
+    Requires admin authentication via Bearer token in Authorization header.
 
     Args:
         storage_service: StorageService instance.
-        token_service: TokenService instance.
-        authorization: Optional Authorization header for token validation.
+        admin: Validated admin token (injected by dependency).
 
     Returns:
         StatusResponse with server status information.
+
+    Raises:
+        HTTPException 401: If token is missing, malformed, invalid, or disabled.
+        HTTPException 403: If token doesn't have admin scope.
     """
-    auth_status = _get_auth_status(authorization, token_service)
     storage_stats = _get_storage_stats(storage_service)
 
     return StatusResponse(
         status="ok",
         version=__version__,
-        auth=auth_status,
         storage=storage_stats,
     )

--- a/src/magpie/server/routes/status.py
+++ b/src/magpie/server/routes/status.py
@@ -73,7 +73,7 @@ def _get_storage_stats(storage_service: StorageService) -> StorageStats:
 @router.get("/api/v1/status")
 async def get_status(
     storage_service: Annotated[StorageService, Depends(get_storage_service)],
-    admin: Annotated[TokenInfo, Depends(require_admin_scope)],
+    _admin: Annotated[TokenInfo, Depends(require_admin_scope)],
 ) -> StatusResponse:
     """Get server status including health, version, and storage stats (admin only).
 
@@ -86,7 +86,7 @@ async def get_status(
 
     Args:
         storage_service: StorageService instance.
-        admin: Validated admin token (injected by dependency).
+        _admin: Validated admin token (injected by dependency, unused in body).
 
     Returns:
         StatusResponse with server status information.

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -283,12 +283,13 @@ def api_client_no_auth_override(
 ) -> TestClient:
     """Create test API client without auth overrides for authentication tests.
 
-    This fixture explicitly clears all dependency overrides and only sets up
-    storage and token services, without the autouse auth bypass. Use this for
-    tests that need to verify actual authentication and authorization behavior.
+    This fixture sets up storage and token services without the autouse auth
+    bypass. Use this for tests that need to verify actual authentication and
+    authorization behavior.
+
+    The autouse override_auth_dependencies fixture will detect this fixture
+    in request.fixturenames and skip applying auth overrides.
     """
-    # Clear any auth overrides from the autouse conftest fixture
-    app.dependency_overrides.clear()
 
     def override_storage_service() -> StorageService:
         return test_storage_service
@@ -299,7 +300,9 @@ def api_client_no_auth_override(
     app.dependency_overrides[get_storage_service] = override_storage_service
     app.dependency_overrides[get_token_service] = override_token_service
     yield TestClient(app, raise_server_exceptions=False)
-    app.dependency_overrides.clear()
+    # Clean up only the overrides we added
+    app.dependency_overrides.pop(get_storage_service, None)
+    app.dependency_overrides.pop(get_token_service, None)
 
 
 # =============================================================================
@@ -390,7 +393,15 @@ def override_auth_dependencies(request):
 
     Test modules that define their own token fixtures (admin_token, read_token,
     write_token) are testing authentication behavior and are skipped.
+
+    If a test uses api_client_no_auth_override, this fixture skips applying
+    overrides to avoid fixture ordering conflicts.
     """
+    # Skip auth overrides if test is using no-auth-override fixture
+    if "api_client_no_auth_override" in request.fixturenames:
+        yield
+        return
+
     app.dependency_overrides[require_admin_scope] = _noop_require_admin_scope
     app.dependency_overrides[require_admin_scope_header] = _noop_require_admin_scope_header
     app.dependency_overrides[require_write_scope] = _noop_require_write_scope

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -196,9 +196,9 @@ def token_service(test_config: MagpieSettings) -> TokenService:
 
 
 @pytest.fixture
-def test_token_service(test_config: MagpieSettings) -> TokenService:
+def test_token_service(token_service: TokenService) -> TokenService:
     """Alias for token_service for tests using this naming convention."""
-    return TokenService(test_config)
+    return token_service
 
 
 # =============================================================================
@@ -390,9 +390,6 @@ def override_auth_dependencies(request):
     Integration tests run against the FastAPI app directly without Caddy,
     so there are no Authorization headers. This fixture disables auth
     checking for all integration tests.
-
-    Test modules that define their own token fixtures (admin_token, read_token,
-    write_token) are testing authentication behavior and are skipped.
 
     If a test uses api_client_no_auth_override, this fixture skips applying
     overrides to avoid fixture ordering conflicts.

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -27,6 +27,7 @@ from magpie.config import MagpieSettings
 from magpie.server.app import app
 from magpie.server.deps import (
     get_storage_service,
+    get_token_service,
     require_admin_scope,
     require_admin_scope_header,
     require_write_scope,
@@ -194,6 +195,12 @@ def token_service(test_config: MagpieSettings) -> TokenService:
     return TokenService(test_config)
 
 
+@pytest.fixture
+def test_token_service(test_config: MagpieSettings) -> TokenService:
+    """Alias for token_service for tests using this naming convention."""
+    return TokenService(test_config)
+
+
 # =============================================================================
 # Token Fixtures
 # =============================================================================
@@ -267,6 +274,31 @@ def api_client(test_storage_service: StorageService) -> TestClient:
 
     app.dependency_overrides[get_storage_service] = override_storage_service
     yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def api_client_no_auth_override(
+    test_storage_service: StorageService, test_token_service: TokenService
+) -> TestClient:
+    """Create test API client without auth overrides for authentication tests.
+
+    This fixture explicitly clears all dependency overrides and only sets up
+    storage and token services, without the autouse auth bypass. Use this for
+    tests that need to verify actual authentication and authorization behavior.
+    """
+    # Clear any auth overrides from the autouse conftest fixture
+    app.dependency_overrides.clear()
+
+    def override_storage_service() -> StorageService:
+        return test_storage_service
+
+    def override_token_service() -> TokenService:
+        return test_token_service
+
+    app.dependency_overrides[get_storage_service] = override_storage_service
+    app.dependency_overrides[get_token_service] = override_token_service
+    yield TestClient(app, raise_server_exceptions=False)
     app.dependency_overrides.clear()
 
 

--- a/tests/integration/test_cli_status.py
+++ b/tests/integration/test_cli_status.py
@@ -5,13 +5,18 @@ from __future__ import annotations
 import io
 import json
 from pathlib import Path
+from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 import pytest
+
+if TYPE_CHECKING:
+    import httpx
 from click.testing import CliRunner
 from fastapi.testclient import TestClient
 
 from magpie import __version__
+from magpie.auth.models import TokenScope
 from magpie.auth.service import TokenService
 from magpie.cli import cli
 from magpie.config import MagpieSettings
@@ -58,6 +63,26 @@ def api_client(
     app.dependency_overrides[get_storage_service] = override_storage_service
     app.dependency_overrides[get_token_service] = override_token_service
     yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def api_client_no_auth_override(
+    test_storage_service: StorageService, test_token_service: TokenService
+) -> TestClient:
+    """Create test API client without auth overrides for authentication tests."""
+    # Clear any auth overrides from the autouse conftest fixture
+    app.dependency_overrides.clear()
+
+    def override_storage_service() -> StorageService:
+        return test_storage_service
+
+    def override_token_service() -> TokenService:
+        return test_token_service
+
+    app.dependency_overrides[get_storage_service] = override_storage_service
+    app.dependency_overrides[get_token_service] = override_token_service
+    yield TestClient(app, raise_server_exceptions=False)
     app.dependency_overrides.clear()
 
 
@@ -160,6 +185,51 @@ class TestStatusCommand:
 
         assert result.exit_code != 0
         assert "No server configured" in result.output
+
+    def test_status_requires_token(self, cli_runner_no_config: CliRunner) -> None:
+        """Status without token configured fails with error."""
+        result = cli_runner_no_config.invoke(cli, ["--server", "http://test", "status"])
+
+        assert result.exit_code != 0
+        assert "No token configured" in result.output
+
+    def test_status_unauthorized_shows_error(
+        self,
+        cli_runner: CliRunner,
+        api_client_no_auth_override: TestClient,
+        token_service: TokenService,
+    ) -> None:
+        """Status with non-admin token shows appropriate error."""
+        read_token = token_service.create_token("reader", TokenScope.READ)
+
+        class MockClientWithAuth:
+            def __init__(self, client: TestClient, token: str) -> None:
+                self.client = client
+                self.token = token
+
+            def get(self, url: str, **kwargs: object) -> "httpx.Response":
+                headers = kwargs.pop("headers", {})
+                headers["Authorization"] = f"Bearer {self.token}"
+                return self.client.get(url, headers=headers, **kwargs)
+
+            def __enter__(self) -> "MockClientWithAuth":
+                return self
+
+            def __exit__(self, *args: object) -> None:
+                pass
+
+        mock_client = MockClientWithAuth(api_client_no_auth_override, read_token)
+
+        with patch(PATCH_GET_CLIENT) as mock_get_client:
+            mock_get_client.return_value = mock_client
+
+            result = cli_runner.invoke(
+                cli,
+                ["--server", "http://test", "--token", read_token, "status"],
+            )
+
+        assert result.exit_code != 0
+        assert "403" in result.output or "Admin" in result.output or "Forbidden" in result.output
 
     def test_status_json_output(self, cli_runner: CliRunner, api_client: TestClient) -> None:
         """Status command outputs valid JSON when --format json is used."""

--- a/tests/integration/test_cli_status.py
+++ b/tests/integration/test_cli_status.py
@@ -4,11 +4,8 @@ from __future__ import annotations
 
 import io
 import json
-from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest.mock import patch
-
-import pytest
 
 if TYPE_CHECKING:
     import httpx
@@ -19,71 +16,9 @@ from magpie import __version__
 from magpie.auth.models import TokenScope
 from magpie.auth.service import TokenService
 from magpie.cli import cli
-from magpie.config import MagpieSettings
-from magpie.server.app import app
-from magpie.server.deps import get_storage_service, get_token_service
-from magpie.storage.service import StorageService
 
 # Patch path for get_client - must match where it's imported/used in the CLI module
 PATCH_GET_CLIENT = "magpie.cli.get_client"
-
-
-@pytest.fixture
-def test_config(tmp_path: Path) -> MagpieSettings:
-    """Create test configuration with temporary paths."""
-    config = MagpieSettings(storage_path=tmp_path)
-    config.temp_path.mkdir(parents=True, exist_ok=True)
-    return config
-
-
-@pytest.fixture
-def test_storage_service(test_config: MagpieSettings) -> StorageService:
-    """Create a StorageService instance for testing."""
-    return StorageService(test_config)
-
-
-@pytest.fixture
-def test_token_service(test_config: MagpieSettings) -> TokenService:
-    """Create a TokenService instance for testing."""
-    return TokenService(test_config)
-
-
-@pytest.fixture
-def api_client(
-    test_storage_service: StorageService, test_token_service: TokenService
-) -> TestClient:
-    """Create test API client with overridden dependencies."""
-
-    def override_storage_service() -> StorageService:
-        return test_storage_service
-
-    def override_token_service() -> TokenService:
-        return test_token_service
-
-    app.dependency_overrides[get_storage_service] = override_storage_service
-    app.dependency_overrides[get_token_service] = override_token_service
-    yield TestClient(app)
-    app.dependency_overrides.clear()
-
-
-@pytest.fixture
-def api_client_no_auth_override(
-    test_storage_service: StorageService, test_token_service: TokenService
-) -> TestClient:
-    """Create test API client without auth overrides for authentication tests."""
-    # Clear any auth overrides from the autouse conftest fixture
-    app.dependency_overrides.clear()
-
-    def override_storage_service() -> StorageService:
-        return test_storage_service
-
-    def override_token_service() -> TokenService:
-        return test_token_service
-
-    app.dependency_overrides[get_storage_service] = override_storage_service
-    app.dependency_overrides[get_token_service] = override_token_service
-    yield TestClient(app, raise_server_exceptions=False)
-    app.dependency_overrides.clear()
 
 
 def upload_test_artifact(

--- a/tests/integration/test_cli_status.py
+++ b/tests/integration/test_cli_status.py
@@ -229,7 +229,7 @@ class TestStatusCommand:
             )
 
         assert result.exit_code != 0
-        assert "403" in result.output or "Admin" in result.output or "Forbidden" in result.output
+        assert "Admin scope required" in result.output
 
     def test_status_json_output(self, cli_runner: CliRunner, api_client: TestClient) -> None:
         """Status command outputs valid JSON when --format json is used."""

--- a/tests/integration/test_cli_status.py
+++ b/tests/integration/test_cli_status.py
@@ -108,7 +108,7 @@ class TestStatusCommand:
 
             result = cli_runner.invoke(
                 cli,
-                ["--server", "http://test.example.com", "status"],
+                ["--server", "http://test.example.com", "--token", "dummy-token", "status"],
             )
 
         assert result.exit_code == 0, f"Output: {result.output}"
@@ -122,7 +122,7 @@ class TestStatusCommand:
 
             result = cli_runner.invoke(
                 cli,
-                ["--server", "http://test", "status"],
+                ["--server", "http://test", "--token", "dummy-token", "status"],
             )
 
         assert result.exit_code == 0
@@ -136,7 +136,7 @@ class TestStatusCommand:
 
             result = cli_runner.invoke(
                 cli,
-                ["--server", "http://test", "status"],
+                ["--server", "http://test", "--token", "dummy-token", "status"],
             )
 
         assert result.exit_code == 0
@@ -152,7 +152,7 @@ class TestStatusCommand:
 
             result = cli_runner.invoke(
                 cli,
-                ["--server", "http://test", "status"],
+                ["--server", "http://test", "--token", "dummy-token", "status"],
             )
 
         assert result.exit_code == 0
@@ -173,7 +173,7 @@ class TestStatusCommand:
 
             result = cli_runner.invoke(
                 cli,
-                ["--server", "http://test", "status"],
+                ["--server", "http://test", "--token", "dummy-token", "status"],
             )
 
         assert result.exit_code == 0
@@ -238,7 +238,7 @@ class TestStatusCommand:
 
             result = cli_runner.invoke(
                 cli,
-                ["--server", "http://test", "--format", "json", "status"],
+                ["--server", "http://test", "--token", "dummy-token", "--format", "json", "status"],
             )
 
         assert result.exit_code == 0, f"Output: {result.output}"
@@ -261,7 +261,7 @@ class TestStatusCommand:
 
             result = cli_runner.invoke(
                 cli,
-                ["--server", "http://test", "--format", "json", "status"],
+                ["--server", "http://test", "--token", "dummy-token", "--format", "json", "status"],
             )
 
         assert result.exit_code == 0
@@ -284,7 +284,7 @@ class TestStatusFormatSize:
 
             result = cli_runner.invoke(
                 cli,
-                ["--server", "http://test", "status"],
+                ["--server", "http://test", "--token", "dummy-token", "status"],
             )
 
         assert result.exit_code == 0

--- a/tests/integration/test_cli_status.py
+++ b/tests/integration/test_cli_status.py
@@ -118,22 +118,6 @@ class TestStatusCommand:
         assert "Version:" in result.output
         assert __version__ in result.output
 
-    def test_status_shows_auth_no_token(
-        self, cli_runner_no_config: CliRunner, api_client: TestClient
-    ) -> None:
-        """Status command shows no token configured when token is missing."""
-        with patch(PATCH_GET_CLIENT) as mock_get_client:
-            mock_get_client.return_value = api_client
-
-            result = cli_runner_no_config.invoke(
-                cli,
-                ["--server", "http://test", "status"],
-            )
-
-        assert result.exit_code == 0
-        assert "Auth:" in result.output
-        assert "No token configured" in result.output
-
     def test_status_shows_storage_stats(
         self, cli_runner: CliRunner, api_client: TestClient
     ) -> None:
@@ -194,7 +178,6 @@ class TestStatusCommand:
         assert data["data"]["server"] == "http://test"
         assert data["data"]["status"] == "ok"
         assert data["data"]["version"] == __version__
-        assert "auth" in data["data"]
         assert "storage" in data["data"]
 
     def test_status_json_includes_storage_stats(

--- a/tests/integration/test_status_endpoint.py
+++ b/tests/integration/test_status_endpoint.py
@@ -9,7 +9,6 @@ import pytest
 from fastapi.testclient import TestClient
 
 from magpie import __version__
-from magpie.auth.models import TokenScope
 from magpie.auth.service import TokenService
 from magpie.config import MagpieSettings
 from magpie.server.app import app
@@ -56,7 +55,11 @@ def api_client(
 
 
 class TestStatusEndpoint:
-    """Tests for GET /api/v1/status endpoint."""
+    """Tests for GET /api/v1/status endpoint.
+
+    Note: Authentication is mocked via autouse fixture in conftest.py.
+    These tests verify endpoint logic, not authentication behavior.
+    """
 
     def test_status_returns_ok(self, api_client: TestClient) -> None:
         """Status endpoint returns ok status."""
@@ -74,60 +77,6 @@ class TestStatusEndpoint:
         data = response.json()
         assert "version" in data
         assert data["version"] == __version__
-
-    def test_status_returns_auth_info_without_token(self, api_client: TestClient) -> None:
-        """Status endpoint returns auth info showing no valid token."""
-        response = api_client.get("/api/v1/status")
-
-        assert response.status_code == 200
-        data = response.json()
-        assert "auth" in data
-        assert data["auth"]["valid"] is False
-
-    def test_status_returns_auth_info_with_valid_token(
-        self, api_client: TestClient, test_token_service: TokenService
-    ) -> None:
-        """Status endpoint validates token and returns scope and name when valid."""
-        token = test_token_service.create_token("test-status-token", TokenScope.READ)
-
-        response = api_client.get(
-            "/api/v1/status",
-            headers={"Authorization": f"Bearer {token}"},
-        )
-
-        assert response.status_code == 200
-        data = response.json()
-        assert data["auth"]["valid"] is True
-        assert data["auth"]["scope"] == "read"
-        assert data["auth"]["name"] == "test-status-token"
-
-    def test_status_returns_auth_info_with_admin_token(
-        self, api_client: TestClient, test_token_service: TokenService
-    ) -> None:
-        """Status endpoint correctly identifies admin scope tokens."""
-        token = test_token_service.create_token("admin-token", TokenScope.ADMIN)
-
-        response = api_client.get(
-            "/api/v1/status",
-            headers={"Authorization": f"Bearer {token}"},
-        )
-
-        assert response.status_code == 200
-        data = response.json()
-        assert data["auth"]["valid"] is True
-        assert data["auth"]["scope"] == "admin"
-        assert data["auth"]["name"] == "admin-token"
-
-    def test_status_returns_invalid_for_bad_token(self, api_client: TestClient) -> None:
-        """Status endpoint returns invalid for malformed or unknown tokens."""
-        response = api_client.get(
-            "/api/v1/status",
-            headers={"Authorization": "Bearer invalid_token_12345"},
-        )
-
-        assert response.status_code == 200
-        data = response.json()
-        assert data["auth"]["valid"] is False
 
     def test_status_returns_storage_stats(self, api_client: TestClient) -> None:
         """Status endpoint returns storage statistics."""

--- a/tests/integration/test_status_endpoint.py
+++ b/tests/integration/test_status_endpoint.py
@@ -54,6 +54,73 @@ def api_client(
     app.dependency_overrides.clear()
 
 
+@pytest.fixture
+def api_client_no_auth_override(
+    test_storage_service: StorageService, test_token_service: TokenService
+) -> TestClient:
+    """Create test API client without auth overrides for authentication tests."""
+    # Clear any auth overrides from the autouse conftest fixture
+    app.dependency_overrides.clear()
+
+    def override_storage_service() -> StorageService:
+        return test_storage_service
+
+    def override_token_service() -> TokenService:
+        return test_token_service
+
+    app.dependency_overrides[get_storage_service] = override_storage_service
+    app.dependency_overrides[get_token_service] = override_token_service
+    yield TestClient(app, raise_server_exceptions=False)
+    app.dependency_overrides.clear()
+
+
+class TestStatusEndpointAuth:
+    """Tests for status endpoint authentication and authorization."""
+
+    def test_status_requires_admin_token(
+        self, api_client_no_auth_override: TestClient, admin_token: str
+    ) -> None:
+        """Status endpoint requires admin token."""
+        response = api_client_no_auth_override.get(
+            "/api/v1/status",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "ok"
+
+    def test_status_with_read_token_returns_403(
+        self, api_client_no_auth_override: TestClient, read_token: str
+    ) -> None:
+        """Status with read token returns 403."""
+        response = api_client_no_auth_override.get(
+            "/api/v1/status",
+            headers={"Authorization": f"Bearer {read_token}"},
+        )
+
+        assert response.status_code == 403
+        assert "Admin scope required" in response.json()["detail"]
+
+    def test_status_with_write_token_returns_403(
+        self, api_client_no_auth_override: TestClient, write_token: str
+    ) -> None:
+        """Status with write token returns 403."""
+        response = api_client_no_auth_override.get(
+            "/api/v1/status",
+            headers={"Authorization": f"Bearer {write_token}"},
+        )
+
+        assert response.status_code == 403
+        assert "Admin scope required" in response.json()["detail"]
+
+    def test_status_without_auth_returns_401(self, api_client_no_auth_override: TestClient) -> None:
+        """Status without authorization returns 401."""
+        response = api_client_no_auth_override.get("/api/v1/status")
+
+        assert response.status_code == 401
+
+
 class TestStatusEndpoint:
     """Tests for GET /api/v1/status endpoint.
 

--- a/tests/integration/test_status_endpoint.py
+++ b/tests/integration/test_status_endpoint.py
@@ -3,75 +3,10 @@
 from __future__ import annotations
 
 import io
-from pathlib import Path
 
-import pytest
 from fastapi.testclient import TestClient
 
 from magpie import __version__
-from magpie.auth.service import TokenService
-from magpie.config import MagpieSettings
-from magpie.server.app import app
-from magpie.server.deps import get_storage_service, get_token_service
-from magpie.storage.service import StorageService
-
-
-@pytest.fixture
-def test_config(tmp_path: Path) -> MagpieSettings:
-    """Create test configuration with temporary paths."""
-    config = MagpieSettings(storage_path=tmp_path)
-    config.temp_path.mkdir(parents=True, exist_ok=True)
-    return config
-
-
-@pytest.fixture
-def test_storage_service(test_config: MagpieSettings) -> StorageService:
-    """Create a StorageService instance for testing."""
-    return StorageService(test_config)
-
-
-@pytest.fixture
-def test_token_service(test_config: MagpieSettings) -> TokenService:
-    """Create a TokenService instance for testing."""
-    return TokenService(test_config)
-
-
-@pytest.fixture
-def api_client(
-    test_storage_service: StorageService, test_token_service: TokenService
-) -> TestClient:
-    """Create test API client with overridden dependencies."""
-
-    def override_storage_service() -> StorageService:
-        return test_storage_service
-
-    def override_token_service() -> TokenService:
-        return test_token_service
-
-    app.dependency_overrides[get_storage_service] = override_storage_service
-    app.dependency_overrides[get_token_service] = override_token_service
-    yield TestClient(app)
-    app.dependency_overrides.clear()
-
-
-@pytest.fixture
-def api_client_no_auth_override(
-    test_storage_service: StorageService, test_token_service: TokenService
-) -> TestClient:
-    """Create test API client without auth overrides for authentication tests."""
-    # Clear any auth overrides from the autouse conftest fixture
-    app.dependency_overrides.clear()
-
-    def override_storage_service() -> StorageService:
-        return test_storage_service
-
-    def override_token_service() -> TokenService:
-        return test_token_service
-
-    app.dependency_overrides[get_storage_service] = override_storage_service
-    app.dependency_overrides[get_token_service] = override_token_service
-    yield TestClient(app, raise_server_exceptions=False)
-    app.dependency_overrides.clear()
 
 
 class TestStatusEndpointAuth:


### PR DESCRIPTION
## Summary

This PR implements issue #293 by making the `/api/v1/status` endpoint require admin authentication.

## Changes

- Changed `/api/v1/status` endpoint to require admin scope authentication
- Applied `require_admin_scope` dependency to enforce authentication
- Removed `AuthStatus` model and related auth validation logic from endpoint
- Updated CLI status command to reflect admin-only requirement
- Updated integration tests to work with autouse auth mocking fixture

## Testing

- All unit tests pass
- All integration tests pass
- Linting and formatting checks pass

## Related

Closes #293

---

AI-generated via Claude Code w/ Sonnet 4.5