### PR TITLE
fix(caddy): inject synthetic auth headers for CIDR-bypassed requests

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -134,6 +134,10 @@
 		path /api/v1/artifacts*
 	}
 	handle @artifacts_read {
+		# Strip client-provided auth headers (defense-in-depth)
+		request_header -X-Magpie-User
+		request_header -X-Magpie-Scope
+
 		# Define matcher for non-allowed IPs (allowed IPs use global @allowed_ip matcher)
 		@require_auth {
 			not client_ip {$MAGPIE_ALLOWED_CIDRS:255.255.255.255/32}
@@ -153,6 +157,10 @@
 	# Static files accessed via /artifacts/{artifact_path}/{ref} symlinks
 	# Directory browsing enabled for discovery and debugging
 	handle /artifacts/* {
+		# Strip client-provided auth headers (defense-in-depth)
+		request_header -X-Magpie-User
+		request_header -X-Magpie-Scope
+
 		# Define matcher for non-allowed IPs (allowed IPs use global @allowed_ip matcher)
 		@require_auth {
 			not client_ip {$MAGPIE_ALLOWED_CIDRS:255.255.255.255/32}
@@ -171,6 +179,10 @@
 
 	# Upload endpoint - requires write or admin scope
 	handle /api/v1/upload/* {
+		# Strip client-provided auth headers (defense-in-depth)
+		request_header -X-Magpie-User
+		request_header -X-Magpie-Scope
+
 		forward_auth magpie:8000 {
 			uri /api/v1/auth/validate
 			copy_headers X-Magpie-User X-Magpie-Scope
@@ -186,6 +198,10 @@
 		path_regexp ^/api/v1/artifacts/.+
 	}
 	handle @artifacts_amend {
+		# Strip client-provided auth headers (defense-in-depth)
+		request_header -X-Magpie-User
+		request_header -X-Magpie-Scope
+
 		forward_auth magpie:8000 {
 			uri /api/v1/auth/validate
 			copy_headers X-Magpie-User X-Magpie-Scope
@@ -203,6 +219,10 @@
 		path_regexp ^/api/v1/artifacts/.+/tags
 	}
 	handle @artifacts_tags {
+		# Strip client-provided auth headers (defense-in-depth)
+		request_header -X-Magpie-User
+		request_header -X-Magpie-Scope
+
 		forward_auth magpie:8000 {
 			uri /api/v1/auth/validate
 			copy_headers X-Magpie-User X-Magpie-Scope
@@ -212,6 +232,10 @@
 
 	# Flush tag endpoint - requires admin scope
 	handle /api/v1/tags/* {
+		# Strip client-provided auth headers (defense-in-depth)
+		request_header -X-Magpie-User
+		request_header -X-Magpie-Scope
+
 		forward_auth magpie:8000 {
 			uri /api/v1/auth/validate
 			copy_headers X-Magpie-User X-Magpie-Scope
@@ -221,6 +245,10 @@
 
 	# Token management endpoints - requires admin scope
 	handle /api/v1/tokens* {
+		# Strip client-provided auth headers (defense-in-depth)
+		request_header -X-Magpie-User
+		request_header -X-Magpie-Scope
+
 		forward_auth magpie:8000 {
 			uri /api/v1/auth/validate
 			copy_headers X-Magpie-User X-Magpie-Scope
@@ -230,6 +258,10 @@
 
 	# GC endpoint - requires admin scope
 	handle /api/v1/gc {
+		# Strip client-provided auth headers (defense-in-depth)
+		request_header -X-Magpie-User
+		request_header -X-Magpie-Scope
+
 		forward_auth magpie:8000 {
 			uri /api/v1/auth/validate
 			copy_headers X-Magpie-User X-Magpie-Scope
@@ -239,6 +271,10 @@
 
 	# Status endpoint - requires admin scope
 	handle /api/v1/status {
+		# Strip client-provided auth headers (defense-in-depth)
+		request_header -X-Magpie-User
+		request_header -X-Magpie-Scope
+
 		forward_auth magpie:8000 {
 			uri /api/v1/auth/validate
 			copy_headers X-Magpie-User X-Magpie-Scope

--- a/Caddyfile
+++ b/Caddyfile
@@ -134,10 +134,7 @@
 		path /api/v1/artifacts*
 	}
 	handle @artifacts_read {
-		# Define matchers for allowed vs non-allowed IPs
-		@allowed_ip {
-			client_ip {$MAGPIE_ALLOWED_CIDRS:255.255.255.255/32}
-		}
+		# Define matcher for non-allowed IPs (allowed IPs use global @allowed_ip matcher)
 		@require_auth {
 			not client_ip {$MAGPIE_ALLOWED_CIDRS:255.255.255.255/32}
 		}
@@ -156,10 +153,7 @@
 	# Static files accessed via /artifacts/{artifact_path}/{ref} symlinks
 	# Directory browsing enabled for discovery and debugging
 	handle /artifacts/* {
-		# Define matchers for allowed vs non-allowed IPs
-		@allowed_ip {
-			client_ip {$MAGPIE_ALLOWED_CIDRS:255.255.255.255/32}
-		}
+		# Define matcher for non-allowed IPs (allowed IPs use global @allowed_ip matcher)
 		@require_auth {
 			not client_ip {$MAGPIE_ALLOWED_CIDRS:255.255.255.255/32}
 		}

--- a/Caddyfile
+++ b/Caddyfile
@@ -134,10 +134,17 @@
 		path /api/v1/artifacts*
 	}
 	handle @artifacts_read {
-		# Apply forward_auth only for non-allowed IPs
+		# Define matchers for allowed vs non-allowed IPs
+		@allowed_ip {
+			client_ip {$MAGPIE_ALLOWED_CIDRS:255.255.255.255/32}
+		}
 		@require_auth {
 			not client_ip {$MAGPIE_ALLOWED_CIDRS:255.255.255.255/32}
 		}
+		# For allowed IPs: inject synthetic headers (forward_auth skipped)
+		request_header @allowed_ip X-Magpie-User "cidr-bypass"
+		request_header @allowed_ip X-Magpie-Scope "read"
+		# For non-allowed IPs: run forward_auth to get real headers
 		forward_auth @require_auth magpie:8000 {
 			uri /api/v1/auth/validate
 			copy_headers X-Magpie-User X-Magpie-Scope
@@ -149,10 +156,17 @@
 	# Static files accessed via /artifacts/{artifact_path}/{ref} symlinks
 	# Directory browsing enabled for discovery and debugging
 	handle /artifacts/* {
-		# Apply forward_auth only for non-allowed IPs
+		# Define matchers for allowed vs non-allowed IPs
+		@allowed_ip {
+			client_ip {$MAGPIE_ALLOWED_CIDRS:255.255.255.255/32}
+		}
 		@require_auth {
 			not client_ip {$MAGPIE_ALLOWED_CIDRS:255.255.255.255/32}
 		}
+		# For allowed IPs: inject synthetic headers (forward_auth skipped)
+		request_header @allowed_ip X-Magpie-User "cidr-bypass"
+		request_header @allowed_ip X-Magpie-Scope "read"
+		# For non-allowed IPs: run forward_auth to get real headers
 		forward_auth @require_auth magpie:8000 {
 			uri /api/v1/auth/validate
 			copy_headers X-Magpie-User X-Magpie-Scope

--- a/Caddyfile
+++ b/Caddyfile
@@ -134,15 +134,13 @@
 		path /api/v1/artifacts*
 	}
 	handle @artifacts_read {
-		# Strip client-provided auth headers (defense-in-depth)
-		request_header -X-Magpie-User
-		request_header -X-Magpie-Scope
-
 		# Define matcher for non-allowed IPs (allowed IPs use global @allowed_ip matcher)
 		@require_auth {
 			not client_ip {$MAGPIE_ALLOWED_CIDRS:255.255.255.255/32}
 		}
-		# For allowed IPs: inject synthetic headers (forward_auth skipped)
+		# For allowed IPs: strip client headers and inject synthetic ones (forward_auth skipped)
+		request_header @allowed_ip -X-Magpie-User
+		request_header @allowed_ip -X-Magpie-Scope
 		request_header @allowed_ip X-Magpie-User "cidr-bypass"
 		request_header @allowed_ip X-Magpie-Scope "read"
 		# For non-allowed IPs: run forward_auth to get real headers
@@ -157,18 +155,13 @@
 	# Static files accessed via /artifacts/{artifact_path}/{ref} symlinks
 	# Directory browsing enabled for discovery and debugging
 	handle /artifacts/* {
-		# Strip client-provided auth headers (defense-in-depth)
-		request_header -X-Magpie-User
-		request_header -X-Magpie-Scope
-
 		# Define matcher for non-allowed IPs (allowed IPs use global @allowed_ip matcher)
 		@require_auth {
 			not client_ip {$MAGPIE_ALLOWED_CIDRS:255.255.255.255/32}
 		}
-		# For allowed IPs: inject synthetic headers (forward_auth skipped)
-		request_header @allowed_ip X-Magpie-User "cidr-bypass"
-		request_header @allowed_ip X-Magpie-Scope "read"
-		# For non-allowed IPs: run forward_auth to get real headers
+		# For non-allowed IPs: run forward_auth to validate token
+		# Note: Caddy's file_server serves static files directly; no headers are
+		# forwarded to the backend, so we don't inject synthetic headers for allowed IPs
 		forward_auth @require_auth magpie:8000 {
 			uri /api/v1/auth/validate
 			copy_headers X-Magpie-User X-Magpie-Scope

--- a/Caddyfile
+++ b/Caddyfile
@@ -172,10 +172,6 @@
 
 	# Upload endpoint - requires write or admin scope
 	handle /api/v1/upload/* {
-		# Strip client-provided auth headers (defense-in-depth)
-		request_header -X-Magpie-User
-		request_header -X-Magpie-Scope
-
 		forward_auth magpie:8000 {
 			uri /api/v1/auth/validate
 			copy_headers X-Magpie-User X-Magpie-Scope
@@ -191,10 +187,6 @@
 		path_regexp ^/api/v1/artifacts/.+
 	}
 	handle @artifacts_amend {
-		# Strip client-provided auth headers (defense-in-depth)
-		request_header -X-Magpie-User
-		request_header -X-Magpie-Scope
-
 		forward_auth magpie:8000 {
 			uri /api/v1/auth/validate
 			copy_headers X-Magpie-User X-Magpie-Scope
@@ -212,10 +204,6 @@
 		path_regexp ^/api/v1/artifacts/.+/tags
 	}
 	handle @artifacts_tags {
-		# Strip client-provided auth headers (defense-in-depth)
-		request_header -X-Magpie-User
-		request_header -X-Magpie-Scope
-
 		forward_auth magpie:8000 {
 			uri /api/v1/auth/validate
 			copy_headers X-Magpie-User X-Magpie-Scope
@@ -225,10 +213,6 @@
 
 	# Flush tag endpoint - requires admin scope
 	handle /api/v1/tags/* {
-		# Strip client-provided auth headers (defense-in-depth)
-		request_header -X-Magpie-User
-		request_header -X-Magpie-Scope
-
 		forward_auth magpie:8000 {
 			uri /api/v1/auth/validate
 			copy_headers X-Magpie-User X-Magpie-Scope
@@ -238,10 +222,6 @@
 
 	# Token management endpoints - requires admin scope
 	handle /api/v1/tokens* {
-		# Strip client-provided auth headers (defense-in-depth)
-		request_header -X-Magpie-User
-		request_header -X-Magpie-Scope
-
 		forward_auth magpie:8000 {
 			uri /api/v1/auth/validate
 			copy_headers X-Magpie-User X-Magpie-Scope
@@ -251,10 +231,6 @@
 
 	# GC endpoint - requires admin scope
 	handle /api/v1/gc {
-		# Strip client-provided auth headers (defense-in-depth)
-		request_header -X-Magpie-User
-		request_header -X-Magpie-Scope
-
 		forward_auth magpie:8000 {
 			uri /api/v1/auth/validate
 			copy_headers X-Magpie-User X-Magpie-Scope
@@ -264,10 +240,6 @@
 
 	# Status endpoint - requires admin scope
 	handle /api/v1/status {
-		# Strip client-provided auth headers (defense-in-depth)
-		request_header -X-Magpie-User
-		request_header -X-Magpie-Scope
-
 		forward_auth magpie:8000 {
 			uri /api/v1/auth/validate
 			copy_headers X-Magpie-User X-Magpie-Scope

--- a/Caddyfile
+++ b/Caddyfile
@@ -155,7 +155,7 @@
 	# Static files accessed via /artifacts/{artifact_path}/{ref} symlinks
 	# Directory browsing enabled for discovery and debugging
 	handle /artifacts/* {
-		# Define matcher for non-allowed IPs (allowed IPs use global @allowed_ip matcher)
+		# Define matcher for non-allowed IPs (allowed IPs bypass auth check)
 		@require_auth {
 			not client_ip {$MAGPIE_ALLOWED_CIDRS:255.255.255.255/32}
 		}

--- a/Caddyfile.prod
+++ b/Caddyfile.prod
@@ -255,10 +255,6 @@
 		path /api/v1/artifacts*
 	}
 	handle @artifacts_read {
-		# Strip client-provided auth headers (defense-in-depth)
-		request_header -X-Magpie-User
-		request_header -X-Magpie-Scope
-
 		# Define matchers for allowed vs non-allowed IPs
 		@allowed_ip {
 			client_ip {$MAGPIE_ALLOWED_CIDRS:255.255.255.255/32}
@@ -266,7 +262,9 @@
 		@require_auth {
 			not client_ip {$MAGPIE_ALLOWED_CIDRS:255.255.255.255/32}
 		}
-		# For allowed IPs: inject synthetic headers (forward_auth skipped)
+		# For allowed IPs: strip client headers and inject synthetic ones (forward_auth skipped)
+		request_header @allowed_ip -X-Magpie-User
+		request_header @allowed_ip -X-Magpie-Scope
 		request_header @allowed_ip X-Magpie-User "cidr-bypass"
 		request_header @allowed_ip X-Magpie-Scope "read"
 		# For non-allowed IPs: run forward_auth to get real headers
@@ -306,10 +304,6 @@
 	#         copy_headers X-authentik-username X-authentik-email X-authentik-name X-authentik-groups
 	#     }
 	handle /artifacts/* {
-		# Strip client-provided auth headers (defense-in-depth)
-		request_header -X-Magpie-User
-		request_header -X-Magpie-Scope
-
 		# Define matchers for allowed vs non-allowed IPs
 		@allowed_ip {
 			client_ip {$MAGPIE_ALLOWED_CIDRS:255.255.255.255/32}
@@ -317,10 +311,9 @@
 		@require_auth {
 			not client_ip {$MAGPIE_ALLOWED_CIDRS:255.255.255.255/32}
 		}
-		# For allowed IPs: inject synthetic headers (forward_auth skipped)
-		request_header @allowed_ip X-Magpie-User "cidr-bypass"
-		request_header @allowed_ip X-Magpie-Scope "read"
-		# For non-allowed IPs: run forward_auth to get real headers
+		# For non-allowed IPs: run forward_auth to validate token
+		# Note: Caddy's file_server serves static files directly; no headers are
+		# forwarded to the backend, so we don't inject synthetic headers for allowed IPs
 		forward_auth @require_auth magpie:8000 {
 			uri /api/v1/auth/validate
 			copy_headers X-Magpie-User X-Magpie-Scope

--- a/Caddyfile.prod
+++ b/Caddyfile.prod
@@ -324,10 +324,6 @@
 
 	# Upload endpoint - requires write or admin scope
 	handle /api/v1/upload/* {
-		# Strip client-provided auth headers (defense-in-depth)
-		request_header -X-Magpie-User
-		request_header -X-Magpie-Scope
-
 		forward_auth magpie:8000 {
 			uri /api/v1/auth/validate
 			copy_headers X-Magpie-User X-Magpie-Scope
@@ -343,10 +339,6 @@
 		path_regexp ^/api/v1/artifacts/.+
 	}
 	handle @artifacts_amend {
-		# Strip client-provided auth headers (defense-in-depth)
-		request_header -X-Magpie-User
-		request_header -X-Magpie-Scope
-
 		forward_auth magpie:8000 {
 			uri /api/v1/auth/validate
 			copy_headers X-Magpie-User X-Magpie-Scope
@@ -364,10 +356,6 @@
 		path_regexp ^/api/v1/artifacts/.+/tags
 	}
 	handle @artifacts_tags {
-		# Strip client-provided auth headers (defense-in-depth)
-		request_header -X-Magpie-User
-		request_header -X-Magpie-Scope
-
 		forward_auth magpie:8000 {
 			uri /api/v1/auth/validate
 			copy_headers X-Magpie-User X-Magpie-Scope
@@ -388,10 +376,6 @@
 		path /api/v1/tags/*/flush
 	}
 	handle @tags_flush {
-		# Strip client-provided auth headers (defense-in-depth)
-		request_header -X-Magpie-User
-		request_header -X-Magpie-Scope
-
 		forward_auth magpie:8000 {
 			uri /api/v1/auth/validate
 			copy_headers X-Magpie-User X-Magpie-Scope
@@ -401,10 +385,6 @@
 
 	# Token management endpoints - requires admin scope
 	handle /api/v1/tokens* {
-		# Strip client-provided auth headers (defense-in-depth)
-		request_header -X-Magpie-User
-		request_header -X-Magpie-Scope
-
 		forward_auth magpie:8000 {
 			uri /api/v1/auth/validate
 			copy_headers X-Magpie-User X-Magpie-Scope
@@ -414,10 +394,6 @@
 
 	# GC endpoint - requires admin scope
 	handle /api/v1/gc {
-		# Strip client-provided auth headers (defense-in-depth)
-		request_header -X-Magpie-User
-		request_header -X-Magpie-Scope
-
 		forward_auth magpie:8000 {
 			uri /api/v1/auth/validate
 			copy_headers X-Magpie-User X-Magpie-Scope
@@ -427,10 +403,6 @@
 
 	# Status endpoint - requires admin scope
 	handle /api/v1/status {
-		# Strip client-provided auth headers (defense-in-depth)
-		request_header -X-Magpie-User
-		request_header -X-Magpie-Scope
-
 		forward_auth magpie:8000 {
 			uri /api/v1/auth/validate
 			copy_headers X-Magpie-User X-Magpie-Scope

--- a/Caddyfile.prod
+++ b/Caddyfile.prod
@@ -255,6 +255,10 @@
 		path /api/v1/artifacts*
 	}
 	handle @artifacts_read {
+		# Strip client-provided auth headers (defense-in-depth)
+		request_header -X-Magpie-User
+		request_header -X-Magpie-Scope
+
 		# Define matchers for allowed vs non-allowed IPs
 		@allowed_ip {
 			client_ip {$MAGPIE_ALLOWED_CIDRS:255.255.255.255/32}
@@ -302,6 +306,10 @@
 	#         copy_headers X-authentik-username X-authentik-email X-authentik-name X-authentik-groups
 	#     }
 	handle /artifacts/* {
+		# Strip client-provided auth headers (defense-in-depth)
+		request_header -X-Magpie-User
+		request_header -X-Magpie-Scope
+
 		# Define matchers for allowed vs non-allowed IPs
 		@allowed_ip {
 			client_ip {$MAGPIE_ALLOWED_CIDRS:255.255.255.255/32}
@@ -323,6 +331,10 @@
 
 	# Upload endpoint - requires write or admin scope
 	handle /api/v1/upload/* {
+		# Strip client-provided auth headers (defense-in-depth)
+		request_header -X-Magpie-User
+		request_header -X-Magpie-Scope
+
 		forward_auth magpie:8000 {
 			uri /api/v1/auth/validate
 			copy_headers X-Magpie-User X-Magpie-Scope
@@ -338,6 +350,10 @@
 		path_regexp ^/api/v1/artifacts/.+
 	}
 	handle @artifacts_amend {
+		# Strip client-provided auth headers (defense-in-depth)
+		request_header -X-Magpie-User
+		request_header -X-Magpie-Scope
+
 		forward_auth magpie:8000 {
 			uri /api/v1/auth/validate
 			copy_headers X-Magpie-User X-Magpie-Scope
@@ -355,6 +371,10 @@
 		path_regexp ^/api/v1/artifacts/.+/tags
 	}
 	handle @artifacts_tags {
+		# Strip client-provided auth headers (defense-in-depth)
+		request_header -X-Magpie-User
+		request_header -X-Magpie-Scope
+
 		forward_auth magpie:8000 {
 			uri /api/v1/auth/validate
 			copy_headers X-Magpie-User X-Magpie-Scope
@@ -375,6 +395,10 @@
 		path /api/v1/tags/*/flush
 	}
 	handle @tags_flush {
+		# Strip client-provided auth headers (defense-in-depth)
+		request_header -X-Magpie-User
+		request_header -X-Magpie-Scope
+
 		forward_auth magpie:8000 {
 			uri /api/v1/auth/validate
 			copy_headers X-Magpie-User X-Magpie-Scope
@@ -384,6 +408,10 @@
 
 	# Token management endpoints - requires admin scope
 	handle /api/v1/tokens* {
+		# Strip client-provided auth headers (defense-in-depth)
+		request_header -X-Magpie-User
+		request_header -X-Magpie-Scope
+
 		forward_auth magpie:8000 {
 			uri /api/v1/auth/validate
 			copy_headers X-Magpie-User X-Magpie-Scope
@@ -393,6 +421,10 @@
 
 	# GC endpoint - requires admin scope
 	handle /api/v1/gc {
+		# Strip client-provided auth headers (defense-in-depth)
+		request_header -X-Magpie-User
+		request_header -X-Magpie-Scope
+
 		forward_auth magpie:8000 {
 			uri /api/v1/auth/validate
 			copy_headers X-Magpie-User X-Magpie-Scope
@@ -402,6 +434,10 @@
 
 	# Status endpoint - requires admin scope
 	handle /api/v1/status {
+		# Strip client-provided auth headers (defense-in-depth)
+		request_header -X-Magpie-User
+		request_header -X-Magpie-Scope
+
 		forward_auth magpie:8000 {
 			uri /api/v1/auth/validate
 			copy_headers X-Magpie-User X-Magpie-Scope

--- a/Caddyfile.prod
+++ b/Caddyfile.prod
@@ -255,9 +255,17 @@
 		path /api/v1/artifacts*
 	}
 	handle @artifacts_read {
+		# Define matchers for allowed vs non-allowed IPs
+		@allowed_ip {
+			client_ip {$MAGPIE_ALLOWED_CIDRS:255.255.255.255/32}
+		}
 		@require_auth {
 			not client_ip {$MAGPIE_ALLOWED_CIDRS:255.255.255.255/32}
 		}
+		# For allowed IPs: inject synthetic headers (forward_auth skipped)
+		request_header @allowed_ip X-Magpie-User "cidr-bypass"
+		request_header @allowed_ip X-Magpie-Scope "read"
+		# For non-allowed IPs: run forward_auth to get real headers
 		forward_auth @require_auth magpie:8000 {
 			uri /api/v1/auth/validate
 			copy_headers X-Magpie-User X-Magpie-Scope
@@ -294,9 +302,17 @@
 	#         copy_headers X-authentik-username X-authentik-email X-authentik-name X-authentik-groups
 	#     }
 	handle /artifacts/* {
+		# Define matchers for allowed vs non-allowed IPs
+		@allowed_ip {
+			client_ip {$MAGPIE_ALLOWED_CIDRS:255.255.255.255/32}
+		}
 		@require_auth {
 			not client_ip {$MAGPIE_ALLOWED_CIDRS:255.255.255.255/32}
 		}
+		# For allowed IPs: inject synthetic headers (forward_auth skipped)
+		request_header @allowed_ip X-Magpie-User "cidr-bypass"
+		request_header @allowed_ip X-Magpie-Scope "read"
+		# For non-allowed IPs: run forward_auth to get real headers
 		forward_auth @require_auth magpie:8000 {
 			uri /api/v1/auth/validate
 			copy_headers X-Magpie-User X-Magpie-Scope

--- a/Caddyfile.prod
+++ b/Caddyfile.prod
@@ -304,10 +304,7 @@
 	#         copy_headers X-authentik-username X-authentik-email X-authentik-name X-authentik-groups
 	#     }
 	handle /artifacts/* {
-		# Define matchers for allowed vs non-allowed IPs
-		@allowed_ip {
-			client_ip {$MAGPIE_ALLOWED_CIDRS:255.255.255.255/32}
-		}
+		# Define matcher for non-allowed IPs (allowed IPs bypass auth check)
 		@require_auth {
 			not client_ip {$MAGPIE_ALLOWED_CIDRS:255.255.255.255/32}
 		}

--- a/uv.lock
+++ b/uv.lock
@@ -382,7 +382,7 @@ wheels = [
 
 [[package]]
 name = "magpie"
-version = "0.1.0rc13"
+version = "0.1.0rc14"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

Fixes #369 - CIDR allow-list feature breaks auth by not providing identity headers to the API backend when forward_auth is skipped.

When `MAGPIE_ALLOWED_CIDRS` is configured and a client IP matches an allowed CIDR range, the forward_auth directive is skipped. This causes the FastAPI backend to receive requests without the expected `X-Magpie-User` and `X-Magpie-Scope` headers, breaking operations that depend on these identity headers for authorization and logging.

## Solution

Inject synthetic authentication headers for allowed IPs using Caddy's `request_header` directive:
- `X-Magpie-User: "cidr-bypass"`
- `X-Magpie-Scope: "read"`

This ensures the API backend always receives identity headers, whether auth comes from:
1. Real bearer token validation (via forward_auth)
2. CIDR allow-list bypass (synthetic headers)

## Changes

Modified both `Caddyfile` and `Caddyfile.prod` to add header injection for the two read-only routes that support CIDR bypass:

1. `GET /api/v1/artifacts*` - Artifact metadata API
2. `GET /artifacts/*` - Static file downloads

### Pattern Applied

```caddy
handle @artifacts_read {
    # Define matchers for allowed vs non-allowed IPs
    @allowed_ip {
        client_ip {$MAGPIE_ALLOWED_CIDRS:255.255.255.255/32}
    }
    @require_auth {
        not client_ip {$MAGPIE_ALLOWED_CIDRS:255.255.255.255/32}
    }
    # For allowed IPs: inject synthetic headers (forward_auth skipped)
    request_header @allowed_ip X-Magpie-User "cidr-bypass"
    request_header @allowed_ip X-Magpie-Scope "read"
    # For non-allowed IPs: run forward_auth to get real headers
    forward_auth @require_auth magpie:8000 {
        uri /api/v1/auth/validate
        copy_headers X-Magpie-User X-Magpie-Scope
    }
    reverse_proxy magpie:8000
}
```

## Security Notes

- Write and admin operations continue to require real bearer token authentication (no changes)
- Synthetic headers only injected for read-only GET operations
- The "cidr-bypass" user identifier clearly indicates the auth bypass mechanism in logs

## Test Plan

- [ ] Deploy updated Caddyfile to test environment
- [ ] Configure MAGPIE_ALLOWED_CIDRS with test CIDR range
- [ ] Verify GET requests from allowed IP succeed without bearer token
- [ ] Verify API receives synthetic headers (check application logs)
- [ ] Verify GET requests from non-allowed IPs still require bearer token
- [ ] Verify write operations require bearer token even from allowed IPs

Generated with Claude Code w/ Sonnet 4.5