### PR TITLE
Enable GitHub Dependabot for dependency vulnerability alerts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,10 +22,9 @@ updates:
     # Add labels for easier triage
     labels:
       - "dependencies"
-      - "python"
     # Keep PR reviewers in the loop
     reviewers:
-      - "SouthwestCCDC/magpie-maintainers"
+      - "SouthwestCCDC/blackteam"
     # Allow Dependabot to rebase PRs automatically
     rebase-strategy: "auto"
 
@@ -45,7 +44,6 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
-      - "github-actions"
     reviewers:
-      - "SouthwestCCDC/magpie-maintainers"
+      - "SouthwestCCDC/blackteam"
     rebase-strategy: "auto"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,51 @@
+# Dependabot configuration for automated dependency updates
+# Documentation: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  # Python dependencies (via pip - compatible with uv)
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/Phoenix"
+    # Group minor and patch updates together to reduce PR noise
+    groups:
+      python-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    # Limit open PRs to avoid overwhelming maintainers
+    open-pull-requests-limit: 10
+    # Add labels for easier triage
+    labels:
+      - "dependencies"
+      - "python"
+    # Keep PR reviewers in the loop
+    reviewers:
+      - "SouthwestCCDC/magpie-maintainers"
+    # Allow Dependabot to rebase PRs automatically
+    rebase-strategy: "auto"
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/Phoenix"
+    # Group all GitHub Actions updates together
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
+    reviewers:
+      - "SouthwestCCDC/magpie-maintainers"
+    rebase-strategy: "auto"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,7 @@
 | `docs` | Documentation |
 | `installer` | Install script |
 | `deployment` | Generic deployment features (not environment-specific) |
+| `dependencies` | Automated dependency updates (Dependabot) |
 | `security` | Security-related issues and improvements |
 
 **Priority:**


### PR DESCRIPTION
## Summary

Implements issue #390 to enable GitHub Dependabot for automated dependency updates and vulnerability alerts.

- Adds `.github/dependabot.yml` configuration file
- Enables Dependabot for Python dependencies (pip ecosystem, compatible with uv)
- Enables Dependabot for GitHub Actions workflow dependencies
- Configures weekly update schedule (Mondays at 9 AM Arizona time)
- Groups minor/patch Python updates to reduce PR noise
- Groups all GitHub Actions updates together
- Limits open PRs to manageable numbers (10 for Python, 5 for Actions)
- Auto-assigns to `blackteam` team for review

## Configuration Details

### Python Dependencies
- Uses `pip` package ecosystem (compatible with uv package manager)
- Minor and patch updates grouped together to avoid PR spam
- Major version updates create individual PRs for careful review

### GitHub Actions
- All GitHub Actions updates grouped into single PRs
- Keeps workflow dependencies current with security patches

### Schedule
- Weekly checks on Mondays at 9:00 AM America/Phoenix timezone
- Aligns with team's weekly planning cycle

## Benefits

1. **Security**: Automatic alerts for known vulnerabilities in dependencies
2. **Maintenance**: Keeps dependencies up-to-date with minimal manual effort
3. **Awareness**: Team stays informed about dependency updates via PR reviews
4. **Safety**: Grouped updates reduce noise while preserving visibility

## Testing

The configuration was validated with Python YAML parser to ensure syntax correctness. Dependabot will run automatically once merged and will create PRs according to the schedule.

## References

- Issue: #390
- Dependabot docs: https://docs.github.com/en/code-security/dependabot

---
Generated with Claude Code (Sonnet 4.5)