### PR TITLE
chore: bump version to 0.1.0-rc14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "magpie"
-version = "0.1.0-rc13"
+version = "0.1.0-rc14"
 description = "Content-addressed artifact storage with mutable tags"
 authors = [{ name = "SWCCDC Team" }]
 readme = "README.md"


### PR DESCRIPTION
## Summary

- Bump version from 0.1.0-rc13 to 0.1.0-rc14 in pyproject.toml

## Notes

The magpie-deploy.sh script automatically detects the version from pyproject.toml, so no changes to that file are needed.

Generated with [Claude Code](https://claude.com/claude-code)