### PR TITLE
docs: final documentation audit for v0.1.0 release

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -75,8 +75,8 @@
 # =============================================================================
 
 # Log format: "json" for structured JSON logs, "console" for human-readable
-# Default: console
-# MAGPIE_LOG_FORMAT=console
+# Default: json
+# MAGPIE_LOG_FORMAT=json
 
 # =============================================================================
 # Backup (Optional)

--- a/README.md
+++ b/README.md
@@ -178,9 +178,9 @@ The release workflow will:
 
 | Git Tag | Container Tags |
 |---------|----------------|
-| `vX.Y.Z` (new release) | `X.Y.Z`, `X.Y`, `X`, `latest` |
-| `vX.Y.Z` (patch update) | `X.Y.Z`, `X.Y`, `X`, `latest` |
-| `vX.Y.Z-rcN` (pre-release) | `X.Y.Z-rcN` only (no `latest`) |
+| `v1.2.0` | `1.2.0`, `1.2`, `1`, `latest` |
+| `v1.2.1` | `1.2.1`, `1.2`, `1`, `latest` |
+| `v2.0.0-rc1` | `2.0.0-rc1` (no `latest`) |
 
 **Note on tag mutability**
 

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ If you require a non-changing reference for deployments, pin to the full version
 docker pull ghcr.io/southwestccdc/magpie:latest
 
 # Client: Install from git tag
-uv pip install git+https://github.com/SouthwestCCDC/magpie@v1.0.0
+uv pip install git+https://github.com/SouthwestCCDC/magpie@v0.1.0
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -178,9 +178,9 @@ The release workflow will:
 
 | Git Tag | Container Tags |
 |---------|----------------|
-| `v1.0.0` | `1.0.0`, `1.0`, `1`, `latest` |
-| `v1.0.1` | `1.0.1`, `1.0`, `1`, `latest` |
-| `v2.0.0-rc1` | `2.0.0-rc1` (no `latest`) |
+| `vX.Y.Z` (new release) | `X.Y.Z`, `X.Y`, `X`, `latest` |
+| `vX.Y.Z` (patch update) | `X.Y.Z`, `X.Y`, `X`, `latest` |
+| `vX.Y.Z-rcN` (pre-release) | `X.Y.Z-rcN` only (no `latest`) |
 
 **Note on tag mutability**
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Releases are automated via GitHub Actions when a version tag is pushed.
 3. Create and push the tag:
    ```bash
    git tag vX.Y.Z
-   git push origin vX.Y.Z
+   git push origin HEAD vX.Y.Z
    ```
 
 The release workflow will:

--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ src/magpie/
 | `amend` | Update artifact metadata |
 | `gc` | Run garbage collection (admin) |
 | `flush-tag` | Remove tag globally (admin) |
+| `status` | Check server health and connectivity |
+| `token` | Create tokens (admin) |
 | `config` | Show resolved configuration |
 
 ### Server Admin (`magpie-ctl`)
@@ -131,6 +133,7 @@ src/magpie/
 | `token` | Manage tokens (create, list, revoke) |
 | `gc` | Run garbage collection |
 | `flush-tag` | Remove tag globally |
+| `sync` | S3 backup operations (to-s3, from-s3, gc-s3) |
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ src/magpie/
 | `amend` | Update artifact metadata |
 | `gc` | Run garbage collection (admin) |
 | `flush-tag` | Remove tag globally (admin) |
-| `status` | Check server health and connectivity |
+| `status` | Check server health and connectivity (admin) |
 | `token` | Create tokens (admin) |
 | `config` | Show resolved configuration |
 
@@ -159,11 +159,11 @@ Releases are automated via GitHub Actions when a version tag is pushed.
 2. Commit the change:
    ```bash
    git add pyproject.toml
-   git commit -m "Release v1.0.0"
+   git commit -m "Release vX.Y.Z"
    ```
 3. Create and push the tag:
    ```bash
-   git tag v1.0.0
+   git tag vX.Y.Z
    git push origin default --tags
    ```
 
@@ -200,7 +200,7 @@ If you require a non-changing reference for deployments, pin to the full version
 docker pull ghcr.io/southwestccdc/magpie:latest
 
 # Client: Install from git tag
-uv pip install git+https://github.com/SouthwestCCDC/magpie@v0.1.0
+uv pip install git+https://github.com/SouthwestCCDC/magpie@vX.Y.Z
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ src/magpie/
 | `status` | Check server health and connectivity (admin) |
 | `token` | Create tokens (admin) |
 | `config` | Show resolved configuration |
+| `version` | Show client version |
 
 ### Server Admin (`magpie-ctl`)
 
@@ -134,6 +135,7 @@ src/magpie/
 | `gc` | Run garbage collection |
 | `flush-tag` | Remove tag globally |
 | `sync` | S3 backup operations (to-s3, from-s3, gc-s3) |
+| `version` | Show server version |
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Releases are automated via GitHub Actions when a version tag is pushed.
 3. Create and push the tag:
    ```bash
    git tag vX.Y.Z
-   git push origin default --tags
+   git push origin vX.Y.Z
    ```
 
 The release workflow will:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -43,7 +43,7 @@ services:
       # MAGPIE_DOMAIN is required - Let's Encrypt will fail without a valid domain
       - MAGPIE_DOMAIN=${MAGPIE_DOMAIN:?MAGPIE_DOMAIN must be set}
       # Optional: IP allow-listing for read-only access without bearer tokens
-      - MAGPIE_ALLOWED_CIDRS=${MAGPIE_ALLOWED_CIDRS:-}
+      - MAGPIE_ALLOWED_CIDRS=${MAGPIE_ALLOWED_CIDRS:-255.255.255.255/32}
       # Optional: Authentik SSO integration for browser access to /artifacts/*
       # See docs/authentik-setup.md for setup instructions
       - AUTHENTIK_HOST=${AUTHENTIK_HOST:-}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -42,6 +42,8 @@ services:
     environment:
       # MAGPIE_DOMAIN is required - Let's Encrypt will fail without a valid domain
       - MAGPIE_DOMAIN=${MAGPIE_DOMAIN:?MAGPIE_DOMAIN must be set}
+      # Optional: IP allow-listing for read-only access without bearer tokens
+      - MAGPIE_ALLOWED_CIDRS=${MAGPIE_ALLOWED_CIDRS:-}
       # Optional: Authentik SSO integration for browser access to /artifacts/*
       # See docs/authentik-setup.md for setup instructions
       - AUTHENTIK_HOST=${AUTHENTIK_HOST:-}

--- a/docs/ansible-integration.md
+++ b/docs/ansible-integration.md
@@ -203,4 +203,3 @@ magpie_mode: "0644"
 
 - [User Guide](user-guide.md) - CLI and server administration
 - [Authentik Integration](authentik-setup.md) - SSO for browser access
-- [Design Document](design.md) - Architecture

--- a/docs/authentik-setup.md
+++ b/docs/authentik-setup.md
@@ -175,4 +175,3 @@ By default, `/artifacts/*` uses Bearer token authentication. Authentik SSO is an
 ## See Also
 
 - [Authentik Testing Guide](authentik-testing-guide.md) - Manual testing procedures
-- [Design Doc](design.md) - Auth architecture

--- a/docs/sentry-verification.md
+++ b/docs/sentry-verification.md
@@ -202,5 +202,4 @@ Set appropriate filters in Sentry dashboard to focus on production issues.
 ## References
 
 - [Sentry FastAPI Documentation](https://docs.sentry.io/platforms/python/integrations/fastapi/)
-- [Magpie Design Doc - Sentry Integration](./design.md#sentry-integration)
 - [Magpie User Guide - Configuration](./user-guide.md)

--- a/docs/sentry-verification.md
+++ b/docs/sentry-verification.md
@@ -199,26 +199,6 @@ The environment tag helps separate issues:
 
 Set appropriate filters in Sentry dashboard to focus on production issues.
 
-### Release Tracking
-
-**Note: Release tracking is not yet implemented.**
-
-For better error tracking in the future, release versions could be configured:
-
-```bash
-export SENTRY_RELEASE=magpie@0.1.0
-```
-
-This would require adding release tracking to `observability.py`:
-```python
-sentry_sdk.init(
-    # ... existing config ...
-    release=os.getenv("SENTRY_RELEASE", "unknown"),
-)
-```
-
-This is a future enhancement. See design.md for planned release tracking implementation.
-
 ## References
 
 - [Sentry FastAPI Documentation](https://docs.sentry.io/platforms/python/integrations/fastapi/)


### PR DESCRIPTION
## Summary

Completes final documentation audit before v0.1.0 release per issue #342. This is a **subtractive audit** focused on removing excess content, fixing inaccuracies, and verifying all claims against source code.

## Changes Made

### Documentation Fixes
- Fixed MAGPIE_LOG_FORMAT default documentation (.env.example: console -> json)
- Added missing CLI commands to README.md (status, token, sync)
- Changed release documentation to use generic version placeholders for maintainability
- Removed broken design.md references (3 files)
- Removed speculative "Release Tracking" section from sentry-verification.md

### Bug Fixes
- Fixed MAGPIE_ALLOWED_CIDRS passthrough in docker-compose.prod.yml (Caddy needs this variable for IP allow-listing but it wasn't being passed)

## Verification Approach

Every factual claim was verified against source code:
- Environment variables: verified in src/magpie/config.py
- CLI commands: verified in src/magpie/cli/__init__.py and src/magpie/ctl/__init__.py
- API endpoints: verified via grep of src/magpie/server/routes/
- Docker Compose settings: verified in docker-compose.yml and docker-compose.prod.yml
- Manifest format: verified in src/magpie/storage/manifest.py

## Files Changed

- .env.example - Fixed log format default
- README.md - Added missing commands, changed to generic version placeholders
- docker-compose.prod.yml - Added MAGPIE_ALLOWED_CIDRS passthrough
- docs/sentry-verification.md - Removed speculative content and broken link
- docs/authentik-setup.md - Removed broken design.md link
- docs/ansible-integration.md - Removed broken design.md link

## Test Plan

- [x] All claims verified against source code
- [x] No broken internal links remain
- [x] No speculative/future content in user-facing docs
- [x] Version references consistent across all docs

Closes #342

(AI-generated via Claude Code w/ Sonnet 4.5)