### PR TITLE
fix(ai-context): use GraphQL API for PR comment fetching

### DIFF
--- a/.ai/context/pr-comment-handling.md
+++ b/.ai/context/pr-comment-handling.md
@@ -16,11 +16,36 @@ gh auth login
 
 ## Proactive Check After Push
 
-After pushing changes to a PR, check for review comments:
+After pushing changes to a PR, check for review comments.
+
+Use GraphQL to filter out resolved and outdated comments:
 
 ```bash
-gh api repos/SouthwestCCDC/magpie/pulls/{N}/comments --jq '.[] | {id, path, line, body}' | head -20
+gh api graphql -f query='
+query {
+  repository(owner: "SouthwestCCDC", name: "magpie") {
+    pullRequest(number: {N}) {
+      reviewThreads(first: 20) {
+        nodes {
+          isResolved
+          isOutdated
+          comments(first: 10) {
+            nodes {
+              id
+              body
+              path
+              line
+              author { login }
+            }
+          }
+        }
+      }
+    }
+  }
+}' --jq '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false and .isOutdated == false) | .comments.nodes[] | {id: .id, path: .path, line: .line, body: .body}'
 ```
+
+Replace `{N}` with the PR number.
 
 ## Response Workflow
 


### PR DESCRIPTION
## Summary

- Replace REST API (`pulls/{N}/comments`) with GraphQL `reviewThreads` query
- Enables filtering by `isResolved` and `isOutdated` status
- Agents now only process active, relevant review comments

This aligns with the pattern already used in the scoring repo and should fix issues where agents were re-processing resolved comments or missing thread context.

## Test plan

- [ ] Verify GraphQL query works: run the command with a real PR number
- [ ] Confirm developer agents correctly filter comments when addressing PR feedback

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>