### PR TITLE
Add S3/AWS environment variables to docker-compose.prod.yml

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -78,6 +78,13 @@ services:
       # IMPORTANT: Keep debug mode disabled in production. Enabling it exposes
       # detailed error messages and stack traces that could leak sensitive info.
       - MAGPIE_DEBUG=false
+      # S3/AWS configuration for magpie-ctl sync command
+      - MAGPIE_S3_BUCKET=${MAGPIE_S3_BUCKET:-}
+      - MAGPIE_S3_PREFIX=${MAGPIE_S3_PREFIX:-}
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-}
+      - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN:-}
+      - AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-}
     expose:
       - "8000"  # Internal only - accessed via Caddy
     restart: unless-stopped


### PR DESCRIPTION
## Summary

- Add S3/AWS environment variables to docker-compose.prod.yml magpie service
- Aligns production compose file with dev compose file from PR #374

## Context

PR #374 added these environment variables to `docker-compose.yml` for the dev environment but missed `docker-compose.prod.yml`. This caused `magpie-ctl sync` to fail in production deployments.

## Changes

Added the following environment variables to the magpie service in docker-compose.prod.yml:
- `MAGPIE_S3_BUCKET`
- `MAGPIE_S3_PREFIX`
- `AWS_ACCESS_KEY_ID`
- `AWS_SECRET_ACCESS_KEY`
- `AWS_SESSION_TOKEN`
- `AWS_DEFAULT_REGION`

All variables use the same pattern as the dev compose file: `${VAR_NAME:-}` to provide empty defaults.

## Test Plan

- [x] Linting passes (`uv run ruff check src/ tests/`)
- [x] Format check passes (`uv run ruff format --check src/ tests/`)
- [x] Unit tests pass (`uv run pytest tests/unit/ -x`)
- [ ] CI checks pass

## Related

- Fixes #378
- Related to PR #374 (original addition to dev compose file)
- Related to #232 (broader compose file consolidation tech debt)

Generated with [Claude Code](https://claude.com/claude-code) w/ Sonnet 4.5