### PR TITLE
chore: bump version to 0.1.0-rc8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "magpie"
-version = "0.1.0-rc7"
+version = "0.1.0-rc8"
 description = "Content-addressed artifact storage with mutable tags"
 authors = [{ name = "SWCCDC Team" }]
 readme = "README.md"


### PR DESCRIPTION
## Summary

Version bump to 0.1.0-rc8.

This release includes:
- Fix for `--no-latest` flag behavior (#329)
- Non-recursive default for `ls` command (#330)

## Test plan

- [x] Version updated in pyproject.toml
- [ ] CI passes

Generated with [Claude Code](https://claude.com/claude-code) (Sonnet 4.5)