### PR TITLE
Add feedback loop context for AI agents

### DIFF
--- a/.ai/context/feedback-loop.md
+++ b/.ai/context/feedback-loop.md
@@ -20,7 +20,7 @@ The loop MUST halt when:
 
 1. **Non-convergence**: Issues not decreasing round-over-round
 2. **Circular feedback**: Same issue 3+ times, or A->B->A reversion
-3. **Design decision**: Category C items present
+3. **Design decision**: comments flagged as design decisions (requiring human input)
 4. **Round limit**: 4 rounds completed
 
 ## Escalation Format

--- a/.ai/context/feedback-loop.md
+++ b/.ai/context/feedback-loop.md
@@ -1,0 +1,72 @@
+# PR Review Feedback Loop
+
+This file provides context for AI agents working within the PR review feedback loop.
+
+## Overview
+
+The feedback loop enables orchestrators to iterate on PR reviews autonomously while maintaining safeguards. This is an **opt-in** mode - humans must explicitly request it.
+
+## Key Parameters
+
+| Parameter | Value |
+|-----------|-------|
+| Round limit | 4 |
+| Scratch notes | `.ai/scratch/issue-{N}/` |
+| Escalation marker | `<!-- AWAITING_HUMAN: {reason} -->` |
+
+## Stop Conditions
+
+The loop MUST halt when:
+
+1. **Non-convergence**: Issues not decreasing round-over-round
+2. **Circular feedback**: Same issue 3+ times, or A->B->A reversion
+3. **Design decision**: Category C items present
+4. **Round limit**: 4 rounds completed
+
+## Escalation Format
+
+When stopping, post a PR comment with:
+
+```markdown
+<!-- AWAITING_HUMAN: {reason} -->
+
+## Agent Paused - Human Input Required
+
+**Reason**: {explanation}
+
+**Review history**:
+| Round | Comments | Addressed | Remaining |
+|-------|----------|-----------|-----------|
+
+**Blocking items**:
+- {issues}
+
+**What I need**: {question}
+
+(AI-generated via Claude Code w/ {model})
+```
+
+## External Reviews
+
+When humans or GitHub Copilot add reviews:
+- Treat as new round baseline
+- Re-fetch and categorize all comments
+- Track external vs agent comments separately
+
+## Scratch Notes Location
+
+```
+.ai/scratch/
+└── issue-{N}/
+    ├── orchestrator/
+    ├── developer/
+    └── reviewer/
+```
+
+See `docs/repo/patterns/ai-scratch-notes.md` for format details.
+
+## References
+
+- Full pattern: `docs/repo/patterns/review-feedback-loop.md`
+- GraphQL patterns: `docs/repo/patterns/github-graphql-patterns.md`
+- Universal rules: `docs/repo/universal-agent-rules.md` (Section 8)

--- a/.ai/context/pr-comment-handling.md
+++ b/.ai/context/pr-comment-handling.md
@@ -43,7 +43,7 @@ query {
       }
     }
   }
-}' --jq '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false and .isOutdated == false) | .comments.nodes[] | {id: .databaseId, path: .path, line: .line, body: .body}'
+}' --jq '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false and .isOutdated == false) | .comments.nodes[] | {comment_id: .databaseId, path: .path, line: .line, body: .body}'
 ```
 
 Replace `{N}` with the PR number.

--- a/.ai/context/pr-comment-handling.md
+++ b/.ai/context/pr-comment-handling.md
@@ -32,6 +32,7 @@ query {
           comments(first: 10) {
             nodes {
               id
+              databaseId
               body
               path
               line
@@ -42,7 +43,7 @@ query {
       }
     }
   }
-}' --jq '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false and .isOutdated == false) | .comments.nodes[] | {id: .id, path: .path, line: .line, body: .body}'
+}' --jq '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false and .isOutdated == false) | .comments.nodes[] | {id: .databaseId, path: .path, line: .line, body: .body}'
 ```
 
 Replace `{N}` with the PR number.

--- a/.ai/context/pr-comment-handling.md
+++ b/.ai/context/pr-comment-handling.md
@@ -98,3 +98,42 @@ Original comment: https://github.com/SouthwestCCDC/magpie/pull/{N}#discussion_r{
 ```
 
 Then reply to the original comment with the issue link.
+
+## Feedback Loop Integration
+
+When working within an orchestrator-managed feedback loop:
+
+### Before Starting
+
+1. Check for existing scratch notes:
+   ```bash
+   ls -la .ai/scratch/issue-{N}/
+   ```
+
+2. Read the most recent orchestrator notes to understand:
+   - Current round number
+   - Previous comments and resolutions
+   - Any patterns to watch for
+
+### During Round
+
+Track as you work:
+- Comments received this round
+- Comments addressed (with commit SHAs)
+- Any issues that seem recurring
+
+### After Round
+
+Update scratch notes in `.ai/scratch/issue-{N}/developer/{timestamp}.md`:
+- What was addressed
+- Any non-convergence patterns noticed
+- Recommendations for orchestrator
+
+### Flagging Patterns
+
+Alert the orchestrator if you notice:
+- **Recurring issues**: Same feedback appearing 3+ times
+- **Circular feedback**: "Change A to B" followed by "Change B to A"
+- **Non-convergence**: More issues appearing than being resolved
+
+Include these observations in your summary to help the orchestrator decide whether to continue or escalate.

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ data/
 
 # Claude Code hook logs
 .claude/logs/
+
+# AI agent scratch notes (not committed)
+.ai/scratch/


### PR DESCRIPTION
## Summary

- Add `feedback-loop.md` context file for AI agents working in feedback loops
- Update `pr-comment-handling.md` with feedback loop integration section
- Add `.ai/scratch/` to gitignore for agent scratch notes

## Context

Part of the PR review feedback loop system that enables orchestrator-driven review iteration with human oversight. See the workspace `docs/repo/patterns/review-feedback-loop.md` for the full pattern documentation.

## Test plan

- [ ] Verify `.ai/scratch/` is ignored by git
- [ ] Context files are readable by AI agents

(AI-generated via Claude Code w/ Opus 4.5)