### PR TITLE
fix(security): Enforce authentication before path resolution

### DIFF
--- a/src/magpie/server/deps.py
+++ b/src/magpie/server/deps.py
@@ -122,6 +122,49 @@ def require_admin_scope_header(
         )
 
 
+def require_authentication() -> None:
+    """Dependency that requires authentication via Caddy forward_auth.
+
+    Checks for the presence of the X-Magpie-Scope header, which is set by
+    Caddy's forward_auth middleware after successful token validation. If
+    the header is missing, it means the request bypassed authentication
+    (e.g., from an IP not in MAGPIE_ALLOWED_CIDRS when forward_auth is
+    conditionally applied, or the auth failed).
+
+    This dependency should be used on endpoints that need to ensure
+    authentication happens BEFORE any path resolution or business logic,
+    preventing information disclosure through different response codes
+    (401 vs 404).
+
+    Raises:
+        HTTPException 401: If X-Magpie-Scope header is missing (unauthenticated).
+    """
+    # This function intentionally does NOT take x_magpie_scope as a parameter
+    # because we want to enforce that it must be present. FastAPI will
+    # handle extracting it via the _validate_scope_header call below.
+    # We use a private helper that will raise 401 if the header is missing.
+
+
+def require_read_scope(
+    x_magpie_scope: Annotated[str | None, Header(alias="X-Magpie-Scope")] = None,
+) -> None:
+    """Dependency that requires read, write, or admin scope from Caddy forward_auth.
+
+    Checks the X-Magpie-Scope header set by Caddy's forward_auth middleware
+    and ensures the token has at least read scope. This enforces authentication
+    BEFORE any path resolution or business logic.
+
+    Args:
+        x_magpie_scope: Scope header value from Caddy forward_auth.
+
+    Raises:
+        HTTPException 401: If X-Magpie-Scope header is missing (unauthenticated).
+        HTTPException 403: If scope value is not a valid TokenScope enum value.
+    """
+    # Validate scope header (raises 401 if missing, 403 if invalid)
+    _validate_scope_header(x_magpie_scope)
+
+
 def require_admin_scope(
     authorization: Annotated[str | None, Header()] = None,
     token_service: Annotated[TokenService, Depends(get_token_service)] = None,

--- a/src/magpie/server/deps.py
+++ b/src/magpie/server/deps.py
@@ -122,29 +122,6 @@ def require_admin_scope_header(
         )
 
 
-def require_authentication() -> None:
-    """Dependency that requires authentication via Caddy forward_auth.
-
-    Checks for the presence of the X-Magpie-Scope header, which is set by
-    Caddy's forward_auth middleware after successful token validation. If
-    the header is missing, it means the request bypassed authentication
-    (e.g., from an IP not in MAGPIE_ALLOWED_CIDRS when forward_auth is
-    conditionally applied, or the auth failed).
-
-    This dependency should be used on endpoints that need to ensure
-    authentication happens BEFORE any path resolution or business logic,
-    preventing information disclosure through different response codes
-    (401 vs 404).
-
-    Raises:
-        HTTPException 401: If X-Magpie-Scope header is missing (unauthenticated).
-    """
-    # This function intentionally does NOT take x_magpie_scope as a parameter
-    # because we want to enforce that it must be present. FastAPI will
-    # handle extracting it via the _validate_scope_header call below.
-    # We use a private helper that will raise 401 if the header is missing.
-
-
 def require_read_scope(
     x_magpie_scope: Annotated[str | None, Header(alias="X-Magpie-Scope")] = None,
 ) -> None:

--- a/src/magpie/server/routes/artifacts.py
+++ b/src/magpie/server/routes/artifacts.py
@@ -300,7 +300,7 @@ async def amend_metadata(
 @router.get("/api/v1/artifacts")
 async def list_artifact_paths(
     storage_service: Annotated[StorageService, Depends(get_storage_service)],
-    _read_scope_check: Annotated[None, Depends(require_read_scope)],
+    _read_scope_check: Annotated[None, Depends(require_read_scope)] = None,
     prefix: str = "",
 ) -> ArtifactPathsResponse:
     """List artifact paths matching a prefix.

--- a/src/magpie/server/routes/artifacts.py
+++ b/src/magpie/server/routes/artifacts.py
@@ -9,7 +9,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException, Path, Response, status
 from pydantic import BaseModel, Field, field_validator
 
-from magpie.server.deps import get_storage_service, require_write_scope
+from magpie.server.deps import get_storage_service, require_read_scope, require_write_scope
 from magpie.storage.exceptions import ArtifactNotFoundError, InvalidArtifactPathError
 from magpie.storage.paths import normalize_artifact_path
 from magpie.storage.service import StorageService
@@ -123,8 +123,12 @@ async def get_artifact_info(
     path: str,
     ref: str,
     storage_service: Annotated[StorageService, Depends(get_storage_service)],
+    _read_scope_check: Annotated[None, Depends(require_read_scope)] = None,
 ) -> ArtifactInfoResponse:
     """Get metadata for a specific artifact version.
+
+    Requires authentication (read, write, or admin scope). Unauthenticated
+    requests will receive 401 before any path resolution occurs.
 
     Resolves the ref parameter as either a tag name (e.g., "latest") or a
     hash reference (e.g., "@abc12345") and returns the artifact's metadata.
@@ -137,6 +141,7 @@ async def get_artifact_info(
         ArtifactInfoResponse with full metadata for the resolved version.
 
     Raises:
+        HTTPException 401: If X-Magpie-Scope header is missing (unauthenticated).
         ArtifactNotFoundError: If path doesn't exist or ref doesn't resolve.
             Automatically converted to HTTP 404 by error handlers.
     """
@@ -295,9 +300,13 @@ async def amend_metadata(
 @router.get("/api/v1/artifacts")
 async def list_artifact_paths(
     storage_service: Annotated[StorageService, Depends(get_storage_service)],
+    _read_scope_check: Annotated[None, Depends(require_read_scope)],
     prefix: str = "",
 ) -> ArtifactPathsResponse:
     """List artifact paths matching a prefix.
+
+    Requires authentication (read, write, or admin scope). Unauthenticated
+    requests will receive 401 before any path resolution occurs.
 
     Returns all artifact paths (directories with .magpie manifests) under
     the storage root. Useful for discovery and tab-completion.
@@ -308,6 +317,9 @@ async def list_artifact_paths(
 
     Returns:
         ArtifactPathsResponse with list of matching artifact paths.
+
+    Raises:
+        HTTPException 401: If X-Magpie-Scope header is missing (unauthenticated).
     """
     # Normalize prefix if provided (empty string is valid for listing all)
     if prefix:
@@ -324,8 +336,12 @@ async def list_artifact_paths(
 async def list_artifacts(
     path: str,
     storage_service: Annotated[StorageService, Depends(get_storage_service)],
+    _read_scope_check: Annotated[None, Depends(require_read_scope)] = None,
 ) -> ArtifactListResponse:
     """List all versions of an artifact at the specified path.
+
+    Requires authentication (read, write, or admin scope). Unauthenticated
+    requests will receive 401 before any path resolution occurs.
 
     Returns all stored versions with their tags and metadata. If the artifact
     path doesn't exist or has no uploads, returns an empty versions list.
@@ -336,6 +352,9 @@ async def list_artifacts(
     Returns:
         ArtifactListResponse with artifact path and list of versions.
         Empty versions list if path doesn't exist.
+
+    Raises:
+        HTTPException 401: If X-Magpie-Scope header is missing (unauthenticated).
     """
     path = _normalize_path(path)
     artifact_infos = storage_service.list_artifacts(path)

--- a/tests/concurrency/conftest.py
+++ b/tests/concurrency/conftest.py
@@ -13,6 +13,7 @@ from magpie.server.app import app
 from magpie.server.deps import (
     require_admin_scope,
     require_admin_scope_header,
+    require_read_scope,
     require_write_scope,
 )
 
@@ -35,6 +36,11 @@ def _noop_require_admin_scope_header() -> None:
     return None
 
 
+def _noop_require_read_scope() -> None:
+    """No-op override for require_read_scope in tests."""
+    return None
+
+
 @pytest.fixture(autouse=True)
 def override_auth_dependencies():
     """Override auth dependencies for concurrency tests.
@@ -53,11 +59,13 @@ def override_auth_dependencies():
         require_admin_scope: app.dependency_overrides.get(require_admin_scope),
         require_admin_scope_header: app.dependency_overrides.get(require_admin_scope_header),
         require_write_scope: app.dependency_overrides.get(require_write_scope),
+        require_read_scope: app.dependency_overrides.get(require_read_scope),
     }
     try:
         app.dependency_overrides[require_admin_scope] = _noop_require_admin_scope
         app.dependency_overrides[require_admin_scope_header] = _noop_require_admin_scope_header
         app.dependency_overrides[require_write_scope] = _noop_require_write_scope
+        app.dependency_overrides[require_read_scope] = _noop_require_read_scope
         yield
     finally:
         # Restore original state (remove overrides we added)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -29,6 +29,7 @@ from magpie.server.deps import (
     get_storage_service,
     require_admin_scope,
     require_admin_scope_header,
+    require_read_scope,
     require_write_scope,
 )
 from magpie.storage.service import StorageService
@@ -348,6 +349,15 @@ def _noop_require_admin_scope_header() -> None:
     return None
 
 
+def _noop_require_read_scope() -> None:
+    """No-op override for require_read_scope in tests.
+
+    Returns None as this dependency only validates scope but does not
+    return token info.
+    """
+    return None
+
+
 @pytest.fixture(autouse=True)
 def override_auth_dependencies(request):
     """Override auth dependencies for integration tests.
@@ -362,10 +372,12 @@ def override_auth_dependencies(request):
     app.dependency_overrides[require_admin_scope] = _noop_require_admin_scope
     app.dependency_overrides[require_admin_scope_header] = _noop_require_admin_scope_header
     app.dependency_overrides[require_write_scope] = _noop_require_write_scope
+    app.dependency_overrides[require_read_scope] = _noop_require_read_scope
     yield
     app.dependency_overrides.pop(require_admin_scope, None)
     app.dependency_overrides.pop(require_admin_scope_header, None)
     app.dependency_overrides.pop(require_write_scope, None)
+    app.dependency_overrides.pop(require_read_scope, None)
 
 
 # =============================================================================

--- a/tests/security/conftest.py
+++ b/tests/security/conftest.py
@@ -18,6 +18,7 @@ from magpie.server.deps import (
     get_storage_service,
     require_admin_scope,
     require_admin_scope_header,
+    require_read_scope,
     require_write_scope,
 )
 from magpie.storage.service import StorageService
@@ -37,6 +38,10 @@ def _noop_require_write_scope() -> None:
 
 def _noop_require_admin_scope_header() -> None:
     """No-op override for require_admin_scope_header in tests."""
+
+
+def _noop_require_read_scope() -> None:
+    """No-op override for require_read_scope in tests."""
 
 
 @pytest.fixture
@@ -75,6 +80,7 @@ def client(test_storage_service: StorageService) -> TestClient:
         require_admin_scope: app.dependency_overrides.get(require_admin_scope),
         require_admin_scope_header: app.dependency_overrides.get(require_admin_scope_header),
         require_write_scope: app.dependency_overrides.get(require_write_scope),
+        require_read_scope: app.dependency_overrides.get(require_read_scope),
     }
 
     def override_storage_service() -> StorageService:
@@ -84,6 +90,7 @@ def client(test_storage_service: StorageService) -> TestClient:
     app.dependency_overrides[require_admin_scope] = _noop_require_admin_scope
     app.dependency_overrides[require_admin_scope_header] = _noop_require_admin_scope_header
     app.dependency_overrides[require_write_scope] = _noop_require_write_scope
+    app.dependency_overrides[require_read_scope] = _noop_require_read_scope
     yield TestClient(app)
 
     # Restore previous state (or remove if there was none)

--- a/tests/security/test_auth_timing.py
+++ b/tests/security/test_auth_timing.py
@@ -1,0 +1,313 @@
+"""Security tests for authentication timing (issue #302).
+
+This module tests that authentication is checked BEFORE path existence,
+preventing information disclosure through timing or status code differences.
+
+The vulnerability: If path existence is checked before authentication, an
+attacker can enumerate valid artifact paths by observing different response
+codes (404 for non-existent vs 401 for existing but unauthorized).
+
+The fix: Authentication must be checked first, returning 401 for all
+unauthenticated requests regardless of whether the path exists.
+
+AI-assisted: Generated with Claude Code (Sonnet 4.5).
+"""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from magpie.config import MagpieSettings
+from magpie.server.app import app
+from magpie.server.deps import (
+    get_storage_service,
+    require_admin_scope,
+    require_admin_scope_header,
+    require_write_scope,
+)
+from magpie.storage.service import StorageService
+
+
+@pytest.fixture
+def test_config(tmp_path: Path) -> MagpieSettings:
+    """Create test configuration with temporary paths."""
+    config = MagpieSettings(storage_path=tmp_path)
+    config.temp_path.mkdir(parents=True, exist_ok=True)
+    return config
+
+
+@pytest.fixture
+def test_storage_service(test_config: MagpieSettings) -> StorageService:
+    """Create a StorageService instance for testing."""
+    return StorageService(test_config)
+
+
+@pytest.fixture
+def client_with_write_auth(test_storage_service: StorageService) -> TestClient:
+    """Create test client that overrides ONLY write auth (not read auth).
+
+    This fixture allows us to test read endpoints without authentication
+    while still bypassing write auth for setup operations.
+    """
+    saved_overrides = {
+        get_storage_service: app.dependency_overrides.get(get_storage_service),
+        require_admin_scope: app.dependency_overrides.get(require_admin_scope),
+        require_admin_scope_header: app.dependency_overrides.get(require_admin_scope_header),
+        require_write_scope: app.dependency_overrides.get(require_write_scope),
+    }
+
+    def override_storage_service() -> StorageService:
+        return test_storage_service
+
+    def _noop_require_write_scope() -> None:
+        """No-op override for require_write_scope in tests."""
+
+    def _noop_require_admin_scope_header() -> None:
+        """No-op override for require_admin_scope_header in tests."""
+
+    # Override storage and write auth, but NOT read auth
+    app.dependency_overrides[get_storage_service] = override_storage_service
+    app.dependency_overrides[require_write_scope] = _noop_require_write_scope
+    app.dependency_overrides[require_admin_scope_header] = _noop_require_admin_scope_header
+
+    yield TestClient(app)
+
+    # Restore previous state
+    for dep, saved_value in saved_overrides.items():
+        if saved_value is None:
+            app.dependency_overrides.pop(dep, None)
+        else:
+            app.dependency_overrides[dep] = saved_value
+
+
+class TestAuthenticationBeforePathResolution:
+    """Test that authentication is checked before path existence.
+
+    These tests verify the fix for issue #302: all unauthenticated requests
+    to protected endpoints must return 401, regardless of whether the
+    requested path exists or not.
+    """
+
+    def test_get_artifact_info_nonexistent_path_returns_401_not_404(
+        self, client_with_write_auth: TestClient
+    ) -> None:
+        """Unauthenticated request to non-existent path returns 401, not 404.
+
+        Before the fix, this would return 404 because path existence was
+        checked before authentication, leaking information about what paths
+        exist in storage.
+        """
+        # Request info for a path that definitely doesn't exist
+        # WITHOUT X-Magpie-Scope header (unauthenticated)
+        response = client_with_write_auth.get("/api/v1/artifacts/nonexistent/path/latest/info")
+
+        # Should return 401 (unauthenticated), NOT 404 (not found)
+        assert response.status_code == 401
+        assert "authentication required" in response.text.lower()
+
+    def test_get_artifact_info_existing_path_returns_401(
+        self, client_with_write_auth: TestClient
+    ) -> None:
+        """Unauthenticated request to existing path also returns 401.
+
+        This verifies that the response is consistent regardless of path
+        existence, preventing enumeration attacks.
+        """
+        # First, create an artifact (write auth is bypassed for this setup)
+        content = b"test content for auth timing test"
+        files = {"file": ("test.bin", io.BytesIO(content), "application/octet-stream")}
+        upload_response = client_with_write_auth.post(
+            "/api/v1/upload/security/authtest",
+            files=files,
+        )
+        assert upload_response.status_code == 200
+
+        # Now request info for the path WITHOUT X-Magpie-Scope header
+        response = client_with_write_auth.get("/api/v1/artifacts/security/authtest/latest/info")
+
+        # Should return 401 (unauthenticated), same as non-existent path
+        assert response.status_code == 401
+        assert "authentication required" in response.text.lower()
+
+    def test_get_artifact_info_with_auth_returns_200_for_existing(
+        self, client_with_write_auth: TestClient
+    ) -> None:
+        """Authenticated request to existing path returns 200.
+
+        This verifies that authentication checking doesn't break normal
+        operation for authenticated requests.
+        """
+        # Create an artifact
+        content = b"test content"
+        files = {"file": ("test.bin", io.BytesIO(content), "application/octet-stream")}
+        upload_response = client_with_write_auth.post(
+            "/api/v1/upload/security/authtest2",
+            files=files,
+        )
+        assert upload_response.status_code == 200
+
+        # Request with X-Magpie-Scope header (simulating authenticated request)
+        response = client_with_write_auth.get(
+            "/api/v1/artifacts/security/authtest2/latest/info",
+            headers={"X-Magpie-Scope": "read"},
+        )
+
+        # Should return 200 (success)
+        assert response.status_code == 200
+
+    def test_get_artifact_info_with_auth_returns_404_for_nonexistent(
+        self, client_with_write_auth: TestClient
+    ) -> None:
+        """Authenticated request to non-existent path returns 404.
+
+        This verifies that 404 is returned ONLY when authenticated, not
+        for unauthenticated requests (which should get 401 first).
+        """
+        # Request non-existent path WITH X-Magpie-Scope header
+        response = client_with_write_auth.get(
+            "/api/v1/artifacts/nonexistent/path2/latest/info",
+            headers={"X-Magpie-Scope": "read"},
+        )
+
+        # Should return 404 (not found) for authenticated users
+        assert response.status_code == 404
+
+    def test_list_artifacts_nonexistent_path_returns_401_not_empty_list(
+        self, client_with_write_auth: TestClient
+    ) -> None:
+        """Unauthenticated list request returns 401, not empty list.
+
+        Before the fix, listing a non-existent path would return 200 with
+        an empty list, while listing an existing path would return different
+        content, leaking information about path existence.
+        """
+        # List a non-existent path WITHOUT authentication
+        response = client_with_write_auth.get("/api/v1/artifacts/nonexistent/listtest")
+
+        # Should return 401, not 200 with empty list
+        assert response.status_code == 401
+        assert "authentication required" in response.text.lower()
+
+    def test_list_artifacts_existing_path_returns_401(
+        self, client_with_write_auth: TestClient
+    ) -> None:
+        """Unauthenticated list request to existing path also returns 401."""
+        # Create an artifact
+        content = b"test content"
+        files = {"file": ("test.bin", io.BytesIO(content), "application/octet-stream")}
+        upload_response = client_with_write_auth.post(
+            "/api/v1/upload/security/listtest",
+            files=files,
+        )
+        assert upload_response.status_code == 200
+
+        # List WITHOUT authentication
+        response = client_with_write_auth.get("/api/v1/artifacts/security/listtest")
+
+        # Should return 401, same as non-existent path
+        assert response.status_code == 401
+        assert "authentication required" in response.text.lower()
+
+    def test_list_artifact_paths_returns_401_without_auth(
+        self, client_with_write_auth: TestClient
+    ) -> None:
+        """Unauthenticated request to list all paths returns 401.
+
+        The list endpoint could be used to enumerate all artifact paths
+        if it allowed unauthenticated access.
+        """
+        # Request to list all paths WITHOUT authentication
+        response = client_with_write_auth.get("/api/v1/artifacts")
+
+        # Should return 401
+        assert response.status_code == 401
+        assert "authentication required" in response.text.lower()
+
+    def test_list_artifact_paths_with_prefix_returns_401_without_auth(
+        self, client_with_write_auth: TestClient
+    ) -> None:
+        """Unauthenticated request to list paths with prefix returns 401."""
+        # Request with prefix WITHOUT authentication
+        response = client_with_write_auth.get(
+            "/api/v1/artifacts",
+            params={"prefix": "security"},
+        )
+
+        # Should return 401
+        assert response.status_code == 401
+        assert "authentication required" in response.text.lower()
+
+
+class TestAuthenticationConsistency:
+    """Test that authentication behavior is consistent across endpoints.
+
+    These tests verify that all read endpoints enforce authentication
+    consistently, preventing any endpoint from being an information
+    disclosure vector.
+    """
+
+    def test_all_read_endpoints_require_auth(self, client_with_write_auth: TestClient) -> None:
+        """All GET endpoints under /api/v1/artifacts require authentication.
+
+        This test verifies that every read endpoint returns 401 for
+        unauthenticated requests, preventing any path from being used
+        to enumerate artifacts.
+        """
+        read_endpoints = [
+            "/api/v1/artifacts",
+            "/api/v1/artifacts/test/path",
+            "/api/v1/artifacts/test/path/latest/info",
+        ]
+
+        for endpoint in read_endpoints:
+            response = client_with_write_auth.get(endpoint)
+            assert response.status_code == 401, (
+                f"Endpoint {endpoint} should return 401 for unauthenticated requests, "
+                f"got {response.status_code}"
+            )
+            assert "authentication required" in response.text.lower()
+
+    def test_authenticated_requests_work_normally(self, client_with_write_auth: TestClient) -> None:
+        """Authenticated requests to all endpoints work normally.
+
+        This verifies that adding authentication checks doesn't break
+        normal operation for authenticated users.
+        """
+        # Create a test artifact
+        content = b"consistency test content"
+        files = {"file": ("test.bin", io.BytesIO(content), "application/octet-stream")}
+        upload_response = client_with_write_auth.post(
+            "/api/v1/upload/security/consistency",
+            files=files,
+        )
+        assert upload_response.status_code == 200
+
+        # Test all read endpoints with authentication
+        auth_headers = {"X-Magpie-Scope": "read"}
+
+        # List all paths
+        response = client_with_write_auth.get(
+            "/api/v1/artifacts",
+            headers=auth_headers,
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert "security/consistency" in data["paths"]
+
+        # List versions
+        response = client_with_write_auth.get(
+            "/api/v1/artifacts/security/consistency",
+            headers=auth_headers,
+        )
+        assert response.status_code == 200
+
+        # Get info
+        response = client_with_write_auth.get(
+            "/api/v1/artifacts/security/consistency/latest/info",
+            headers=auth_headers,
+        )
+        assert response.status_code == 200


### PR DESCRIPTION
## Summary

Fixes #302 - Information disclosure vulnerability where path existence was checked before authentication.

## Problem

Previously, unauthenticated requests to artifact endpoints would leak information about path existence:
- Non-existent path: 404 Not Found
- Existing path: 401 Unauthorized

This allowed attackers to enumerate valid artifact paths.

## Solution

Added `require_read_scope` dependency that checks for the `X-Magpie-Scope` header (set by Caddy forward_auth) before any path resolution occurs. Applied this dependency to all GET endpoints under `/api/v1/artifacts/*`.

Now all unauthenticated requests return 401, regardless of path existence:
- Non-existent path: 401 Unauthorized
- Existing path: 401 Unauthorized

Authenticated requests work normally:
- Non-existent path: 404 Not Found  
- Existing path: 200 OK

## Changes

- Add `require_read_scope()` dependency in `src/magpie/server/deps.py`
- Apply to `get_artifact_info()`, `list_artifacts()`, and `list_artifact_paths()` endpoints
- Add comprehensive security tests in `tests/security/test_auth_timing.py`
- Update integration test fixtures to override new dependency

## Testing

- All existing tests pass (1105 tests)
- 10 new security tests verify authentication timing
- Linting and formatting clean

(AI-generated via Claude Code w/ Sonnet 4.5)