### PR TITLE
chore: bump version to 0.1.0-rc9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "magpie"
-version = "0.1.0-rc8"
+version = "0.1.0-rc9"
 description = "Content-addressed artifact storage with mutable tags"
 authors = [{ name = "SWCCDC Team" }]
 readme = "README.md"


### PR DESCRIPTION
## Summary

Version bump to 0.1.0-rc9.

This release includes the fix for dynamic version detection in the installer script (PR #332).

## Changes

- Updated `pyproject.toml` version from `0.1.0-rc8` to `0.1.0-rc9`

Generated with [Claude Code](https://claude.com/claude-code) w/ Sonnet 4.5