### PR TITLE
Fix: Add S3 environment variables to docker-compose.yml

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -93,8 +93,10 @@
 
 # AWS credentials for S3 backup (required if using S3 sync commands)
 # Can also use IAM role or instance profile instead of explicit credentials
+# For temporary credentials (e.g., STS assume-role), also set AWS_SESSION_TOKEN
 # AWS_ACCESS_KEY_ID=
 # AWS_SECRET_ACCESS_KEY=
+# AWS_SESSION_TOKEN=
 # AWS_DEFAULT_REGION=us-east-1
 
 # =============================================================================

--- a/.env.example
+++ b/.env.example
@@ -88,6 +88,15 @@
 # S3 bucket name for artifact backup (leave empty to disable S3 backup)
 # MAGPIE_S3_BUCKET=
 
+# S3 key prefix for artifact backup (optional, e.g., "magpie/backups")
+# MAGPIE_S3_PREFIX=
+
+# AWS credentials for S3 backup (required if using S3 sync commands)
+# Can also use IAM role or instance profile instead of explicit credentials
+# AWS_ACCESS_KEY_ID=
+# AWS_SECRET_ACCESS_KEY=
+# AWS_DEFAULT_REGION=us-east-1
+
 # =============================================================================
 # Observability (Optional)
 # =============================================================================

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,11 @@ services:
       - MAGPIE_STORAGE_PATH=/data/artifacts
       - MAGPIE_DATABASE_PATH=${MAGPIE_DATABASE_PATH:-/data/magpie.db}
       - MAGPIE_DEBUG=${MAGPIE_DEBUG:-false}
+      - MAGPIE_S3_BUCKET=${MAGPIE_S3_BUCKET:-}
+      - MAGPIE_S3_PREFIX=${MAGPIE_S3_PREFIX:-}
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-}
+      - AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-}
     expose:
       - "8000"  # Internal only - accessed via Caddy
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,7 @@ services:
       - MAGPIE_S3_PREFIX=${MAGPIE_S3_PREFIX:-}
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-}
+      - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN:-}
       - AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-}
     expose:
       - "8000"  # Internal only - accessed via Caddy


### PR DESCRIPTION
## Summary

- Added S3 and AWS environment variables to magpie service in docker-compose.yml
- Updated .env.example to document S3 backup configuration options

## Problem

The installer-generated `docker-compose.yml` did not pass S3 environment variables to the magpie container, causing `magpie-ctl sync` commands to fail with "MAGPIE_S3_BUCKET environment variable is required" even when the variables were configured in `.env`.

## Solution

Added the following environment variables to the magpie service in `docker-compose.yml`:
- `MAGPIE_S3_BUCKET` - S3 bucket name for backups
- `MAGPIE_S3_PREFIX` - Optional S3 key prefix
- `AWS_ACCESS_KEY_ID` - AWS credentials
- `AWS_SECRET_ACCESS_KEY` - AWS credentials
- `AWS_DEFAULT_REGION` - AWS region
- `AWS_SESSION_TOKEN` - for STS/AssumeRole/etc.

All variables use the `${VAR:-}` syntax to pass through from `.env` with empty string defaults if not set.

Also updated `.env.example` to document the S3 and AWS configuration variables that were previously missing.

## Testing

- Ran `uv run ruff check` - all checks passed
- Ran `uv run ruff format --check` - all files formatted correctly
- Ran `uv run pytest tests/unit/ -x` - all 831 tests passed

## Files Changed

- `/home/george/swccdc/magpie-worktrees/issue-272-1769562486/docker-compose.yml` - Added 5 environment variables
- `/home/george/swccdc/magpie-worktrees/issue-272-1769562486/.env.example` - Added documentation for S3 and AWS variables

Fixes #272

(AI-generated via Claude Code w/ Sonnet 4.5)