### PR TITLE
chore: bump version to 0.1.0-rc7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "magpie"
-version = "0.1.0-rc5"
+version = "0.1.0-rc7"
 description = "Content-addressed artifact storage with mutable tags"
 authors = [{ name = "SWCCDC Team" }]
 readme = "README.md"


### PR DESCRIPTION
## Summary

- Bump version from 0.1.0-rc5 to 0.1.0-rc7 in pyproject.toml

## Test plan

- CI checks will verify build and test suite passes with new version

Generated with [Claude Code](https://claude.com/claude-code) w/ Sonnet 4.5