### PR TITLE
chore: bump version to 0.1.0-rc13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "magpie"
-version = "0.1.0-rc12"
+version = "0.1.0-rc13"
 description = "Content-addressed artifact storage with mutable tags"
 authors = [{ name = "SWCCDC Team" }]
 readme = "README.md"


### PR DESCRIPTION
## Summary

Bump version from 0.1.0-rc12 to 0.1.0-rc13 in preparation for next release.

Generated with [Claude Code](https://claude.com/claude-code)