### PR TITLE
docs(contributing): add security label to category list

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,7 @@
 | `docs` | Documentation |
 | `installer` | Install script |
 | `deployment` | Generic deployment features (not environment-specific) |
+| `security` | Security-related issues and improvements |
 
 **Priority:**
 | Label | Meaning |


### PR DESCRIPTION
## Summary
- Adds `security` label to the Category section in CONTRIBUTING.md
- Documents label usage as "Security-related issues and improvements"

## Context
The security label was created via gh CLI with color `#d73a4a` (red) and has been applied to issues #387, #390, #391, #392, #393, #394, and #396.

This PR completes the documentation portion of issue #401.

## Test plan
- [x] Label creation verified via gh CLI
- [x] Label applied to 7 existing security issues
- [x] Documentation updated in CONTRIBUTING.md

Addresses #401

Generated with Claude Code (Sonnet 4.5)