### PR TITLE
feat(cli): add token create command

### DIFF
--- a/src/magpie/cli/__init__.py
+++ b/src/magpie/cli/__init__.py
@@ -164,6 +164,7 @@ from magpie.cli.commands import (  # noqa: E402
     push,
     status,
     tag,
+    token,
     untag,
     url,
 )
@@ -174,6 +175,7 @@ cli.add_command(ls)
 cli.add_command(info)
 cli.add_command(url)
 cli.add_command(tag)
+cli.add_command(token)
 cli.add_command(untag)
 cli.add_command(flush_tag)
 cli.add_command(amend)

--- a/src/magpie/cli/commands/__init__.py
+++ b/src/magpie/cli/commands/__init__.py
@@ -11,6 +11,7 @@ from magpie.cli.commands.parse import ParseError, parse_artifact_path, parse_art
 from magpie.cli.commands.push import push
 from magpie.cli.commands.status import status
 from magpie.cli.commands.tag import tag
+from magpie.cli.commands.token import token
 from magpie.cli.commands.untag import untag
 from magpie.cli.commands.url import url
 
@@ -28,6 +29,7 @@ __all__ = [
     "push",
     "status",
     "tag",
+    "token",
     "untag",
     "url",
 ]

--- a/src/magpie/cli/commands/token.py
+++ b/src/magpie/cli/commands/token.py
@@ -1,0 +1,89 @@
+"""Token command for managing authentication tokens."""
+
+from __future__ import annotations
+
+import click
+
+from magpie.cli import CLIContext
+from magpie.cli.errors import handle_response_error
+from magpie.cli.formatting import (
+    CommandResult,
+    ErrorCode,
+    is_json_output,
+    output_error,
+    output_result,
+)
+
+
+@click.group()
+def token() -> None:
+    """Manage authentication tokens."""
+    pass
+
+
+@token.command(name="create")
+@click.option(
+    "--name", required=True, help="Token name (alphanumeric, dots, underscores, hyphens)."
+)
+@click.option(
+    "--scope",
+    type=click.Choice(["read", "write", "admin"], case_sensitive=False),
+    default="read",
+    help="Token scope (default: read).",
+)
+@click.pass_obj
+def create_token(ctx: CLIContext, name: str, scope: str) -> None:
+    """Create a new authentication token.
+
+    Requires admin scope. The plaintext token is only returned once and
+    cannot be retrieved later. Make sure to save it securely.
+
+    Examples:
+
+        magpie token create --name my-token --scope read
+
+        magpie token create --name deploy-bot --scope write
+
+        magpie token create --name admin-user --scope admin
+    """
+    if not ctx.server:
+        msg = "No server configured. Use --server or set MAGPIE_SERVER."
+        if is_json_output():
+            output_error(ErrorCode.CONFIG_ERROR, msg)
+            return  # output_error never returns, but explicit for clarity
+        raise click.ClickException(msg)
+
+    if ctx.debug:
+        click.echo(f"Creating token '{name}' with scope '{scope}'...", err=True)
+
+    with ctx.get_client() as client:
+        response = client.post(
+            "/api/v1/tokens",
+            json={"name": name, "scope": scope.lower()},
+        )
+
+        if response.status_code != 200:
+            handle_response_error(response, "Token create", ctx.token)
+
+        data = response.json()
+
+    # JSON output
+    if is_json_output():
+        output_result(
+            CommandResult(
+                data={
+                    "name": data["name"],
+                    "token": data["token"],
+                    "scope": data["scope"],
+                },
+                human_output="",  # Not used for JSON
+            )
+        )
+        return
+
+    # Human output
+    click.echo(f"Created token: {data['name']}")
+    click.echo(f"Scope: {data['scope']}")
+    click.echo()
+    click.echo("Token (save this - it will only be shown once):")
+    click.echo(f"  {data['token']}")

--- a/src/magpie/cli/commands/token.py
+++ b/src/magpie/cli/commands/token.py
@@ -53,10 +53,9 @@ def create_token(ctx: CLIContext, name: str, scope: str) -> None:
             return  # output_error never returns, but explicit for clarity
         raise click.ClickException(msg)
 
-    if ctx.debug:
-        click.echo(f"Creating token '{name}' with scope '{scope}'...", err=True)
-
     with ctx.get_client() as client:
+        if ctx.debug:
+            click.echo(f"Creating token '{name}' with scope '{scope}'...", err=True)
         response = client.post(
             "/api/v1/tokens",
             json={"name": name, "scope": scope.lower()},

--- a/tests/integration/test_cli_token.py
+++ b/tests/integration/test_cli_token.py
@@ -25,6 +25,7 @@ def api_client(token_service: TokenService) -> TestClient:
     This fixture keeps auth mocked (via require_admin_scope override) but also
     provides the token_service dependency so token creation works.
     """
+
     # Keep the auth override to mock authentication
     def _noop_require_admin_scope() -> TokenInfo:
         """No-op override for require_admin_scope in tests."""

--- a/tests/integration/test_cli_token.py
+++ b/tests/integration/test_cli_token.py
@@ -1,0 +1,256 @@
+"""Integration tests for CLI token commands."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+from fastapi.testclient import TestClient
+
+from magpie.auth.service import TokenService
+from magpie.cli import cli
+from magpie.server.app import app
+from magpie.server.deps import get_token_service, require_admin_scope
+from magpie.auth.models import TokenScope
+from magpie.auth.service import TokenInfo
+
+# Patch path for get_client - must match where it's imported/used in the CLI module
+PATCH_GET_CLIENT = "magpie.cli.get_client"
+
+
+@pytest.fixture
+def api_client(token_service: TokenService) -> TestClient:
+    """Create test client with overridden token service dependency.
+
+    This fixture keeps auth mocked (via require_admin_scope override) but also
+    provides the token_service dependency so token creation works.
+    """
+    # Keep the auth override to mock authentication
+    def _noop_require_admin_scope() -> TokenInfo:
+        """No-op override for require_admin_scope in tests."""
+        return TokenInfo(
+            name="test-token",
+            scope=TokenScope.ADMIN,
+        )
+
+    def override_token_service() -> TokenService:
+        return token_service
+
+    app.dependency_overrides[require_admin_scope] = _noop_require_admin_scope
+    app.dependency_overrides[get_token_service] = override_token_service
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+class TestTokenCreateCommand:
+    """Integration tests for token create command."""
+
+    def test_token_create_with_defaults(
+        self, cli_runner: CliRunner, api_client: TestClient
+    ) -> None:
+        """Token create with defaults creates read-scoped token."""
+        with patch(PATCH_GET_CLIENT) as mock_get_client:
+            mock_get_client.return_value = api_client
+
+            result = cli_runner.invoke(
+                cli,
+                ["--server", "http://test", "token", "create", "--name", "test-token"],
+            )
+
+        assert result.exit_code == 0, f"Output: {result.output}"
+        assert "Created token: test-token" in result.output
+        assert "Scope: read" in result.output
+        assert "mgp_" in result.output
+
+    def test_token_create_with_write_scope(
+        self, cli_runner: CliRunner, api_client: TestClient
+    ) -> None:
+        """Token create can specify write scope."""
+        with patch(PATCH_GET_CLIENT) as mock_get_client:
+            mock_get_client.return_value = api_client
+
+            result = cli_runner.invoke(
+                cli,
+                [
+                    "--server",
+                    "http://test",
+                    "token",
+                    "create",
+                    "--name",
+                    "write-token",
+                    "--scope",
+                    "write",
+                ],
+            )
+
+        assert result.exit_code == 0, f"Output: {result.output}"
+        assert "Created token: write-token" in result.output
+        assert "Scope: write" in result.output
+        assert "mgp_" in result.output
+
+    def test_token_create_with_admin_scope(
+        self, cli_runner: CliRunner, api_client: TestClient
+    ) -> None:
+        """Token create can specify admin scope."""
+        with patch(PATCH_GET_CLIENT) as mock_get_client:
+            mock_get_client.return_value = api_client
+
+            result = cli_runner.invoke(
+                cli,
+                [
+                    "--server",
+                    "http://test",
+                    "token",
+                    "create",
+                    "--name",
+                    "admin-token",
+                    "--scope",
+                    "admin",
+                ],
+            )
+
+        assert result.exit_code == 0, f"Output: {result.output}"
+        assert "Created token: admin-token" in result.output
+        assert "Scope: admin" in result.output
+        assert "mgp_" in result.output
+
+    def test_token_create_case_insensitive_scope(
+        self, cli_runner: CliRunner, api_client: TestClient
+    ) -> None:
+        """Token create accepts case-insensitive scope values."""
+        with patch(PATCH_GET_CLIENT) as mock_get_client:
+            mock_get_client.return_value = api_client
+
+            result = cli_runner.invoke(
+                cli,
+                [
+                    "--server",
+                    "http://test",
+                    "token",
+                    "create",
+                    "--name",
+                    "mixed-case",
+                    "--scope",
+                    "WRITE",
+                ],
+            )
+
+        assert result.exit_code == 0, f"Output: {result.output}"
+        assert "Created token: mixed-case" in result.output
+        assert "Scope: write" in result.output
+
+    def test_token_create_duplicate_name_fails(
+        self, cli_runner: CliRunner, api_client: TestClient
+    ) -> None:
+        """Token create fails when token name already exists."""
+        with patch(PATCH_GET_CLIENT) as mock_get_client:
+            mock_get_client.return_value = api_client
+
+            # Create first token
+            result1 = cli_runner.invoke(
+                cli,
+                ["--server", "http://test", "token", "create", "--name", "duplicate-name"],
+            )
+            assert result1.exit_code == 0
+
+            # Try to create second token with same name
+            result2 = cli_runner.invoke(
+                cli,
+                ["--server", "http://test", "token", "create", "--name", "duplicate-name"],
+            )
+
+        assert result2.exit_code != 0
+        assert "already exists" in result2.output.lower() or "duplicate" in result2.output.lower()
+
+    def test_token_create_invalid_name_fails(
+        self, cli_runner: CliRunner, api_client: TestClient
+    ) -> None:
+        """Token create fails with invalid token name."""
+        with patch(PATCH_GET_CLIENT) as mock_get_client:
+            mock_get_client.return_value = api_client
+
+            # Try names with invalid characters
+            invalid_names = [
+                "-starts-with-dash",
+                ".starts-with-dot",
+                "has spaces",
+                "has@special",
+            ]
+
+            for name in invalid_names:
+                result = cli_runner.invoke(
+                    cli,
+                    ["--server", "http://test", "token", "create", "--name", name],
+                )
+
+                assert result.exit_code != 0, f"Expected failure for name: {name}"
+
+    def test_token_create_requires_name(
+        self, cli_runner: CliRunner, api_client: TestClient
+    ) -> None:
+        """Token create requires --name option."""
+        with patch(PATCH_GET_CLIENT) as mock_get_client:
+            mock_get_client.return_value = api_client
+
+            result = cli_runner.invoke(
+                cli,
+                ["--server", "http://test", "token", "create"],
+            )
+
+        assert result.exit_code != 0
+        assert "--name" in result.output or "Missing option" in result.output
+
+    def test_token_create_requires_server(self, cli_runner_no_config: CliRunner) -> None:
+        """Token create without server configured fails with error."""
+        result = cli_runner_no_config.invoke(
+            cli,
+            ["token", "create", "--name", "test-token"],
+        )
+
+        assert result.exit_code != 0
+        assert "No server configured" in result.output
+
+    def test_token_create_shows_warning(
+        self, cli_runner: CliRunner, api_client: TestClient
+    ) -> None:
+        """Token create shows warning that token is only shown once."""
+        with patch(PATCH_GET_CLIENT) as mock_get_client:
+            mock_get_client.return_value = api_client
+
+            result = cli_runner.invoke(
+                cli,
+                ["--server", "http://test", "token", "create", "--name", "warning-test"],
+            )
+
+        assert result.exit_code == 0
+        assert "only be shown once" in result.output.lower() or "save this" in result.output.lower()
+
+    def test_token_create_json_output(self, cli_runner: CliRunner, api_client: TestClient) -> None:
+        """Token create supports JSON output format."""
+        with patch(PATCH_GET_CLIENT) as mock_get_client:
+            mock_get_client.return_value = api_client
+
+            result = cli_runner.invoke(
+                cli,
+                [
+                    "--server",
+                    "http://test",
+                    "--format",
+                    "json",
+                    "token",
+                    "create",
+                    "--name",
+                    "json-token",
+                ],
+            )
+
+        assert result.exit_code == 0
+        # Parse output as JSON and verify structure
+        import json
+
+        output = json.loads(result.output)
+        assert output["data"]["name"] == "json-token"
+        assert output["data"]["scope"] == "read"
+        assert "token" in output["data"]
+        assert output["data"]["token"].startswith("mgp_")

--- a/tests/integration/test_cli_token.py
+++ b/tests/integration/test_cli_token.py
@@ -8,12 +8,11 @@ import pytest
 from click.testing import CliRunner
 from fastapi.testclient import TestClient
 
-from magpie.auth.service import TokenService
+from magpie.auth.models import TokenScope
+from magpie.auth.service import TokenInfo, TokenService
 from magpie.cli import cli
 from magpie.server.app import app
 from magpie.server.deps import get_token_service, require_admin_scope
-from magpie.auth.models import TokenScope
-from magpie.auth.service import TokenInfo
 
 # Patch path for get_client - must match where it's imported/used in the CLI module
 PATCH_GET_CLIENT = "magpie.cli.get_client"


### PR DESCRIPTION
## Summary

Implements `magpie token create` command that creates authentication tokens via the API (not direct DB access).

## Changes

- Added new `token` command group to CLI
- Implemented `token create` subcommand with:
  - `--name` (required): Token name with validation
  - `--scope` (optional): Token scope (read/write/admin), defaults to read
  - Case-insensitive scope input
  - Clear warning that token is only shown once
  - JSON output support
- Added comprehensive integration tests (10 tests covering success paths, error handling, and edge cases)
- Properly integrated with existing CLI error handling and output formatting

## Testing

All tests pass:
- Unit tests: 820 passed
- Integration tests: 1115 passed (includes 10 new tests for token create)
- Linting: clean

## Closes

Closes #305

(AI-generated via Claude Code w/ Sonnet 4.5)