### PR TITLE
fix(deploy): apply defaults for missing TLS_MODE and TRUSTED_PROXIES during update

### DIFF
--- a/scripts/magpie-deploy.sh
+++ b/scripts/magpie-deploy.sh
@@ -1025,6 +1025,10 @@ cmd_update() {
             set +a
         fi
 
+        # Apply defaults for vars that may be missing from old .env files (migration from pre-#345 installs)
+        TLS_MODE="${TLS_MODE:-$DEFAULT_TLS_MODE}"
+        TRUSTED_PROXIES="${TRUSTED_PROXIES:-$DEFAULT_TRUSTED_PROXIES}"
+
         # Prefer regenerating the Caddyfile to preserve TLS/trusted_proxies settings
         # If TLS_MODE is not set (because it's not in .env), this will fall back to direct copy with a warning
         if [[ -n "${TLS_MODE:-}" ]] && declare -F generate_caddyfile >/dev/null 2>&1; then

--- a/scripts/magpie-deploy.sh
+++ b/scripts/magpie-deploy.sh
@@ -1029,18 +1029,11 @@ cmd_update() {
         TLS_MODE="${TLS_MODE:-$DEFAULT_TLS_MODE}"
         TRUSTED_PROXIES="${TRUSTED_PROXIES:-$DEFAULT_TRUSTED_PROXIES}"
 
-        # Prefer regenerating the Caddyfile to preserve TLS/trusted_proxies settings
-        # If TLS_MODE is not set (because it's not in .env), this will fall back to direct copy with a warning
-        if [[ -n "${TLS_MODE:-}" ]] && declare -F generate_caddyfile >/dev/null 2>&1; then
+        # Regenerate the Caddyfile using the configured (or defaulted) TLS settings
+        if declare -F generate_caddyfile >/dev/null 2>&1; then
             generate_caddyfile
         else
-            if [[ -z "${TLS_MODE:-}" ]]; then
-                log_warn "TLS_MODE not found in environment; falling back to direct Caddyfile copy"
-                log_warn "If you customized TLS settings, you may need to reapply them manually"
-                log_warn "See issue #340 for planned improvement to persist TLS configuration"
-            else
-                log_warn "generate_caddyfile() not found; falling back to direct Caddyfile copy"
-            fi
+            log_warn "generate_caddyfile() not found; falling back to direct Caddyfile copy"
             cp "${INSTALL_DIR}/repo/Caddyfile.prod" "${INSTALL_DIR}/etc/Caddyfile"
         fi
     fi


### PR DESCRIPTION
## Summary

Fixes #347 by applying default values for `TLS_MODE` and `TRUSTED_PROXIES` during update when they are missing from the `.env` file.

## Problem

When `cmd_update()` runs on old installations that don't have `TLS_MODE` or `TRUSTED_PROXIES` in their `.env` file (pre-#345 installs), these variables remain empty and `generate_caddyfile()` produces broken output (e.g., empty `trusted_proxies` directive in the Caddyfile).

## Solution

After sourcing the `.env` file in `cmd_update()`, apply defaults for any missing values:

```bash
# Apply defaults for vars that may be missing from old .env files (migration from pre-#345 installs)
TLS_MODE="${TLS_MODE:-$DEFAULT_TLS_MODE}"
TRUSTED_PROXIES="${TRUSTED_PROXIES:-$DEFAULT_TRUSTED_PROXIES}"
```

This ensures that even old installations without these variables in their `.env` will get the correct defaults when updating, and `generate_caddyfile()` will produce valid output.

## Test Plan

- [x] All unit tests pass (832 tests)
- [x] Linting passes (ruff check)
- [x] Formatting passes (ruff format)
- [x] Manual verification: The defaults are applied after sourcing `.env` and before the `generate_caddyfile()` check

Generated with [Claude Code](https://claude.com/claude-code)