### PR TITLE
fix(caddy): add explicit matcher to root redirect directive

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -237,7 +237,7 @@
 
 	# Redirect root to artifact browser
 	handle / {
-		redir /artifacts/ permanent
+		redir * /artifacts/ permanent
 	}
 
 	# =========================================================================

--- a/Caddyfile.prod
+++ b/Caddyfile.prod
@@ -395,7 +395,7 @@
 
 	# Redirect root to artifact browser
 	handle / {
-		redir /artifacts/ permanent
+		redir * /artifacts/ permanent
 	}
 
 	# =========================================================================


### PR DESCRIPTION
## Summary

- Fixed broken root redirect in both Caddyfile and Caddyfile.prod
- Added explicit `*` matcher to redirect directive so Caddy properly interprets `/artifacts/` as the destination instead of a path matcher

## Changes

Changed redirect syntax from:
```caddy
handle / {
    redir /artifacts/ permanent
}
```

To:
```caddy
handle / {
    redir * /artifacts/ permanent
}
```

This affects both the dev (Caddyfile) and production (Caddyfile.prod) configurations.

## Test plan

- [x] All unit tests pass (832 tests)
- [x] Linting passes (ruff check + format)
- [ ] Manual testing: verify root path redirect works in docker-compose environment

Closes #350

Generated with [Claude Code](https://claude.com/claude-code) (Sonnet 4.5)