### PR TITLE
docs: remove remaining GitHub line number anchors

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -5,7 +5,7 @@ This guide covers deploying Magpie artifact storage using Docker Compose.
 ## Prerequisites
 
 - **Docker with Compose v2.1+** (required for healthcheck conditions in `docker-compose.prod.yml`)
-- **Python 3.13+** (only if installing client CLI locally, see [pyproject.toml](../pyproject.toml#L7))
+- **Python 3.13+** (only if installing client CLI locally, see [pyproject.toml](../pyproject.toml))
 
 For production deployments with Let's Encrypt auto-TLS:
 - Public DNS record pointing to your server
@@ -43,7 +43,7 @@ export MAGPIE_DATA_DIR=./data  # Host path for persistent storage (contains arti
 docker compose -f docker-compose.prod.yml up -d
 ```
 
-**Required environment variables** (see [docker-compose.prod.yml](../docker-compose.prod.yml#L14-L15)):
+**Required environment variables** (see [docker-compose.prod.yml](../docker-compose.prod.yml)):
 - `MAGPIE_DOMAIN`: Domain name for TLS (e.g., `magpie.swccdc.com`)
 - `MAGPIE_DATA_DIR`: Host directory for data storage (default: `./data` in docker-compose.yml). This is the HOST path - can be relative (e.g., `./data`) or absolute (e.g., `/opt/magpie/data`). Inside the container, it's always mounted at `/data`. The directory will contain the `artifacts/` subdirectory and `magpie.db` database file
 


### PR DESCRIPTION
## Summary

Removes the last remaining GitHub line number anchors from documentation, completing the cleanup of brittle line number references identified in #319.

## Changes

- `installation.md`: Remove `#L7` anchor from pyproject.toml reference
- `installation.md`: Remove `#L14-L15` anchor from docker-compose.prod.yml reference

## Context

Issue #319 reported 13 documentation inaccuracies from a fact verification audit. Investigation found:

1. **Line number references**: Most inaccuracies were already fixed in the codebase (inline line numbers removed from monitoring.md, authentik-setup.md per the cleanup pattern). Only these two GitHub anchor links remained.

2. **FACT-MO-027 (systemd file claim)**: The audit claimed `deployment/systemd/magpie-gc.service` doesn't exist, but this is incorrect - the file exists at that path and is correctly referenced in `docs/monitoring.md:145`.

3. **Remaining "+ 6 more" issues**: Not specified in the issue, and all other line references have already been removed from the docs.

## Decision

Followed existing pattern (Option A from #319 recommendations): Remove line number references entirely to prevent future maintenance burden. Line numbers drift immediately when code changes.

## Testing

- Linting passes
- Format check passes
- Verified systemd file exists: `deployment/systemd/magpie-gc.service`
- Verified references still work without anchors

Addresses #319

---

Generated with AI assistance (Claude Code w/ Sonnet 4.5)