### PR TITLE
chore: bump version to 0.1.0-rc10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "magpie"
-version = "0.1.0-rc9"
+version = "0.1.0-rc10"
 description = "Content-addressed artifact storage with mutable tags"
 authors = [{ name = "SWCCDC Team" }]
 readme = "README.md"


### PR DESCRIPTION
## Summary

Bump version from 0.1.0-rc9 to 0.1.0-rc10.

This release includes:
- Installer update fix (proper handling of version updates)
- ls UX fix (showing immediate children only in non-recursive mode)

## Test plan

- [x] Version updated in pyproject.toml
- [ ] CI passes

Generated with [Claude Code](https://claude.com/claude-code) (Sonnet 4.5)