### PR TITLE
fix(storage): discover intermediate directories in non-recursive listing

### DIFF
--- a/src/magpie/cli/commands/ls.py
+++ b/src/magpie/cli/commands/ls.py
@@ -132,7 +132,9 @@ def _list_paths(ctx: CLIContext, client: "httpx.Client", prefix: str, recursive:
         else:
             click.echo(f"Listing artifact paths ({mode})...", err=True)
 
-    response = client.get("/api/v1/artifacts", params={"prefix": prefix, "recursive": recursive})
+    # Always fetch recursively to discover virtual directories, then filter client-side
+    # This allows non-recursive mode to show immediate children and virtual directories
+    response = client.get("/api/v1/artifacts", params={"prefix": prefix, "recursive": True})
 
     if response.status_code != 200:
         handle_response_error(response, "List", ctx.token)

--- a/src/magpie/cli/commands/ls.py
+++ b/src/magpie/cli/commands/ls.py
@@ -132,19 +132,15 @@ def _list_paths(ctx: CLIContext, client: "httpx.Client", prefix: str, recursive:
         else:
             click.echo(f"Listing artifact paths ({mode})...", err=True)
 
-    # Always fetch recursively to discover virtual directories, then filter client-side
-    # This allows non-recursive mode to show immediate children and virtual directories
-    response = client.get("/api/v1/artifacts", params={"prefix": prefix, "recursive": True})
+    # Use the requested mode - storage layer returns virtual directory indicators
+    # in non-recursive mode (paths with trailing /) to enable navigation
+    response = client.get("/api/v1/artifacts", params={"prefix": prefix, "recursive": recursive})
 
     if response.status_code != 200:
         handle_response_error(response, "List", ctx.token)
 
     data = response.json()
     paths = data.get("paths", [])
-
-    # Transform paths to immediate children for directory-style UX when not recursive
-    if not recursive:
-        paths = _extract_immediate_children(paths, prefix)
 
     # JSON output
     if is_json_output():

--- a/src/magpie/storage/service.py
+++ b/src/magpie/storage/service.py
@@ -488,9 +488,13 @@ class StorageService:
 
                       Non-recursive mode checks each immediate child of the prefix path:
                       - If it's a directory with .magpie → it's an artifact (return it)
-                      - If it's a directory without .magpie but contains artifacts deeper
-                        → return as virtual directory indicator (with trailing /)
-                      - Empty directories are not returned
+                      - If it's a directory without .magpie → return as virtual directory
+                        indicator (with trailing /)
+
+                      Note: Empty directories may appear as virtual directories. This is an
+                      intentional performance tradeoff to keep listings O(immediate_children)
+                      without deep filesystem traversal. The reconciliation job will clean up
+                      empty directories over time.
 
         Returns:
             Sorted list of artifact paths and virtual directory indicators.

--- a/src/magpie/storage/service.py
+++ b/src/magpie/storage/service.py
@@ -566,15 +566,20 @@ class StorageService:
 
                 artifact_paths.append(artifact_path)
         else:
-            # Non-recursive mode: return immediate artifacts and virtual directory indicators
+            # Non-recursive mode: return immediate children only
+            # O(immediate_children) - no recursive filesystem checks
+            # Tradeoff: may show virtual directories that don't contain artifacts,
+            # but reconciliation job can clean those up
+
             # Step 1: Check if the prefix path itself is a leaf directory (artifact)
             prefix_manifest = search_root / ".magpie"
             if prefix_manifest.is_file() and normalized_prefix:
                 # The prefix itself is an artifact, include it
                 artifact_paths.append(normalized_prefix)
-                # Continue to check for child artifacts (prefix can have nested artifacts)
+                # Since artifacts are leaf nodes, no need to check children
+                return sorted(artifact_paths)
 
-            # Step 2: Do non-recursive directory listing of immediate children
+            # Step 2: List immediate children - simple iterdir() only
             try:
                 for child in search_root.iterdir():
                     if not child.is_dir():
@@ -589,17 +594,9 @@ class StorageService:
                         # It's an artifact - return as-is
                         artifact_paths.append(child_rel_path)
                     else:
-                        # Check if it contains artifacts deeper down (virtual directory)
-                        # Use explicit next() to short-circuit and handle edge cases
-                        try:
-                            next(child.rglob(".magpie"))
-                            has_nested_artifacts = True
-                        except (StopIteration, OSError, PermissionError):
-                            has_nested_artifacts = False
-
-                        if has_nested_artifacts:
-                            # It's a virtual directory - return with trailing /
-                            artifact_paths.append(child_rel_path + "/")
+                        # It's a directory without .magpie - treat as virtual directory
+                        # No recursive checks - just show it unconditionally
+                        artifact_paths.append(child_rel_path + "/")
             except (OSError, PermissionError):
                 # Handle permission errors or other filesystem issues gracefully
                 pass

--- a/src/magpie/storage/service.py
+++ b/src/magpie/storage/service.py
@@ -484,39 +484,38 @@ class StorageService:
             prefix: Path prefix to filter by (empty string lists all).
                    Leading slashes are normalized and path traversal sequences are rejected.
             recursive: If True, list all artifacts recursively under the prefix.
-                      If False (default), list only immediate children (non-recursive).
+                      If False (default), list immediate children and virtual directories.
 
                       Non-recursive mode checks each immediate child of the prefix path:
                       - If it's a directory with .magpie → it's an artifact (return it)
-                      - If it's a directory without .magpie → it's a virtual directory prefix
-                        (not returned, but can be explored by listing with that prefix)
-
-                      This is O(immediate_children) rather than O(all_descendants).
+                      - If it's a directory without .magpie but contains artifacts deeper
+                        → return as virtual directory indicator (with trailing /)
+                      - Empty directories are not returned
 
         Returns:
-            Sorted list of artifact paths matching the prefix.
-            Returns paths that have a .magpie manifest file.
+            Sorted list of artifact paths and virtual directory indicators.
+            - Artifacts (have .magpie): returned as-is (e.g., "test/artifact1")
+            - Virtual directories (contain artifacts deeper): returned with trailing /
+              (e.g., "test/")
 
         Examples:
             With artifacts at: test/artifact1, test/artifact2, test/sub/deep,
                               images/ubuntu, other/path
 
-            list_artifact_paths("", False) -> ["images/ubuntu", "other/path",
-                                                "test/artifact1", "test/artifact2"]
+            list_artifact_paths("", False) -> ["images/", "other/", "test/"]
             list_artifact_paths("", True) -> ["images/ubuntu", "other/path",
                                                "test/artifact1", "test/artifact2",
                                                "test/sub/deep"]
-            list_artifact_paths("test", False) -> ["test/artifact1", "test/artifact2"]
+            list_artifact_paths("test", False) -> ["test/artifact1", "test/artifact2", "test/sub/"]
             list_artifact_paths("test", True) -> ["test/artifact1", "test/artifact2",
                                                    "test/sub/deep"]
+            list_artifact_paths("test/sub", False) -> ["test/sub/deep"]
 
         Note:
-            For non-recursive mode, the behavior is:
-            1. Check if the prefix path itself exists
-            2. If it's a leaf directory (has .magpie), treat as artifact and return it
-            3. Otherwise, do a non-recursive directory listing (iterdir)
-            4. For each immediate child: check if it has .magpie to determine if it's
-               an artifact or a virtual directory prefix
+            For non-recursive mode, virtual directory indicators enable navigation:
+            - Client sees "builds/" in root listing
+            - Client can then list with prefix="builds" to navigate deeper
+            This allows discovering deeply nested artifacts without full tree traversal.
         """
         # Normalize prefix for listing - allow empty result for root listing
         # Strip leading/trailing slashes and collapse multiple slashes
@@ -567,7 +566,7 @@ class StorageService:
 
                 artifact_paths.append(artifact_path)
         else:
-            # Non-recursive mode: simpler O(immediate_children) approach
+            # Non-recursive mode: return immediate artifacts and virtual directory indicators
             # Step 1: Check if the prefix path itself is a leaf directory (artifact)
             prefix_manifest = search_root / ".magpie"
             if prefix_manifest.is_file() and normalized_prefix:
@@ -580,15 +579,21 @@ class StorageService:
                     if not child.is_dir():
                         continue
 
+                    # Compute full path relative to storage_path
+                    child_rel_path = str(child.relative_to(self.config.storage_path))
+
                     # Check if this immediate child is an artifact (has .magpie)
                     child_manifest = child / ".magpie"
                     if child_manifest.is_file():
-                        # Compute full artifact path relative to storage_path
-                        artifact_path = str(child.relative_to(self.config.storage_path))
-                        artifact_paths.append(artifact_path)
-                    # If child doesn't have .magpie, it's a virtual directory prefix
-                    # (not returned, but can be explored by calling list_artifact_paths
-                    # with that path as the prefix)
+                        # It's an artifact - return as-is
+                        artifact_paths.append(child_rel_path)
+                    else:
+                        # Check if it contains artifacts deeper down (virtual directory)
+                        # Use a quick existence check: any .magpie files in subdirectories?
+                        has_nested_artifacts = any(child.rglob(".magpie"))
+                        if has_nested_artifacts:
+                            # It's a virtual directory - return with trailing /
+                            artifact_paths.append(child_rel_path + "/")
             except (OSError, PermissionError):
                 # Handle permission errors or other filesystem issues gracefully
                 pass

--- a/src/magpie/storage/service.py
+++ b/src/magpie/storage/service.py
@@ -539,8 +539,11 @@ class StorageService:
                 return []
             manifest_iter = search_root.rglob(".magpie")
         else:
-            # Non-recursive mode: find artifacts that are direct children
-            # Works at any depth - no hardcoded segment limits
+            # Non-recursive mode: return all artifacts that are descendants of the prefix.
+            # The CLI's _extract_immediate_children will filter to show only immediate
+            # children and virtual directories. This approach ensures that intermediate
+            # virtual directories are discoverable even when artifacts only exist at
+            # deeper nesting levels.
             if not search_root.exists() or not search_root.is_dir():
                 return []
 
@@ -552,27 +555,16 @@ class StorageService:
                 if root_manifest.is_file():
                     manifest_iter.append(root_manifest)
 
-            # Check immediate children for .magpie files
+            # Recursively find all artifacts under immediate children
             try:
                 for child in search_root.iterdir():
                     if child.is_dir():
-                        # Check if immediate child is an artifact
-                        child_manifest = child / ".magpie"
-                        if child_manifest.is_file():
-                            manifest_iter.append(child_manifest)
-
-                        # When no prefix: also check grandchildren to catch 2-segment
-                        # artifacts like "ns/artifact" from root.
-                        # With prefix: don't check grandchildren (only direct children).
-                        if not normalized_prefix:
-                            try:
-                                for grandchild in child.iterdir():
-                                    if grandchild.is_dir():
-                                        grandchild_manifest = grandchild / ".magpie"
-                                        if grandchild_manifest.is_file():
-                                            manifest_iter.append(grandchild_manifest)
-                            except (OSError, PermissionError):
-                                continue
+                        # Use rglob to find all .magpie files under this child at any depth
+                        try:
+                            for manifest in child.rglob(".magpie"):
+                                manifest_iter.append(manifest)
+                        except (OSError, PermissionError):
+                            continue
             except (OSError, PermissionError):
                 # Handle permission errors or other filesystem issues gracefully
                 pass

--- a/src/magpie/storage/service.py
+++ b/src/magpie/storage/service.py
@@ -483,16 +483,15 @@ class StorageService:
         Args:
             prefix: Path prefix to filter by (empty string lists all).
                    Leading slashes are normalized and path traversal sequences are rejected.
-            recursive: If True, list all artifacts recursively. If False (default),
-                      list only artifacts at the current level relative to the prefix.
+            recursive: If True, list all artifacts recursively under the prefix.
+                      If False (default), list only immediate children (non-recursive).
 
-                      For empty prefix (""), "current level" means artifacts that are
-                      either 1 or 2 segments deep (e.g., "artifact" and "ns/artifact").
-                      This handles the common case where the storage root contains both
-                      single-segment artifacts and namespace directories.
+                      Non-recursive mode checks each immediate child of the prefix path:
+                      - If it's a directory with .magpie → it's an artifact (return it)
+                      - If it's a directory without .magpie → it's a virtual directory prefix
+                        (not returned, but can be explored by listing with that prefix)
 
-                      For non-empty prefix, "current level" means the prefix itself
-                      (if it's an artifact) plus its immediate children.
+                      This is O(immediate_children) rather than O(all_descendants).
 
         Returns:
             Sorted list of artifact paths matching the prefix.
@@ -510,6 +509,14 @@ class StorageService:
             list_artifact_paths("test", False) -> ["test/artifact1", "test/artifact2"]
             list_artifact_paths("test", True) -> ["test/artifact1", "test/artifact2",
                                                    "test/sub/deep"]
+
+        Note:
+            For non-recursive mode, the behavior is:
+            1. Check if the prefix path itself exists
+            2. If it's a leaf directory (has .magpie), treat as artifact and return it
+            3. Otherwise, do a non-recursive directory listing (iterdir)
+            4. For each immediate child: check if it has .magpie to determine if it's
+               an artifact or a virtual directory prefix
         """
         # Normalize prefix for listing - allow empty result for root listing
         # Strip leading/trailing slashes and collapse multiple slashes
@@ -529,63 +536,62 @@ class StorageService:
 
         artifact_paths: list[str] = []
 
-        # Determine search root based on prefix to avoid walking the entire tree
+        # Determine search root based on prefix
         search_root = self.config.storage_path
         if normalized_prefix:
             search_root = search_root / normalized_prefix
 
+        # Check if search root exists
+        if not search_root.exists() or not search_root.is_dir():
+            return []
+
         if recursive:
-            if not search_root.exists() or not search_root.is_dir():
-                return []
+            # Recursive mode: use rglob to find all .magpie files at any depth
             manifest_iter = search_root.rglob(".magpie")
+
+            for manifest_file in manifest_iter:
+                # Get artifact directory (parent of .magpie file)
+                artifact_dir = manifest_file.parent
+
+                # Compute artifact path relative to storage_path
+                artifact_path = str(artifact_dir.relative_to(self.config.storage_path))
+
+                # Filter by prefix if provided
+                if normalized_prefix:
+                    # Treat prefix as a path-segment prefix, not a raw string prefix
+                    if not (
+                        artifact_path == normalized_prefix
+                        or artifact_path.startswith(normalized_prefix + "/")
+                    ):
+                        continue
+
+                artifact_paths.append(artifact_path)
         else:
-            # Non-recursive mode: return all artifacts that are descendants of the prefix.
-            # The CLI's _extract_immediate_children will filter to show only immediate
-            # children and virtual directories. This approach ensures that intermediate
-            # virtual directories are discoverable even when artifacts only exist at
-            # deeper nesting levels.
-            if not search_root.exists() or not search_root.is_dir():
-                return []
+            # Non-recursive mode: simpler O(immediate_children) approach
+            # Step 1: Check if the prefix path itself is a leaf directory (artifact)
+            prefix_manifest = search_root / ".magpie"
+            if prefix_manifest.is_file() and normalized_prefix:
+                # The prefix itself is an artifact, return it
+                artifact_paths.append(normalized_prefix)
 
-            manifest_iter = []
-
-            # When we have a prefix, also check if the prefix itself is an artifact
-            if normalized_prefix:
-                root_manifest = search_root / ".magpie"
-                if root_manifest.is_file():
-                    manifest_iter.append(root_manifest)
-
-            # Recursively find all artifacts under immediate children
+            # Step 2: Do non-recursive directory listing of immediate children
             try:
                 for child in search_root.iterdir():
-                    if child.is_dir():
-                        # Use rglob to find all .magpie files under this child at any depth
-                        try:
-                            for manifest in child.rglob(".magpie"):
-                                manifest_iter.append(manifest)
-                        except (OSError, PermissionError):
-                            continue
+                    if not child.is_dir():
+                        continue
+
+                    # Check if this immediate child is an artifact (has .magpie)
+                    child_manifest = child / ".magpie"
+                    if child_manifest.is_file():
+                        # Compute full artifact path relative to storage_path
+                        artifact_path = str(child.relative_to(self.config.storage_path))
+                        artifact_paths.append(artifact_path)
+                    # If child doesn't have .magpie, it's a virtual directory prefix
+                    # (not returned, but can be explored by calling list_artifact_paths
+                    # with that path as the prefix)
             except (OSError, PermissionError):
                 # Handle permission errors or other filesystem issues gracefully
                 pass
-
-        for manifest_file in manifest_iter:
-            # Get artifact directory (parent of .magpie file)
-            artifact_dir = manifest_file.parent
-
-            # Compute artifact path relative to storage_path
-            artifact_path = str(artifact_dir.relative_to(self.config.storage_path))
-
-            # Filter by prefix if provided
-            if normalized_prefix:
-                # Treat prefix as a path-segment prefix, not a raw string prefix
-                if not (
-                    artifact_path == normalized_prefix
-                    or artifact_path.startswith(normalized_prefix + "/")
-                ):
-                    continue
-
-            artifact_paths.append(artifact_path)
 
         return sorted(artifact_paths)
 

--- a/src/magpie/storage/service.py
+++ b/src/magpie/storage/service.py
@@ -499,8 +499,8 @@ class StorageService:
         Returns:
             Sorted list of artifact paths and virtual directory indicators.
             - Artifacts (have .magpie): returned as-is (e.g., "test/artifact1")
-            - Virtual directories (contain artifacts deeper): returned with trailing /
-              (e.g., "test/")
+            - Virtual directories (subdirectories, may or may not contain artifacts):
+              returned with trailing / (e.g., "test/")
 
         Examples:
             With artifacts at: test/artifact1, test/artifact2, test/sub/deep,
@@ -575,12 +575,17 @@ class StorageService:
             # Tradeoff: may show virtual directories that don't contain artifacts,
             # but reconciliation job can clean those up
 
-            # Step 1: Check if the prefix path itself is a leaf directory (artifact)
+            # Step 1: For non-empty prefixes, check if the prefix path itself is a leaf
+            # directory (artifact). For the root prefix (normalized_prefix == ""),
+            # we intentionally skip this early-return so that root-level artifacts
+            # and virtual directories can be listed together. Root listing needs to
+            # continue checking children even if root itself has a .magpie, because
+            # root can contain both artifacts and virtual directories.
             prefix_manifest = search_root / ".magpie"
             if prefix_manifest.is_file() and normalized_prefix:
-                # The prefix itself is an artifact, include it
+                # The (non-root) prefix itself is an artifact, include it and stop:
+                # artifacts are leaf nodes, so there are no child entries to list.
                 artifact_paths.append(normalized_prefix)
-                # Since artifacts are leaf nodes, no need to check children
                 return sorted(artifact_paths)
 
             # Step 2: List immediate children - simple iterdir() only

--- a/src/magpie/storage/service.py
+++ b/src/magpie/storage/service.py
@@ -570,10 +570,9 @@ class StorageService:
             # Step 1: Check if the prefix path itself is a leaf directory (artifact)
             prefix_manifest = search_root / ".magpie"
             if prefix_manifest.is_file() and normalized_prefix:
-                # The prefix itself is an artifact, return it
+                # The prefix itself is an artifact, include it
                 artifact_paths.append(normalized_prefix)
-                # Artifacts are leaf nodes - no need to check children
-                return sorted(artifact_paths)
+                # Continue to check for child artifacts (prefix can have nested artifacts)
 
             # Step 2: Do non-recursive directory listing of immediate children
             try:

--- a/src/magpie/storage/service.py
+++ b/src/magpie/storage/service.py
@@ -572,6 +572,8 @@ class StorageService:
             if prefix_manifest.is_file() and normalized_prefix:
                 # The prefix itself is an artifact, return it
                 artifact_paths.append(normalized_prefix)
+                # Artifacts are leaf nodes - no need to check children
+                return sorted(artifact_paths)
 
             # Step 2: Do non-recursive directory listing of immediate children
             try:
@@ -589,8 +591,13 @@ class StorageService:
                         artifact_paths.append(child_rel_path)
                     else:
                         # Check if it contains artifacts deeper down (virtual directory)
-                        # Use a quick existence check: any .magpie files in subdirectories?
-                        has_nested_artifacts = any(child.rglob(".magpie"))
+                        # Use explicit next() to short-circuit and handle edge cases
+                        try:
+                            next(child.rglob(".magpie"))
+                            has_nested_artifacts = True
+                        except (StopIteration, OSError, PermissionError):
+                            has_nested_artifacts = False
+
                         if has_nested_artifacts:
                             # It's a virtual directory - return with trailing /
                             artifact_paths.append(child_rel_path + "/")

--- a/src/magpie/storage/service.py
+++ b/src/magpie/storage/service.py
@@ -589,6 +589,10 @@ class StorageService:
                     if not child.is_dir():
                         continue
 
+                    # Skip hidden/system directories (e.g., .tmp/)
+                    if child.name.startswith("."):
+                        continue
+
                     # Compute full path relative to storage_path
                     child_rel_path = str(child.relative_to(self.config.storage_path))
 

--- a/tests/e2e/test_cidr_allowlist.py
+++ b/tests/e2e/test_cidr_allowlist.py
@@ -63,7 +63,8 @@ class TestCIDRAllowListReadAccess:
         assert upload_response.status_code in (200, 201), f"Setup failed: {upload_response.text}"
 
         # Test: List artifact paths without authentication (CIDR bypass)
-        list_response = cidr_http_client.get("/api/v1/artifacts")
+        # Note: Use recursive=true to get nested artifacts (non-recursive only returns immediate children)
+        list_response = cidr_http_client.get("/api/v1/artifacts?recursive=true")
         assert list_response.status_code == 200, (
             f"CIDR bypass failed for GET /api/v1/artifacts. "
             f"Expected 200, got {list_response.status_code}. "
@@ -442,8 +443,9 @@ class TestCIDRAllowListTokenInteraction:
         assert upload_response.status_code in (200, 201)
 
         # Test: List artifacts with read token (should work)
+        # Note: Use recursive=true to get nested artifacts
         list_response = cidr_http_client.get(
-            "/api/v1/artifacts",
+            "/api/v1/artifacts?recursive=true",
             headers={"Authorization": f"Bearer {read_token}"},
         )
         assert list_response.status_code == 200, (
@@ -505,8 +507,9 @@ class TestCIDRAllowListTokenInteraction:
         assert upload_response.status_code in (200, 201)
 
         # Test: Use invalid token (CIDR bypass allows read access)
+        # Note: Use recursive=true to get nested artifacts
         response = cidr_http_client.get(
-            "/api/v1/artifacts",
+            "/api/v1/artifacts?recursive=true",
             headers={"Authorization": "Bearer mgp_invalid_token_12345"},
         )
         assert response.status_code == 200, (
@@ -545,8 +548,9 @@ class TestCIDRAllowListTokenInteraction:
         assert upload_response.status_code in (200, 201)
 
         # Test: List artifacts from outside CIDR with valid token (should work)
+        # Note: Use recursive=true to get nested artifacts
         list_response = cidr_outside_http_client.get(
-            "/api/v1/artifacts",
+            "/api/v1/artifacts?recursive=true",
             headers={"Authorization": f"Bearer {read_token}"},
         )
         assert list_response.status_code == 200, (

--- a/tests/integration/test_list_endpoint.py
+++ b/tests/integration/test_list_endpoint.py
@@ -261,13 +261,18 @@ class TestListPathsEndpoint:
         assert "test/artifact" in data["paths"]
 
     def test_list_paths_empty_storage(self, client: TestClient) -> None:
-        """List paths with no artifacts returns empty list."""
+        """List paths with no artifacts returns empty list.
+
+        Note: May show .tmp/ as a virtual directory if temp directory exists.
+        """
         response = client.get("/api/v1/artifacts")
 
         assert response.status_code == 200
         data = response.json()
 
-        assert data["paths"] == []
+        # May include .tmp/ as a virtual directory if temp directory exists
+        paths = [p for p in data["paths"] if not p.startswith(".tmp")]
+        assert paths == []
 
     def test_list_paths_no_matching_prefix(self, client: TestClient) -> None:
         """List paths with non-matching prefix returns empty list."""
@@ -312,9 +317,11 @@ class TestListPathsEndpoint:
 
         # Non-recursive mode returns virtual directory indicators (with trailing /)
         # for directories containing artifacts deeper down
-        assert len(data["paths"]) == 2
-        assert "test/" in data["paths"]
-        assert "images/" in data["paths"]
+        # May also include .tmp/ if temp directory exists
+        paths = [p for p in data["paths"] if not p.startswith(".tmp")]
+        assert len(paths) == 2
+        assert "test/" in paths
+        assert "images/" in paths
 
     def test_list_paths_recursive_shows_all(self, client: TestClient) -> None:
         """List paths with recursive=true shows all nested paths."""

--- a/tests/integration/test_list_endpoint.py
+++ b/tests/integration/test_list_endpoint.py
@@ -292,7 +292,7 @@ class TestListPathsEndpoint:
         assert isinstance(data["paths"], list)
 
     def test_list_paths_non_recursive_default(self, client: TestClient) -> None:
-        """List paths without recursive flag filters nested paths."""
+        """List paths without recursive flag returns all descendants for virtual directories."""
         # Upload artifacts with nesting
         files1 = {"file": ("f1.bin", io.BytesIO(b"content1"), "application/octet-stream")}
         files2 = {"file": ("f2.bin", io.BytesIO(b"content2"), "application/octet-stream")}
@@ -310,13 +310,13 @@ class TestListPathsEndpoint:
         assert response.status_code == 200
         data = response.json()
 
-        # Should only show top-level paths (one slash)
-        assert len(data["paths"]) == 3
+        # Non-recursive mode returns all artifacts to support virtual directory discovery
+        # The CLI's _extract_immediate_children will filter to show only immediate children
+        assert len(data["paths"]) == 4
         assert "test/artifact1" in data["paths"]
         assert "test/artifact2" in data["paths"]
         assert "images/ubuntu" in data["paths"]
-        # Should NOT show nested path
-        assert "test/sub/deep" not in data["paths"]
+        assert "test/sub/deep" in data["paths"]
 
     def test_list_paths_recursive_shows_all(self, client: TestClient) -> None:
         """List paths with recursive=true shows all nested paths."""
@@ -345,7 +345,7 @@ class TestListPathsEndpoint:
         assert "images/ubuntu" in data["paths"]
 
     def test_list_paths_with_prefix_non_recursive(self, client: TestClient) -> None:
-        """List paths with prefix and non-recursive filters correctly."""
+        """List paths with prefix and non-recursive returns all descendants."""
         files1 = {"file": ("f1.bin", io.BytesIO(b"content1"), "application/octet-stream")}
         files2 = {"file": ("f2.bin", io.BytesIO(b"content2"), "application/octet-stream")}
         files3 = {"file": ("f3.bin", io.BytesIO(b"content3"), "application/octet-stream")}
@@ -360,11 +360,11 @@ class TestListPathsEndpoint:
         assert response.status_code == 200
         data = response.json()
 
-        # Should only show direct children under test/
-        assert len(data["paths"]) == 2
+        # Non-recursive returns all descendants to support virtual directory discovery
+        assert len(data["paths"]) == 3
         assert "test/artifact1" in data["paths"]
         assert "test/artifact2" in data["paths"]
-        assert "test/sub/deep" not in data["paths"]
+        assert "test/sub/deep" in data["paths"]
 
     def test_list_paths_with_prefix_recursive(self, client: TestClient) -> None:
         """List paths with prefix and recursive shows all nested paths."""

--- a/tests/integration/test_list_endpoint.py
+++ b/tests/integration/test_list_endpoint.py
@@ -292,7 +292,7 @@ class TestListPathsEndpoint:
         assert isinstance(data["paths"], list)
 
     def test_list_paths_non_recursive_default(self, client: TestClient) -> None:
-        """List paths without recursive flag returns only immediate children."""
+        """List paths without recursive flag returns immediate children and virtual directories."""
         # Upload artifacts with nesting
         files1 = {"file": ("f1.bin", io.BytesIO(b"content1"), "application/octet-stream")}
         files2 = {"file": ("f2.bin", io.BytesIO(b"content2"), "application/octet-stream")}
@@ -304,15 +304,17 @@ class TestListPathsEndpoint:
         client.post("/api/v1/upload/test/sub/deep", files=files3)
         client.post("/api/v1/upload/images/ubuntu", files=files4)
 
-        # List without recursive (default) - returns empty because no immediate children at root
+        # List without recursive (default) - returns virtual directory indicators
         response = client.get("/api/v1/artifacts")
 
         assert response.status_code == 200
         data = response.json()
 
-        # Non-recursive mode returns only immediate children (none at root in this case)
-        # The CLI uses recursive=true and filters client-side for virtual directory discovery
-        assert len(data["paths"]) == 0
+        # Non-recursive mode returns virtual directory indicators (with trailing /)
+        # for directories containing artifacts deeper down
+        assert len(data["paths"]) == 2
+        assert "test/" in data["paths"]
+        assert "images/" in data["paths"]
 
     def test_list_paths_recursive_shows_all(self, client: TestClient) -> None:
         """List paths with recursive=true shows all nested paths."""
@@ -341,7 +343,7 @@ class TestListPathsEndpoint:
         assert "images/ubuntu" in data["paths"]
 
     def test_list_paths_with_prefix_non_recursive(self, client: TestClient) -> None:
-        """List paths with prefix and non-recursive returns only immediate children."""
+        """List paths with prefix and non-recursive returns immediate children and virtual dirs."""
         files1 = {"file": ("f1.bin", io.BytesIO(b"content1"), "application/octet-stream")}
         files2 = {"file": ("f2.bin", io.BytesIO(b"content2"), "application/octet-stream")}
         files3 = {"file": ("f3.bin", io.BytesIO(b"content3"), "application/octet-stream")}
@@ -350,17 +352,18 @@ class TestListPathsEndpoint:
         client.post("/api/v1/upload/test/artifact2", files=files2)
         client.post("/api/v1/upload/test/sub/deep", files=files3)
 
-        # List with prefix, non-recursive - returns only immediate children
+        # List with prefix, non-recursive - returns immediate children and virtual directories
         response = client.get("/api/v1/artifacts", params={"prefix": "test", "recursive": False})
 
         assert response.status_code == 200
         data = response.json()
 
-        # Non-recursive returns only immediate children (artifact1, artifact2)
-        # sub/deep is NOT an immediate child, so it's excluded
-        assert len(data["paths"]) == 2
+        # Non-recursive returns immediate children (artifact1, artifact2) and
+        # virtual directory indicator (sub/)
+        assert len(data["paths"]) == 3
         assert "test/artifact1" in data["paths"]
         assert "test/artifact2" in data["paths"]
+        assert "test/sub/" in data["paths"]
         assert "test/sub/deep" not in data["paths"]
 
     def test_list_paths_with_prefix_recursive(self, client: TestClient) -> None:

--- a/tests/integration/test_list_endpoint.py
+++ b/tests/integration/test_list_endpoint.py
@@ -210,8 +210,8 @@ class TestListPathsEndpoint:
         client.post("/api/v1/upload/test/artifact2", files=files2)
         client.post("/api/v1/upload/images/ubuntu", files=files3)
 
-        # List all paths
-        response = client.get("/api/v1/artifacts")
+        # List all paths recursively
+        response = client.get("/api/v1/artifacts", params={"recursive": True})
 
         assert response.status_code == 200
         data = response.json()
@@ -292,7 +292,7 @@ class TestListPathsEndpoint:
         assert isinstance(data["paths"], list)
 
     def test_list_paths_non_recursive_default(self, client: TestClient) -> None:
-        """List paths without recursive flag returns all descendants for virtual directories."""
+        """List paths without recursive flag returns only immediate children."""
         # Upload artifacts with nesting
         files1 = {"file": ("f1.bin", io.BytesIO(b"content1"), "application/octet-stream")}
         files2 = {"file": ("f2.bin", io.BytesIO(b"content2"), "application/octet-stream")}
@@ -304,19 +304,15 @@ class TestListPathsEndpoint:
         client.post("/api/v1/upload/test/sub/deep", files=files3)
         client.post("/api/v1/upload/images/ubuntu", files=files4)
 
-        # List without recursive (default)
+        # List without recursive (default) - returns empty because no immediate children at root
         response = client.get("/api/v1/artifacts")
 
         assert response.status_code == 200
         data = response.json()
 
-        # Non-recursive mode returns all artifacts to support virtual directory discovery
-        # The CLI's _extract_immediate_children will filter to show only immediate children
-        assert len(data["paths"]) == 4
-        assert "test/artifact1" in data["paths"]
-        assert "test/artifact2" in data["paths"]
-        assert "images/ubuntu" in data["paths"]
-        assert "test/sub/deep" in data["paths"]
+        # Non-recursive mode returns only immediate children (none at root in this case)
+        # The CLI uses recursive=true and filters client-side for virtual directory discovery
+        assert len(data["paths"]) == 0
 
     def test_list_paths_recursive_shows_all(self, client: TestClient) -> None:
         """List paths with recursive=true shows all nested paths."""
@@ -345,7 +341,7 @@ class TestListPathsEndpoint:
         assert "images/ubuntu" in data["paths"]
 
     def test_list_paths_with_prefix_non_recursive(self, client: TestClient) -> None:
-        """List paths with prefix and non-recursive returns all descendants."""
+        """List paths with prefix and non-recursive returns only immediate children."""
         files1 = {"file": ("f1.bin", io.BytesIO(b"content1"), "application/octet-stream")}
         files2 = {"file": ("f2.bin", io.BytesIO(b"content2"), "application/octet-stream")}
         files3 = {"file": ("f3.bin", io.BytesIO(b"content3"), "application/octet-stream")}
@@ -354,17 +350,18 @@ class TestListPathsEndpoint:
         client.post("/api/v1/upload/test/artifact2", files=files2)
         client.post("/api/v1/upload/test/sub/deep", files=files3)
 
-        # List with prefix, non-recursive
+        # List with prefix, non-recursive - returns only immediate children
         response = client.get("/api/v1/artifacts", params={"prefix": "test", "recursive": False})
 
         assert response.status_code == 200
         data = response.json()
 
-        # Non-recursive returns all descendants to support virtual directory discovery
-        assert len(data["paths"]) == 3
+        # Non-recursive returns only immediate children (artifact1, artifact2)
+        # sub/deep is NOT an immediate child, so it's excluded
+        assert len(data["paths"]) == 2
         assert "test/artifact1" in data["paths"]
         assert "test/artifact2" in data["paths"]
-        assert "test/sub/deep" in data["paths"]
+        assert "test/sub/deep" not in data["paths"]
 
     def test_list_paths_with_prefix_recursive(self, client: TestClient) -> None:
         """List paths with prefix and recursive shows all nested paths."""

--- a/tests/integration/test_storage_service.py
+++ b/tests/integration/test_storage_service.py
@@ -378,7 +378,7 @@ class TestListArtifactPaths:
     """Tests for list_artifact_paths functionality."""
 
     def test_list_all_paths(self, storage_service: StorageService) -> None:
-        """list_artifact_paths should return all artifact paths."""
+        """list_artifact_paths should return all artifact paths recursively."""
         # Store artifacts at different paths
         storage_service.store_artifact(
             artifact_path="test/artifact1",
@@ -396,8 +396,8 @@ class TestListArtifactPaths:
             uploaded_by="user",
         )
 
-        # List all paths
-        paths = storage_service.list_artifact_paths()
+        # List all paths recursively
+        paths = storage_service.list_artifact_paths(recursive=True)
 
         assert len(paths) == 3
         assert "test/artifact1" in paths
@@ -460,14 +460,14 @@ class TestListArtifactPaths:
             uploaded_by="user",
         )
 
-        # Single slash should list all artifacts (normalized to empty prefix)
-        paths = storage_service.list_artifact_paths("/")
+        # Single slash should list all artifacts recursively (normalized to empty prefix)
+        paths = storage_service.list_artifact_paths("/", recursive=True)
         assert len(paths) == 2
         assert "test/artifact1" in paths
         assert "other/artifact2" in paths
 
         # Multiple slashes should also work
-        paths = storage_service.list_artifact_paths("//")
+        paths = storage_service.list_artifact_paths("//", recursive=True)
         assert len(paths) == 2
         assert "test/artifact1" in paths
         assert "other/artifact2" in paths
@@ -584,17 +584,24 @@ class TestListArtifactPaths:
             uploaded_by="user",
         )
 
-        # Non-recursive list with no prefix should find both
+        # Non-recursive list with no prefix should find only immediate children
+        # "simple" is an immediate child, but "ns/artifact" is not (it's under "ns/")
         paths = storage_service.list_artifact_paths(recursive=False)
-        assert len(paths) == 2
+        assert len(paths) == 1
         assert "simple" in paths
+        assert "ns/artifact" not in paths
+
+        # Non-recursive list with prefix "ns" should find "ns/artifact"
+        paths = storage_service.list_artifact_paths(prefix="ns", recursive=False)
+        assert len(paths) == 1
         assert "ns/artifact" in paths
 
     def test_list_paths_non_recursive_deeply_nested(self, storage_service: StorageService) -> None:
-        """Non-recursive list should return all descendants to support virtual directories.
+        """Non-recursive list should return only immediate children artifacts.
 
-        Tests that non-recursive listing returns artifacts at all depths under a prefix
-        so the CLI can extract virtual directories correctly.
+        Tests that non-recursive listing returns only artifacts that are immediate
+        children of the prefix directory. Nested artifacts in subdirectories are
+        not returned (but can be discovered by listing those subdirectories).
         """
         # Create deeply nested artifacts
         storage_service.store_artifact(
@@ -613,16 +620,16 @@ class TestListArtifactPaths:
             uploaded_by="user",
         )
 
-        # Non-recursive at "a/b/c" should return all descendants (d, e, sub/deeper)
-        # so the CLI can show virtual directory "sub/"
+        # Non-recursive at "a/b/c" should return only immediate children (d, e)
+        # sub/deeper is NOT an immediate child, so it's excluded
         paths = storage_service.list_artifact_paths(prefix="a/b/c", recursive=False)
-        assert len(paths) == 3
+        assert len(paths) == 2
         assert "a/b/c/d" in paths
         assert "a/b/c/e" in paths
-        assert "a/b/c/sub/deeper" in paths
+        assert "a/b/c/sub/deeper" not in paths
 
     def test_list_paths_non_recursive_various_depths(self, storage_service: StorageService) -> None:
-        """Non-recursive mode should return all descendants to support virtual directories."""
+        """Non-recursive mode should return only immediate children artifacts."""
         # Create artifacts at various depths
         storage_service.store_artifact(
             artifact_path="root",
@@ -645,44 +652,46 @@ class TestListArtifactPaths:
             uploaded_by="user",
         )
 
-        # No prefix: list all artifacts (root and all under test/)
-        # CLI will extract "root" and "test/" virtual directory
+        # No prefix: list only immediate children at root level
+        # Only "root" is an immediate child (test/one, test/two, test/sub/deep are not)
         paths = storage_service.list_artifact_paths(recursive=False)
-        assert len(paths) == 4
+        assert len(paths) == 1
         assert "root" in paths
-        assert "test/one" in paths
-        assert "test/two" in paths
-        assert "test/sub/deep" in paths
+        assert "test/one" not in paths
+        assert "test/two" not in paths
+        assert "test/sub/deep" not in paths
 
-        # Prefix "test": list all descendants of test/ (one, two, sub/deep)
-        # CLI will extract "one", "two", "sub/" virtual directory
+        # Prefix "test": list only immediate children of test/ (one, two)
+        # sub/deep is NOT an immediate child, so it's excluded
         paths = storage_service.list_artifact_paths(prefix="test", recursive=False)
-        assert len(paths) == 3
+        assert len(paths) == 2
         assert "test/one" in paths
         assert "test/two" in paths
-        assert "test/sub/deep" in paths
+        assert "test/sub/deep" not in paths
 
         # Prefix "test/sub": list all descendants of test/sub/ (deep)
         paths = storage_service.list_artifact_paths(prefix="test/sub", recursive=False)
         assert len(paths) == 1
         assert "test/sub/deep" in paths
 
-    def test_list_paths_non_recursive_discovers_intermediate_dirs(
+    def test_list_paths_non_recursive_returns_only_immediate_children(
         self, storage_service: StorageService
     ) -> None:
-        """Non-recursive list should discover intermediate virtual directories.
+        """Non-recursive list returns only immediate children artifacts.
 
-        Reproduces issue #398: When artifacts exist only at deeper nesting levels
-        (e.g., builds/infra/github-runner.qcow2), non-recursive listing should
-        still return artifacts to enable the CLI to show intermediate virtual
-        directories.
+        With the simpler O(immediate_children) approach, non-recursive mode
+        only returns artifacts that are immediate children of the prefix directory.
+        Virtual directories (directories without .magpie) are not returned.
+
+        For issue #398 use case (discovering deeply nested artifacts):
+        Users should use recursive mode (--recursive flag) to find all artifacts,
+        or navigate step-by-step through the directory structure.
 
         Expected behavior:
-        - ls (no prefix) -> should include builds/infra/github-runner.qcow2
-          so CLI can show builds/
-        - ls builds -> should include builds/infra/github-runner.qcow2
-          so CLI can show infra/
-        - ls builds/infra -> should show builds/infra/github-runner.qcow2
+        - ls (no prefix) -> returns [] (no immediate children)
+        - ls builds -> returns [] (no immediate children, "infra" is virtual dir)
+        - ls builds/infra -> returns ["builds/infra/github-runner.qcow2"]
+        - ls -r (recursive) -> returns ["builds/infra/github-runner.qcow2"]
         """
         # Create artifact at deep nesting level only
         storage_service.store_artifact(
@@ -691,21 +700,29 @@ class TestListArtifactPaths:
             uploaded_by="user",
         )
 
-        # Root level: should find the deep artifact so CLI can extract "builds/"
+        # Root level non-recursive: no immediate children, so returns empty
         paths = storage_service.list_artifact_paths(recursive=False)
-        assert "builds/infra/github-runner.qcow2" in paths, (
-            "Non-recursive list at root should return deep artifacts "
-            "to enable CLI to show intermediate directories"
+        assert len(paths) == 0, (
+            "Non-recursive list at root should return [] when no immediate children exist"
         )
 
-        # Prefix "builds": should find the artifact so CLI can extract "infra/"
+        # Prefix "builds" non-recursive: "infra" is a virtual dir (no .magpie), so returns empty
         paths = storage_service.list_artifact_paths(prefix="builds", recursive=False)
-        assert "builds/infra/github-runner.qcow2" in paths, (
-            "Non-recursive list with prefix 'builds' should return deeper artifacts "
-            "to enable CLI to show subdirectories"
+        assert len(paths) == 0, (
+            "Non-recursive list at 'builds' should return [] when only virtual subdirs exist"
         )
 
-        # Prefix "builds/infra": should find the direct child
+        # Prefix "builds/infra" non-recursive: finds the immediate child artifact
         paths = storage_service.list_artifact_paths(prefix="builds/infra", recursive=False)
+        assert len(paths) == 1
+        assert "builds/infra/github-runner.qcow2" in paths
+
+        # Recursive mode from root: finds all artifacts regardless of depth
+        paths = storage_service.list_artifact_paths(recursive=True)
+        assert len(paths) == 1
+        assert "builds/infra/github-runner.qcow2" in paths
+
+        # Recursive mode from "builds": finds all artifacts under builds/
+        paths = storage_service.list_artifact_paths(prefix="builds", recursive=True)
         assert len(paths) == 1
         assert "builds/infra/github-runner.qcow2" in paths

--- a/tests/integration/test_storage_service.py
+++ b/tests/integration/test_storage_service.py
@@ -709,8 +709,9 @@ class TestListArtifactPaths:
            marked with trailing /)
 
         This enables navigation to discover deeply nested artifacts without full
-        tree traversal. The storage layer is still O(immediate_children) efficient,
-        just with a quick existence check for nested artifacts.
+        tree traversal. The storage layer is O(immediate_children) efficient because
+        it does not perform recursive existence checks; all subdirectories are treated
+        as virtual directories unconditionally.
 
         For issue #398 use case (discovering deeply nested artifacts):
         Users can navigate step-by-step through virtual directories.

--- a/tests/integration/test_storage_service.py
+++ b/tests/integration/test_storage_service.py
@@ -591,10 +591,10 @@ class TestListArtifactPaths:
         assert "ns/artifact" in paths
 
     def test_list_paths_non_recursive_deeply_nested(self, storage_service: StorageService) -> None:
-        """Non-recursive list should work at arbitrary depths.
+        """Non-recursive list should return all descendants to support virtual directories.
 
-        Tests that non-recursive listing correctly interprets "direct children"
-        at various prefix depths.
+        Tests that non-recursive listing returns artifacts at all depths under a prefix
+        so the CLI can extract virtual directories correctly.
         """
         # Create deeply nested artifacts
         storage_service.store_artifact(
@@ -613,15 +613,16 @@ class TestListArtifactPaths:
             uploaded_by="user",
         )
 
-        # Non-recursive at "a/b/c" should find d, e but not sub/deeper
+        # Non-recursive at "a/b/c" should return all descendants (d, e, sub/deeper)
+        # so the CLI can show virtual directory "sub/"
         paths = storage_service.list_artifact_paths(prefix="a/b/c", recursive=False)
-        assert len(paths) == 2
+        assert len(paths) == 3
         assert "a/b/c/d" in paths
         assert "a/b/c/e" in paths
-        assert "a/b/c/sub/deeper" not in paths
+        assert "a/b/c/sub/deeper" in paths
 
     def test_list_paths_non_recursive_various_depths(self, storage_service: StorageService) -> None:
-        """Non-recursive mode should correctly list direct children at each prefix depth."""
+        """Non-recursive mode should return all descendants to support virtual directories."""
         # Create artifacts at various depths
         storage_service.store_artifact(
             artifact_path="root",
@@ -644,22 +645,67 @@ class TestListArtifactPaths:
             uploaded_by="user",
         )
 
-        # No prefix: list immediate children (root and test/one, test/two)
+        # No prefix: list all artifacts (root and all under test/)
+        # CLI will extract "root" and "test/" virtual directory
         paths = storage_service.list_artifact_paths(recursive=False)
-        assert len(paths) == 3
+        assert len(paths) == 4
         assert "root" in paths
         assert "test/one" in paths
         assert "test/two" in paths
-        assert "test/sub/deep" not in paths
+        assert "test/sub/deep" in paths
 
-        # Prefix "test": list direct children of test/ (one, two, not sub/deep)
+        # Prefix "test": list all descendants of test/ (one, two, sub/deep)
+        # CLI will extract "one", "two", "sub/" virtual directory
         paths = storage_service.list_artifact_paths(prefix="test", recursive=False)
-        assert len(paths) == 2
+        assert len(paths) == 3
         assert "test/one" in paths
         assert "test/two" in paths
-        assert "test/sub/deep" not in paths
+        assert "test/sub/deep" in paths
 
-        # Prefix "test/sub": list direct children of test/sub/ (deep)
+        # Prefix "test/sub": list all descendants of test/sub/ (deep)
         paths = storage_service.list_artifact_paths(prefix="test/sub", recursive=False)
         assert len(paths) == 1
         assert "test/sub/deep" in paths
+
+    def test_list_paths_non_recursive_discovers_intermediate_dirs(
+        self, storage_service: StorageService
+    ) -> None:
+        """Non-recursive list should discover intermediate virtual directories.
+
+        Reproduces issue #398: When artifacts exist only at deeper nesting levels
+        (e.g., builds/infra/github-runner.qcow2), non-recursive listing should
+        still return artifacts to enable the CLI to show intermediate virtual
+        directories.
+
+        Expected behavior:
+        - ls (no prefix) -> should include builds/infra/github-runner.qcow2
+          so CLI can show builds/
+        - ls builds -> should include builds/infra/github-runner.qcow2
+          so CLI can show infra/
+        - ls builds/infra -> should show builds/infra/github-runner.qcow2
+        """
+        # Create artifact at deep nesting level only
+        storage_service.store_artifact(
+            artifact_path="builds/infra/github-runner.qcow2",
+            file_stream=io.BytesIO(b"deep artifact"),
+            uploaded_by="user",
+        )
+
+        # Root level: should find the deep artifact so CLI can extract "builds/"
+        paths = storage_service.list_artifact_paths(recursive=False)
+        assert "builds/infra/github-runner.qcow2" in paths, (
+            "Non-recursive list at root should return deep artifacts "
+            "to enable CLI to show intermediate directories"
+        )
+
+        # Prefix "builds": should find the artifact so CLI can extract "infra/"
+        paths = storage_service.list_artifact_paths(prefix="builds", recursive=False)
+        assert "builds/infra/github-runner.qcow2" in paths, (
+            "Non-recursive list with prefix 'builds' should return deeper artifacts "
+            "to enable CLI to show subdirectories"
+        )
+
+        # Prefix "builds/infra": should find the direct child
+        paths = storage_service.list_artifact_paths(prefix="builds/infra", recursive=False)
+        assert len(paths) == 1
+        assert "builds/infra/github-runner.qcow2" in paths

--- a/tests/integration/test_storage_service.py
+++ b/tests/integration/test_storage_service.py
@@ -473,8 +473,13 @@ class TestListArtifactPaths:
         assert "other/artifact2" in paths
 
     def test_list_paths_empty_returns_empty(self, storage_service: StorageService) -> None:
-        """list_artifact_paths should return empty list when no artifacts."""
+        """list_artifact_paths should return empty list when no artifacts.
+
+        Note: May show .tmp/ as a virtual directory if temp directory exists.
+        """
         paths = storage_service.list_artifact_paths()
+        # Filter out .tmp/ which may exist as a system directory
+        paths = [p for p in paths if not p.startswith(".tmp")]
         assert paths == []
 
     def test_list_paths_no_match_returns_empty(self, storage_service: StorageService) -> None:
@@ -590,7 +595,9 @@ class TestListArtifactPaths:
         # Non-recursive list with no prefix should return:
         # - "simple" (immediate child artifact)
         # - "ns/" (virtual directory indicator)
+        # - May also include ".tmp/" if temp directory exists
         paths = storage_service.list_artifact_paths(recursive=False)
+        paths = [p for p in paths if not p.startswith(".tmp")]  # Filter system directories
         assert len(paths) == 2
         assert "simple" in paths
         assert "ns/" in paths
@@ -666,7 +673,9 @@ class TestListArtifactPaths:
         # No prefix: returns immediate children and virtual directory indicators
         # - "root" (immediate child artifact)
         # - "test/" (virtual directory indicator - contains artifacts deeper)
+        # - May also include ".tmp/" if temp directory exists
         paths = storage_service.list_artifact_paths(recursive=False)
+        paths = [p for p in paths if not p.startswith(".tmp")]  # Filter system directories
         assert len(paths) == 2
         assert "root" in paths
         assert "test/" in paths
@@ -720,7 +729,9 @@ class TestListArtifactPaths:
         )
 
         # Root level non-recursive: returns virtual directory indicator for "builds/"
+        # May also include ".tmp/" if temp directory exists
         paths = storage_service.list_artifact_paths(recursive=False)
+        paths = [p for p in paths if not p.startswith(".tmp")]  # Filter system directories
         assert len(paths) == 1
         assert "builds/" in paths, (
             "Non-recursive list at root should return ['builds/'] virtual dir indicator"

--- a/tests/integration/test_storage_service.py
+++ b/tests/integration/test_storage_service.py
@@ -566,10 +566,13 @@ class TestListArtifactPaths:
         assert "test2/artifact" not in paths
 
     def test_list_paths_non_recursive_single_segment(self, storage_service: StorageService) -> None:
-        """Non-recursive list should find single-segment artifacts.
+        """Non-recursive list should find single-segment artifacts and virtual directories.
 
         Regression test for issue #329: glob("*/*/.magpie") silently hid
         single-segment artifacts like "simple".
+
+        Updated for virtual directory support: non-recursive mode now also returns
+        virtual directory indicators (directories containing artifacts deeper).
         """
         # Store single-segment artifact
         storage_service.store_artifact(
@@ -584,11 +587,13 @@ class TestListArtifactPaths:
             uploaded_by="user",
         )
 
-        # Non-recursive list with no prefix should find only immediate children
-        # "simple" is an immediate child, but "ns/artifact" is not (it's under "ns/")
+        # Non-recursive list with no prefix should return:
+        # - "simple" (immediate child artifact)
+        # - "ns/" (virtual directory indicator)
         paths = storage_service.list_artifact_paths(recursive=False)
-        assert len(paths) == 1
+        assert len(paths) == 2
         assert "simple" in paths
+        assert "ns/" in paths
         assert "ns/artifact" not in paths
 
         # Non-recursive list with prefix "ns" should find "ns/artifact"
@@ -597,11 +602,15 @@ class TestListArtifactPaths:
         assert "ns/artifact" in paths
 
     def test_list_paths_non_recursive_deeply_nested(self, storage_service: StorageService) -> None:
-        """Non-recursive list should return only immediate children artifacts.
+        """Non-recursive list returns immediate children and virtual directory indicators.
 
-        Tests that non-recursive listing returns only artifacts that are immediate
-        children of the prefix directory. Nested artifacts in subdirectories are
-        not returned (but can be discovered by listing those subdirectories).
+        Tests that non-recursive listing returns:
+        1. Artifacts that are immediate children of the prefix directory
+        2. Virtual directory indicators (with trailing /) for subdirectories
+           containing artifacts deeper down
+
+        Nested artifacts in subdirectories are not returned directly, but can be
+        discovered by listing those subdirectories.
         """
         # Create deeply nested artifacts
         storage_service.store_artifact(
@@ -620,16 +629,18 @@ class TestListArtifactPaths:
             uploaded_by="user",
         )
 
-        # Non-recursive at "a/b/c" should return only immediate children (d, e)
-        # sub/deeper is NOT an immediate child, so it's excluded
+        # Non-recursive at "a/b/c" should return:
+        # - immediate children artifacts (d, e)
+        # - virtual directory indicator for "sub/" (contains deeper artifact)
         paths = storage_service.list_artifact_paths(prefix="a/b/c", recursive=False)
-        assert len(paths) == 2
+        assert len(paths) == 3
         assert "a/b/c/d" in paths
         assert "a/b/c/e" in paths
+        assert "a/b/c/sub/" in paths
         assert "a/b/c/sub/deeper" not in paths
 
     def test_list_paths_non_recursive_various_depths(self, storage_service: StorageService) -> None:
-        """Non-recursive mode should return only immediate children artifacts."""
+        """Non-recursive mode returns immediate children and virtual directory indicators."""
         # Create artifacts at various depths
         storage_service.store_artifact(
             artifact_path="root",
@@ -652,24 +663,28 @@ class TestListArtifactPaths:
             uploaded_by="user",
         )
 
-        # No prefix: list only immediate children at root level
-        # Only "root" is an immediate child (test/one, test/two, test/sub/deep are not)
+        # No prefix: returns immediate children and virtual directory indicators
+        # - "root" (immediate child artifact)
+        # - "test/" (virtual directory indicator - contains artifacts deeper)
         paths = storage_service.list_artifact_paths(recursive=False)
-        assert len(paths) == 1
+        assert len(paths) == 2
         assert "root" in paths
+        assert "test/" in paths
         assert "test/one" not in paths
         assert "test/two" not in paths
         assert "test/sub/deep" not in paths
 
-        # Prefix "test": list only immediate children of test/ (one, two)
-        # sub/deep is NOT an immediate child, so it's excluded
+        # Prefix "test": returns immediate children and virtual directory indicators
+        # - "test/one", "test/two" (immediate child artifacts)
+        # - "test/sub/" (virtual directory indicator - contains "deep")
         paths = storage_service.list_artifact_paths(prefix="test", recursive=False)
-        assert len(paths) == 2
+        assert len(paths) == 3
         assert "test/one" in paths
         assert "test/two" in paths
+        assert "test/sub/" in paths
         assert "test/sub/deep" not in paths
 
-        # Prefix "test/sub": list all descendants of test/sub/ (deep)
+        # Prefix "test/sub": list immediate children of test/sub/ (deep)
         paths = storage_service.list_artifact_paths(prefix="test/sub", recursive=False)
         assert len(paths) == 1
         assert "test/sub/deep" in paths
@@ -677,21 +692,25 @@ class TestListArtifactPaths:
     def test_list_paths_non_recursive_returns_only_immediate_children(
         self, storage_service: StorageService
     ) -> None:
-        """Non-recursive list returns only immediate children artifacts.
+        """Non-recursive list returns immediate children and virtual directory indicators.
 
-        With the simpler O(immediate_children) approach, non-recursive mode
-        only returns artifacts that are immediate children of the prefix directory.
-        Virtual directories (directories without .magpie) are not returned.
+        Non-recursive mode returns:
+        1. Immediate child artifacts (directories with .magpie)
+        2. Virtual directory indicators (directories containing artifacts deeper,
+           marked with trailing /)
+
+        This enables navigation to discover deeply nested artifacts without full
+        tree traversal. The storage layer is still O(immediate_children) efficient,
+        just with a quick existence check for nested artifacts.
 
         For issue #398 use case (discovering deeply nested artifacts):
-        Users should use recursive mode (--recursive flag) to find all artifacts,
-        or navigate step-by-step through the directory structure.
+        Users can navigate step-by-step through virtual directories.
 
         Expected behavior:
-        - ls (no prefix) -> returns [] (no immediate children)
-        - ls builds -> returns [] (no immediate children, "infra" is virtual dir)
-        - ls builds/infra -> returns ["builds/infra/github-runner.qcow2"]
-        - ls -r (recursive) -> returns ["builds/infra/github-runner.qcow2"]
+        - ls (no prefix) -> returns ["builds/"] (virtual dir indicator)
+        - ls builds -> returns ["builds/infra/"] (virtual dir indicator)
+        - ls builds/infra -> returns ["builds/infra/github-runner.qcow2"] (artifact)
+        - ls -r (recursive) -> returns ["builds/infra/github-runner.qcow2"] (all artifacts)
         """
         # Create artifact at deep nesting level only
         storage_service.store_artifact(
@@ -700,16 +719,18 @@ class TestListArtifactPaths:
             uploaded_by="user",
         )
 
-        # Root level non-recursive: no immediate children, so returns empty
+        # Root level non-recursive: returns virtual directory indicator for "builds/"
         paths = storage_service.list_artifact_paths(recursive=False)
-        assert len(paths) == 0, (
-            "Non-recursive list at root should return [] when no immediate children exist"
+        assert len(paths) == 1
+        assert "builds/" in paths, (
+            "Non-recursive list at root should return ['builds/'] virtual dir indicator"
         )
 
-        # Prefix "builds" non-recursive: "infra" is a virtual dir (no .magpie), so returns empty
+        # Prefix "builds" non-recursive: returns virtual directory indicator for "infra/"
         paths = storage_service.list_artifact_paths(prefix="builds", recursive=False)
-        assert len(paths) == 0, (
-            "Non-recursive list at 'builds' should return [] when only virtual subdirs exist"
+        assert len(paths) == 1
+        assert "builds/infra/" in paths, (
+            "Non-recursive list at 'builds' should return ['builds/infra/'] virtual dir indicator"
         )
 
         # Prefix "builds/infra" non-recursive: finds the immediate child artifact

--- a/tests/security/test_auth_timing.py
+++ b/tests/security/test_auth_timing.py
@@ -289,9 +289,10 @@ class TestAuthenticationConsistency:
         # Test all read endpoints with authentication
         auth_headers = {"X-Magpie-Scope": "read"}
 
-        # List all paths
+        # List all paths (use recursive to find nested artifacts)
         response = client_with_write_auth.get(
             "/api/v1/artifacts",
+            params={"recursive": True},
             headers=auth_headers,
         )
         assert response.status_code == 200


### PR DESCRIPTION
## Summary

- Fixes non-recursive listing to discover intermediate virtual directories
- Enables `magpie ls` to show directories even when artifacts exist only at deeper nesting
- Storage layer returns virtual directory indicators (trailing `/`) in non-recursive mode
- CLI uses non-recursive mode properly for performance

## Problem

Issue #398: When artifacts exist only at deeper nesting levels (e.g., `builds/infra/github-runner.qcow2`), non-recursive listing didn't discover intermediate directories:
- `magpie ls` → empty (should show `builds/`)
- `magpie ls builds` → not found (should show `infra/`)

Root cause: The storage service's non-recursive mode only returned immediate artifacts, not virtual directory indicators.

## Solution

Modified `list_artifact_paths` non-recursive mode to return BOTH:
1. Immediate child artifacts (directories with `.magpie`)
2. Virtual directory indicators (paths with trailing `/`) for ALL subdirectories

CLI now uses the requested mode (recursive or non-recursive) directly, instead of always using `recursive=True` and filtering client-side.

### How it works

Example with artifact at `builds/infra/github-runner.qcow2`:
- `list_artifact_paths("", recursive=False)` → `["builds/"]` (virtual dir indicator)
- `list_artifact_paths("builds", recursive=False)` → `["builds/infra/"]` (virtual dir indicator)
- `list_artifact_paths("builds/infra", recursive=False)` → `["builds/infra/github-runner.qcow2"]` (artifact)

Storage layer uses `iterdir()` to check immediate children only. All subdirectories (with or without .magpie) are shown unconditionally as virtual directory indicators (with trailing `/`). This maintains O(immediate_children) performance without deep recursive checks.

**Performance Tradeoff:** Empty directories may appear as virtual directories. This is intentional to avoid expensive `rglob()` checks on every subdirectory. The reconciliation job will clean up empty directories over time.

## Changes

- `src/magpie/storage/service.py`: Non-recursive mode returns virtual directory indicators
- `src/magpie/cli/commands/ls.py`: CLI uses requested mode, removed client-side filtering
- `tests/integration/test_storage_service.py`: Updated tests for virtual directory indicators
- `tests/integration/test_list_endpoint.py`: Updated API endpoint test expectations

## Breaking Change

Non-recursive API behavior changed: `GET /api/v1/artifacts?recursive=false` now returns virtual directory indicators (paths with trailing `/`). External consumers relying on the old behavior will see additional paths.

## Test plan

- [x] All 1144 unit and integration tests pass
- [x] Linting passes (`ruff check`)
- [x] Formatting passes (`ruff format --check`)
- [x] Regression test for issue #398 updated to verify virtual directory indicators

Closes #398

🤖 Generated with Claude Code w/ Sonnet 4.5