### PR TITLE
fix: implement --no-latest flag to skip automatic latest tag on upload

### DIFF
--- a/src/magpie/server/routes/upload.py
+++ b/src/magpie/server/routes/upload.py
@@ -132,6 +132,7 @@ async def upload_artifact(
     settings: Annotated[MagpieSettings, Depends(get_magpie_settings)],
     _write_scope_check: Annotated[None, Depends(require_write_scope)] = None,
     source_uri: Annotated[str | None, Query(max_length=2048)] = None,
+    no_latest: Annotated[bool, Query()] = False,
     uploaded_by: str = "anonymous",
     x_magpie_user: Annotated[str | None, Header(alias="X-Magpie-User")] = None,
     content_length: Annotated[int | None, Header(alias="Content-Length")] = None,
@@ -153,6 +154,7 @@ async def upload_artifact(
         file: File content to upload (streamed).
         settings: Application settings for size limit configuration.
         source_uri: Optional source URI for provenance tracking.
+        no_latest: If True, skip creating/updating the "latest" tag (default: False).
         uploaded_by: Identity of the uploader (fallback, default: "anonymous").
         x_magpie_user: Authenticated user from Caddy forward_auth header.
         content_length: Content-Length header for early size validation.
@@ -216,6 +218,7 @@ async def upload_artifact(
             file_stream=file_stream,
             uploaded_by=effective_user,
             source_uri=source_uri,
+            no_latest=no_latest,
         )
     except UploadSizeExceededError as e:
         raise HTTPException(

--- a/src/magpie/storage/service.py
+++ b/src/magpie/storage/service.py
@@ -126,9 +126,6 @@ class StorageService:
             manifest = update_tag(artifact_dir, "latest", full_hash)
             # Reconcile symlinks to match manifest
             reconcile_symlinks(artifact_dir, manifest)
-        else:
-            # Still read manifest to get tags (even without adding "latest")
-            manifest = read_manifest(artifact_dir)
 
         # Build artifact info
         tags = self._get_tags_for_hash(artifact_dir, full_hash)

--- a/src/magpie/storage/service.py
+++ b/src/magpie/storage/service.py
@@ -75,14 +75,16 @@ class StorageService:
         file_stream: BinaryIO,
         uploaded_by: str,
         source_uri: str | None = None,
+        no_latest: bool = False,
     ) -> tuple[ArtifactInfo, bool]:
-        """Store an artifact with automatic tagging as 'latest'.
+        """Store an artifact with optional automatic tagging as 'latest'.
 
         Args:
             artifact_path: Logical path for the artifact (e.g., "project/component").
             file_stream: Binary stream of artifact content.
             uploaded_by: Identity of uploader.
             source_uri: Optional source URI for provenance.
+            no_latest: If True, skip creating/updating the "latest" tag (default: False).
 
         Returns:
             Tuple of (ArtifactInfo, is_duplicate):
@@ -118,12 +120,15 @@ class StorageService:
         )
         write_metadata(artifact_dir, hash_ref, metadata)
 
-        # Update manifest with "latest" tag - store full hash for verification,
-        # symlinks will extract first 8 chars for the actual blob path
-        manifest = update_tag(artifact_dir, "latest", full_hash)
-
-        # Reconcile symlinks to match manifest
-        reconcile_symlinks(artifact_dir, manifest)
+        # Conditionally update manifest with "latest" tag
+        if not no_latest:
+            # Store full hash for verification, symlinks will extract first 8 chars
+            manifest = update_tag(artifact_dir, "latest", full_hash)
+            # Reconcile symlinks to match manifest
+            reconcile_symlinks(artifact_dir, manifest)
+        else:
+            # Still read manifest to get tags (even without adding "latest")
+            manifest = read_manifest(artifact_dir)
 
         # Build artifact info
         tags = self._get_tags_for_hash(artifact_dir, full_hash)


### PR DESCRIPTION
## Summary

Implements the `--no-latest` flag functionality that was documented but not working. The CLI already sends the `no_latest=true` query parameter, but the server endpoint was ignoring it.

## Changes

- Add `no_latest: bool = False` query parameter to `upload_artifact()` endpoint in `server/routes/upload.py`
- Pass `no_latest` flag through to `StorageService.store_artifact()` in `storage/service.py`
- Conditionally skip `update_tag("latest", ...)` and `reconcile_symlinks()` when `no_latest=True`
- Update docstrings to reflect optional latest tagging behavior

## Testing

All existing tests pass, including the specific tests for `--no-latest` behavior:
- `test_push_no_tagged_latest_when_no_latest_flag_used` - Verifies output doesn't show "Tagged: latest"
- `test_push_download_url_uses_hash_ref_when_no_latest` - Verifies download URL uses hash ref instead of /latest

Verified unit tests (820 passed) and integration tests all pass.

## Fixes

Closes #320

Generated with Claude Code w/ Sonnet 4.5