### PR TITLE
chore: bump version to 0.1.0-rc12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "magpie"
-version = "0.1.0-rc11"
+version = "0.1.0-rc12"
 description = "Content-addressed artifact storage with mutable tags"
 authors = [{ name = "SWCCDC Team" }]
 readme = "README.md"


### PR DESCRIPTION
## Summary

- Bump version from 0.1.0-rc11 to 0.1.0-rc12 in pyproject.toml

## Release Notes

This release candidate includes:
- Fix for TLS_MODE and TRUSTED_PROXIES defaults during update (#348)

Generated with Claude Code w/ Sonnet 4.5