### PR TITLE
fix(caddy): require admin auth for /api/v1/status endpoint

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -28,6 +28,7 @@
 #   - POST   /api/v1/tokens                              - Create tokens (admin)
 #   - DELETE /api/v1/tokens/*                            - Revoke tokens (admin)
 #   - POST   /api/v1/gc                                  - Garbage collection (admin)
+#   - GET    /api/v1/status                              - Server status (admin)
 #   - GET    /artifacts/*                                - Static file downloads (except /artifacts/public/*)
 #
 # Note: GET routes may bypass authentication for IPs in MAGPIE_ALLOWED_CIDRS
@@ -35,7 +36,6 @@
 #
 # PUBLIC ROUTES (no authentication required):
 #   - GET    /api/v1/auth/validate         - Auth validation endpoint
-#   - GET    /api/v1/status                - Server status, version, storage stats
 #   - GET    /health                       - Health check
 #   - GET    /artifacts/public/*           - Public static file downloads
 #
@@ -100,11 +100,6 @@
 
 	# Health check endpoint - used by container orchestration
 	handle /health {
-		reverse_proxy magpie:8000
-	}
-
-	# Status endpoint - server health, version, storage stats
-	handle /api/v1/status {
 		reverse_proxy magpie:8000
 	}
 
@@ -220,6 +215,15 @@
 
 	# GC endpoint - requires admin scope
 	handle /api/v1/gc {
+		forward_auth magpie:8000 {
+			uri /api/v1/auth/validate
+			copy_headers X-Magpie-User X-Magpie-Scope
+		}
+		reverse_proxy magpie:8000
+	}
+
+	# Status endpoint - requires admin scope
+	handle /api/v1/status {
 		forward_auth magpie:8000 {
 			uri /api/v1/auth/validate
 			copy_headers X-Magpie-User X-Magpie-Scope

--- a/Caddyfile.prod
+++ b/Caddyfile.prod
@@ -69,6 +69,7 @@
 #   - POST   /api/v1/tokens                              - Create tokens (admin)
 #   - DELETE /api/v1/tokens/*                            - Revoke tokens (admin)
 #   - POST   /api/v1/gc                                  - Garbage collection (admin)
+#   - GET    /api/v1/status                              - Server status (admin)
 #   - GET    /artifacts/*                                - Static file downloads (except /artifacts/public/*)
 #
 # Note: GET routes may bypass authentication for IPs in MAGPIE_ALLOWED_CIDRS
@@ -76,7 +77,6 @@
 #
 # PUBLIC ROUTES (no authentication required):
 #   - GET    /api/v1/auth/validate         - Auth validation endpoint
-#   - GET    /api/v1/status                - Server status, version, storage stats
 #   - GET    /health                       - Health check
 #   - GET    /artifacts/public/*           - Public static file downloads
 #
@@ -227,11 +227,6 @@
 		reverse_proxy magpie:8000
 	}
 
-	# Status endpoint - server health, version, storage stats
-	handle /api/v1/status {
-		reverse_proxy magpie:8000
-	}
-
 	# Auth validation endpoint - must be public (used by forward_auth itself)
 	handle /api/v1/auth/validate {
 		reverse_proxy magpie:8000
@@ -378,6 +373,15 @@
 
 	# GC endpoint - requires admin scope
 	handle /api/v1/gc {
+		forward_auth magpie:8000 {
+			uri /api/v1/auth/validate
+			copy_headers X-Magpie-User X-Magpie-Scope
+		}
+		reverse_proxy magpie:8000
+	}
+
+	# Status endpoint - requires admin scope
+	handle /api/v1/status {
 		forward_auth magpie:8000 {
 			uri /api/v1/auth/validate
 			copy_headers X-Magpie-User X-Magpie-Scope


### PR DESCRIPTION
## Summary

Updates Caddy configuration to require admin authentication for the `/api/v1/status` endpoint, aligning with the FastAPI backend change from PR #299.

## Changes

- Move `/api/v1/status` from PUBLIC ROUTES to PROTECTED ROUTES in both `Caddyfile` and `Caddyfile.prod`
- Wrap the endpoint with `forward_auth` to enforce Bearer token validation at the proxy layer
- Update route protection summary comments to reflect the admin-only requirement

## Impact

- Defense-in-depth: Auth is now enforced at both the proxy (Caddy) and application (FastAPI) layers
- Configuration documentation now accurately reflects endpoint protection
- No functional change for users (endpoint was already admin-only at the FastAPI level)

## Testing

- [x] Configuration changes reviewed
- [x] Consistent with other admin-only endpoints (tokens, gc)
- [x] Comments updated to reflect new routing

Fixes #307

AI-generated via Claude Code w/ Sonnet 4.5