### PR TITLE
docs: create documentation index

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ magpie tag images/ubuntu:latest --as stable
 
 ## Documentation
 
+- [Documentation Index](docs/index.md) - Complete documentation overview
 - [Installation Guide](docs/installation.md) - Server deployment and client setup
 - [User Guide](docs/user-guide.md) - Complete CLI and API reference
 - [Backup and Restore Guide](docs/backup-restore.md) - Backup procedures and disaster recovery
-- [Design Document](docs/design.md) - Architecture and implementation details
 
 ## Development
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,32 @@
+# Magpie Documentation
+
+## Getting Started
+
+- [Installation Guide](installation.md) - Deploy Magpie with Docker Compose
+- [User Guide](user-guide.md) - CLI usage, artifact operations, API reference
+
+## Deployment
+
+- [Production Readiness Checklist](production-checklist.md) - Pre-deployment verification steps
+- [Backup & Restore](backup-restore.md) - Data protection procedures
+- [Monitoring](monitoring.md) - Health check endpoints and basic monitoring
+
+## Authentication
+
+- [Authentik SSO Setup](authentik-setup.md) - Configure SSO for browser access
+- [Authentik Testing Guide](authentik-testing-guide.md) - Verify SSO integration
+
+## Operations
+
+- [Structured Logging](structured-logging.md) - JSON log configuration and correlation IDs
+- [Sentry Verification](sentry-verification.md) - Error tracking integration testing
+
+## Integration
+
+- [Ansible Integration](ansible-integration.md) - Download artifacts in Ansible playbooks
+
+## Suggested Reading Order
+
+New users: Start with [Installation Guide](installation.md) → [User Guide](user-guide.md) → [Production Readiness Checklist](production-checklist.md)
+
+Operators: Review [Backup & Restore](backup-restore.md) → [Monitoring](monitoring.md) → [Structured Logging](structured-logging.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,8 +2,8 @@
 
 ## Getting Started
 
-- [Installation Guide](installation.md) - Deploy Magpie with Docker Compose
-- [User Guide](user-guide.md) - CLI usage, artifact operations, API reference
+- [Installation Guide](installation.md) - Server deployment and client setup
+- [User Guide](user-guide.md) - CLI usage, artifact operations, and API reference
 
 ## Deployment
 
@@ -27,6 +27,14 @@
 
 ## Suggested Reading Order
 
-New users: Start with [Installation Guide](installation.md) → [User Guide](user-guide.md) → [Production Readiness Checklist](production-checklist.md)
+New users: Start with [Installation Guide](installation.md) -> [User Guide](user-guide.md) -> [Production Readiness Checklist](production-checklist.md)
 
-Operators: Review [Backup & Restore](backup-restore.md) → [Monitoring](monitoring.md) → [Structured Logging](structured-logging.md)
+Operators: Review [Backup & Restore](backup-restore.md) -> [Monitoring](monitoring.md) -> [Structured Logging](structured-logging.md)
+
+## Design Documentation
+
+Comprehensive design documentation and architecture decisions are maintained in the `deployment` repository at `docs/docs/projects/active/magpie/` rather than in this repository. This follows the SWCCDC documentation consolidation pattern where cross-project design docs live in the central documentation site.
+
+---
+
+*This documentation was generated with AI assistance (Claude Code w/ Sonnet 4.5)*


### PR DESCRIPTION
## Summary

Creates `docs/index.md` with organized table of contents for all existing documentation.

## Changes

- Add documentation index with 5 categories:
  - Getting Started (installation, user guide)
  - Deployment (production checklist, backup/restore, monitoring)
  - Authentication (Authentik setup and testing)
  - Operations (logging, Sentry)
  - Integration (Ansible)
- Include suggested reading order for new users and operators
- All links verified to existing documentation files

Closes #252

(AI-generated via Claude Code w/ Sonnet 4.5)