### PR TITLE
chore: bump version to 0.1.0-rc15

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "magpie"
-version = "0.1.0-rc14"
+version = "0.1.0-rc15"
 description = "Content-addressed artifact storage with mutable tags"
 authors = [{ name = "SWCCDC Team" }]
 readme = "README.md"

--- a/scripts/magpie-deploy.sh
+++ b/scripts/magpie-deploy.sh
@@ -25,7 +25,7 @@ GHCR_IMAGE="ghcr.io/southwestccdc/magpie"
 MAGPIE_VERSION=""  # Dynamically detected from pyproject.toml after cloning repo
 # For --version output before repo clone, hardcode to match current pyproject.toml.
 # IMPORTANT: Update this when bumping version in pyproject.toml
-HARDCODED_VERSION="0.1.0-rc13"
+HARDCODED_VERSION="0.1.0-rc15"
 
 # Default configuration
 DEFAULT_INSTALL_DIR="/opt/magpie"


### PR DESCRIPTION
## Summary

- Bumps version from 0.1.0-rc14 to 0.1.0-rc15 in pyproject.toml

This is a routine version bump for the next release candidate.

(AI-generated via Claude Code w/ Sonnet 4.5)