### PR TITLE
Replace fixed sleep with retry loop in run-cidr-tests.sh

### DIFF
--- a/scripts/run-cidr-tests.sh
+++ b/scripts/run-cidr-tests.sh
@@ -37,19 +37,34 @@ fi
 echo "Starting CIDR test environment..."
 docker compose -f docker-compose.yml -f docker-compose.cidr-test.yml up -d --build
 
-# Wait for services to be healthy
+# Wait for services to be healthy with retry loop
 echo "Waiting for services to be healthy..."
-sleep 5
 
-# Check curl availability
+# Check curl availability first
 if ! command -v curl &> /dev/null; then
     echo "ERROR: curl is not installed. Please install curl or use docker compose ps to check health status."
     exit 1
 fi
 
-# Check health endpoint
-if ! curl -f http://localhost:8080/health > /dev/null 2>&1; then
-    echo "ERROR: Services failed to start. Check logs:"
+# Health check with retry loop (similar to magpie-deploy.sh wait_for_healthy)
+max_attempts=30
+attempt=1
+health_url="http://localhost:8080/health"
+
+while [ $attempt -le $max_attempts ]; do
+    if curl -sf "$health_url" > /dev/null 2>&1; then
+        echo "Services are healthy (attempt $attempt/$max_attempts)"
+        break
+    fi
+    echo -n "."
+    sleep 2
+    attempt=$((attempt + 1))
+done
+
+# Check if we exhausted all attempts
+if [ $attempt -gt $max_attempts ]; then
+    echo ""
+    echo "ERROR: Services failed to become healthy after $max_attempts attempts. Check logs:"
     docker compose -f docker-compose.yml -f docker-compose.cidr-test.yml logs
     exit 1
 fi


### PR DESCRIPTION
## Summary

Replaces the fixed 5-second sleep in `scripts/run-cidr-tests.sh` with a robust retry loop that polls the health endpoint.

## Changes

- Replaced `sleep 5` with a retry loop (max 30 attempts, 2-second intervals)
- Moved curl availability check before the retry loop for better error reporting
- Added attempt counter to success message for debugging visibility
- Follow the pattern from `magpie-deploy.sh` `wait_for_healthy()` function
- Total maximum wait time increased from 5s to 60s for better reliability

## Motivation

The fixed sleep was unreliable because:
- Services might be ready in less than 5 seconds (wasted time)
- Services might take longer than 5 seconds on slower systems (false failures)

The retry loop provides:
- Early exit when services are ready (faster on fast systems)
- Extended wait time for slower environments (up to 60 seconds)
- Progress feedback via dots during wait
- Clear error messages if health check fails

## Testing

- Bash syntax validated with `bash -n`
- Shellcheck passed (info-level warnings only for trap function, expected)
- Follows established pattern from `magpie-deploy.sh` lines 816-835

## Related

Closes #389

---

Generated with Claude Code w/ Sonnet 4.5