### PR TITLE
fix(deploy): persist TLS_MODE to .env for update command

### DIFF
--- a/scripts/magpie-deploy.sh
+++ b/scripts/magpie-deploy.sh
@@ -420,9 +420,9 @@ MAGPIE_RETENTION_DAYS=90
 
 # TLS configuration (persisted for Caddyfile regeneration during updates)
 # See issue #344
-TLS_MODE=${TLS_MODE}
+TLS_MODE=${TLS_MODE:-}
 DOMAIN=${DOMAIN:-}
-TRUSTED_PROXIES=${TRUSTED_PROXIES}
+TRUSTED_PROXIES=${TRUSTED_PROXIES:-}
 EOF
 }
 

--- a/scripts/magpie-deploy.sh
+++ b/scripts/magpie-deploy.sh
@@ -417,6 +417,12 @@ MAGPIE_DOMAIN=${DOMAIN:-}
 MAGPIE_DEBUG=false
 MAGPIE_LOG_FORMAT=json
 MAGPIE_RETENTION_DAYS=90
+
+# TLS configuration (persisted for Caddyfile regeneration during updates)
+# See issue #344
+TLS_MODE=${TLS_MODE}
+DOMAIN=${DOMAIN:-}
+TRUSTED_PROXIES=${TRUSTED_PROXIES}
 EOF
 }
 


### PR DESCRIPTION
## Summary

- Persist `TLS_MODE`, `DOMAIN`, and `TRUSTED_PROXIES` to `.env` during installation
- Fixes `update` command failing to regenerate Caddyfile correctly due to missing TLS configuration
- The `update` command already sources `.env` before calling `generate_caddyfile()`, so once these values are persisted, updates will work correctly

## Changes

Modified `generate_env_file()` in `scripts/magpie-deploy.sh` to add:
- `TLS_MODE` - Required for Caddyfile regeneration logic
- `DOMAIN` - Required for auto/manual TLS modes
- `TRUSTED_PROXIES` - Required for HTTP-only mode with reverse proxy

## Test Plan

- [x] Bash syntax validation passes (`bash -n`)
- [x] All unit tests pass (`uv run pytest tests/unit/ -x`)
- [x] Linting passes (`uv run ruff check`)
- [x] Formatting correct (`uv run ruff format --check`)

## Manual Testing Needed

To fully verify this fix, an operator should:
1. Install magpie with TLS mode set (any mode: off, auto, or manual)
2. Verify `.env` contains `TLS_MODE`, `DOMAIN`, and `TRUSTED_PROXIES`
3. Run `magpie-deploy.sh update`
4. Verify Caddyfile is correctly regenerated (not just copied from `Caddyfile.prod`)

Closes #344

Generated with [Claude Code](https://claude.com/claude-code) (AI-generated via Claude Code w/ Sonnet 4.5)