### PR TITLE
feat(api,cli): add version to health endpoint and --server flag

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -6,7 +6,7 @@
 ```bash
 curl https://magpie.example.com/health
 ```
-Returns `{"status": "ok"}` if operational. Used by Docker health checks and load balancers.
+Returns `{"status": "ok", "version": "x.y.z"}` if operational. Used by Docker health checks and load balancers.
 
 **Admin status endpoint** (`GET /api/v1/status`, admin token required):
 ```json

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -137,10 +137,12 @@ magpie info images/ubuntu:@a1b2c3d4           # View metadata
 magpie amend images/ubuntu:latest --source-uri https://github.com/example/repo  # Update metadata
 ```
 
-**Server status:**
+**Server status and version:**
 ```bash
-magpie status              # Check connectivity and health
-magpie url images/ubuntu   # Get download URL for scripting
+magpie status                    # Check connectivity and health
+magpie version                   # Show client version
+magpie version --server-version  # Show both client and server versions
+magpie url images/ubuntu         # Get download URL for scripting
 ```
 
 ## Server Initialization

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -139,9 +139,9 @@ magpie amend images/ubuntu:latest --source-uri https://github.com/example/repo  
 
 **Server status and version:**
 ```bash
-magpie status                    # Check connectivity and health
+magpie status                    # Check server status/health (requires admin token)
 magpie version                   # Show client version
-magpie version --server-version  # Show both client and server versions
+magpie version --server-version  # Check connectivity and show both client and server versions
 magpie url images/ubuntu         # Get download URL for scripting
 ```
 

--- a/src/magpie/cli/__init__.py
+++ b/src/magpie/cli/__init__.py
@@ -146,40 +146,41 @@ def cli(
 
 @cli.command()
 @click.option(
-    "--server",
+    "--server-version",
     is_flag=True,
     default=False,
     help="Show server version in addition to client version.",
 )
 @pass_context
-def version(ctx: CLIContext, server: bool) -> None:
+def version(ctx: CLIContext, server_version: bool) -> None:
     """Show version.
 
     Exit code behavior:
-    - Without --server flag: Always exits 0 (shows client version only)
-    - With --server flag: Exits 1 if server unreachable (explicit server version request)
+    - Without --server-version flag: Always exits 0 (shows client version only)
+    - With --server-version flag: Exits 1 if server unreachable (explicit server version request)
 
-    This design treats --server as a strict requirement: if the user explicitly requests
+    This design treats --server-version as a strict requirement: if the user explicitly requests
     server version and it cannot be obtained, the command fails to indicate the requirement
     was not met. This is useful for automation/scripting where server connectivity is critical.
     """
     from magpie import __version__
 
-    if not server:
+    if not server_version:
         click.echo(f"magpie {__version__}")
         return
 
     # Query server version from /health endpoint
     try:
-        client = ctx.get_client()
-        # /health is a public endpoint, no auth needed, but we use the client for consistency
-        response = client.get("/health")
-        response.raise_for_status()
-        data = response.json()
-        server_version = data.get("version", "unknown")
-        click.echo(f"magpie {__version__} (server: {server_version})")
+        # /health is a public endpoint, so we create an unauthenticated client
+        # to avoid unnecessarily sending tokens
+        with get_client(ctx.server, token=None, timeout=ctx.timeout, ca_cert=ctx.ca_cert) as client:
+            response = client.get("/health")
+            response.raise_for_status()
+            data = response.json()
+            server_ver = data.get("version", "unknown")
+            click.echo(f"magpie {__version__} (server: {server_ver})")
     except Exception as e:
-        # Exit 1 when --server flag used but server unreachable (design decision)
+        # Exit 1 when --server-version flag used but server unreachable (design decision)
         # See issue #343 for rationale
         click.echo(f"magpie {__version__} (server: error - {e})", err=True)
         raise click.Abort() from e

--- a/src/magpie/cli/__init__.py
+++ b/src/magpie/cli/__init__.py
@@ -153,7 +153,16 @@ def cli(
 )
 @pass_context
 def version(ctx: CLIContext, server: bool) -> None:
-    """Show version."""
+    """Show version.
+
+    Exit code behavior:
+    - Without --server flag: Always exits 0 (shows client version only)
+    - With --server flag: Exits 1 if server unreachable (explicit server version request)
+
+    This design treats --server as a strict requirement: if the user explicitly requests
+    server version and it cannot be obtained, the command fails to indicate the requirement
+    was not met. This is useful for automation/scripting where server connectivity is critical.
+    """
     from magpie import __version__
 
     if not server:
@@ -170,6 +179,8 @@ def version(ctx: CLIContext, server: bool) -> None:
         server_version = data.get("version", "unknown")
         click.echo(f"magpie {__version__} (server: {server_version})")
     except Exception as e:
+        # Exit 1 when --server flag used but server unreachable (design decision)
+        # See issue #343 for rationale
         click.echo(f"magpie {__version__} (server: error - {e})", err=True)
         raise click.Abort() from e
 

--- a/src/magpie/cli/__init__.py
+++ b/src/magpie/cli/__init__.py
@@ -187,8 +187,6 @@ def version(ctx: CLIContext, server_version: bool) -> None:
     except Exception as e:
         # Exit 1 when --server-version flag used but server unreachable (design decision)
         # See issue #343 for rationale
-        # Print version with error message before raising exception
-        click.echo(f"magpie {__version__} (server: error - {e})", err=True)
         msg = f"Failed to fetch server version: {e}"
         raise click.ClickException(msg) from e
 

--- a/src/magpie/cli/__init__.py
+++ b/src/magpie/cli/__init__.py
@@ -145,11 +145,33 @@ def cli(
 
 
 @cli.command()
-def version() -> None:
+@click.option(
+    "--server",
+    is_flag=True,
+    default=False,
+    help="Show server version in addition to client version.",
+)
+@pass_context
+def version(ctx: CLIContext, server: bool) -> None:
     """Show version."""
     from magpie import __version__
 
-    click.echo(f"magpie {__version__}")
+    if not server:
+        click.echo(f"magpie {__version__}")
+        return
+
+    # Query server version from /health endpoint
+    try:
+        client = ctx.get_client()
+        # /health is a public endpoint, no auth needed, but we use the client for consistency
+        response = client.get("/health")
+        response.raise_for_status()
+        data = response.json()
+        server_version = data.get("version", "unknown")
+        click.echo(f"magpie {__version__} (server: {server_version})")
+    except Exception as e:
+        click.echo(f"magpie {__version__} (server: error - {e})", err=True)
+        raise click.Abort() from e
 
 
 # Register subcommands

--- a/src/magpie/cli/__init__.py
+++ b/src/magpie/cli/__init__.py
@@ -169,6 +169,11 @@ def version(ctx: CLIContext, server_version: bool) -> None:
         click.echo(f"magpie {__version__}")
         return
 
+    # Check server configuration when --server-version flag is used
+    if not ctx.server:
+        msg = "No server configured. Use --server or set MAGPIE_SERVER."
+        raise click.ClickException(msg)
+
     # Query server version from /health endpoint
     try:
         # /health is a public endpoint, so we create an unauthenticated client
@@ -182,8 +187,10 @@ def version(ctx: CLIContext, server_version: bool) -> None:
     except Exception as e:
         # Exit 1 when --server-version flag used but server unreachable (design decision)
         # See issue #343 for rationale
+        # Print version with error message before raising exception
         click.echo(f"magpie {__version__} (server: error - {e})", err=True)
-        raise click.Abort() from e
+        msg = f"Failed to fetch server version: {e}"
+        raise click.ClickException(msg) from e
 
 
 # Register subcommands

--- a/src/magpie/server/app.py
+++ b/src/magpie/server/app.py
@@ -6,6 +6,7 @@ from contextlib import asynccontextmanager
 from typing import AsyncIterator
 
 from fastapi import FastAPI
+from pydantic import BaseModel
 
 from magpie import __version__
 from magpie.config import get_settings
@@ -54,7 +55,14 @@ app.include_router(gc_router)
 app.include_router(status_router)
 
 
+class HealthResponse(BaseModel):
+    """Response model for health check endpoint."""
+
+    status: str
+    version: str
+
+
 @app.get("/health")
-async def health() -> dict[str, str]:
+async def health() -> HealthResponse:
     """Health check endpoint."""
-    return {"status": "ok", "version": __version__}
+    return HealthResponse(status="ok", version=__version__)

--- a/src/magpie/server/app.py
+++ b/src/magpie/server/app.py
@@ -57,4 +57,4 @@ app.include_router(status_router)
 @app.get("/health")
 async def health() -> dict[str, str]:
     """Health check endpoint."""
-    return {"status": "ok"}
+    return {"status": "ok", "version": __version__}

--- a/tests/e2e/test_routing.py
+++ b/tests/e2e/test_routing.py
@@ -135,6 +135,7 @@ class TestPublicRoutes:
         # Verify it returns valid JSON health status
         data = response.json()
         assert "status" in data
+        assert "version" in data
 
     def test_public_artifacts_path_is_public(
         self,

--- a/tests/integration/test_cli_version.py
+++ b/tests/integration/test_cli_version.py
@@ -57,9 +57,8 @@ class TestVersionCommand:
 
         # Should exit with error
         assert result.exit_code == 1
-        # Should show client version and error message
-        assert f"magpie {__version__}" in result.output
-        assert "error" in result.output.lower()
+        # Should show error message with details
+        assert "Failed to fetch server version" in result.output
         assert "Connection refused" in result.output
 
     def test_version_with_server_flag_handles_missing_version_field(
@@ -85,3 +84,15 @@ class TestVersionCommand:
         assert result.exit_code == 0
         assert f"magpie {__version__}" in result.output
         assert "server: unknown" in result.output
+
+    def test_version_with_server_flag_no_server_configured(
+        self, cli_runner_no_config: CliRunner
+    ) -> None:
+        """Version command with --server-version flag fails when no server is configured."""
+        result = cli_runner_no_config.invoke(cli, ["version", "--server-version"])
+
+        # Should exit with error
+        assert result.exit_code == 1
+        # Should show error message about missing server configuration
+        assert "No server configured" in result.output
+        assert "MAGPIE_SERVER" in result.output

--- a/tests/integration/test_cli_version.py
+++ b/tests/integration/test_cli_version.py
@@ -1,4 +1,4 @@
-"""Integration tests for CLI version command with --server flag."""
+"""Integration tests for CLI version command with --server-version flag."""
 
 from __future__ import annotations
 
@@ -15,7 +15,7 @@ class TestVersionCommand:
     """Tests for magpie version command."""
 
     def test_version_shows_client_version(self, cli_runner: CliRunner) -> None:
-        """Version command without --server shows client version only."""
+        """Version command without --server-version shows client version only."""
         result = cli_runner.invoke(cli, ["version"])
 
         assert result.exit_code == 0
@@ -26,13 +26,13 @@ class TestVersionCommand:
     def test_version_with_server_flag_shows_both_versions(
         self, cli_runner: CliRunner, api_client: TestClient
     ) -> None:
-        """Version command with --server flag shows both client and server versions."""
+        """Version command with --server-version flag shows both client and server versions."""
         with patch("magpie.cli.get_client") as mock_get_client:
             mock_get_client.return_value = api_client
 
             result = cli_runner.invoke(
                 cli,
-                ["--server", "http://test", "version", "--server"],
+                ["--server", "http://test", "version", "--server-version"],
             )
 
         assert result.exit_code == 0
@@ -41,16 +41,18 @@ class TestVersionCommand:
         assert f"server: {__version__}" in result.output
 
     def test_version_with_server_flag_handles_connection_error(self, cli_runner: CliRunner) -> None:
-        """Version command with --server flag handles connection errors gracefully."""
+        """Version command with --server-version flag handles connection errors gracefully."""
         mock_client = Mock()
         mock_client.get.side_effect = Exception("Connection refused")
+        mock_client.__enter__ = Mock(return_value=mock_client)
+        mock_client.__exit__ = Mock(return_value=False)
 
         with patch("magpie.cli.get_client") as mock_get_client:
             mock_get_client.return_value = mock_client
 
             result = cli_runner.invoke(
                 cli,
-                ["--server", "http://test", "version", "--server"],
+                ["--server", "http://test", "version", "--server-version"],
             )
 
         # Should exit with error
@@ -63,19 +65,21 @@ class TestVersionCommand:
     def test_version_with_server_flag_handles_missing_version_field(
         self, cli_runner: CliRunner
     ) -> None:
-        """Version command with --server flag handles missing version field."""
+        """Version command with --server-version flag handles missing version field."""
         mock_client = Mock()
         mock_response = Mock()
         mock_response.raise_for_status = Mock()
         mock_response.json.return_value = {"status": "ok"}  # No version field
         mock_client.get.return_value = mock_response
+        mock_client.__enter__ = Mock(return_value=mock_client)
+        mock_client.__exit__ = Mock(return_value=False)
 
         with patch("magpie.cli.get_client") as mock_get_client:
             mock_get_client.return_value = mock_client
 
             result = cli_runner.invoke(
                 cli,
-                ["--server", "http://test", "version", "--server"],
+                ["--server", "http://test", "version", "--server-version"],
             )
 
         assert result.exit_code == 0

--- a/tests/integration/test_cli_version.py
+++ b/tests/integration/test_cli_version.py
@@ -1,0 +1,83 @@
+"""Integration tests for CLI version command with --server flag."""
+
+from __future__ import annotations
+
+from unittest.mock import Mock, patch
+
+from click.testing import CliRunner
+from fastapi.testclient import TestClient
+
+from magpie import __version__
+from magpie.cli import cli
+
+
+class TestVersionCommand:
+    """Tests for magpie version command."""
+
+    def test_version_shows_client_version(self, cli_runner: CliRunner) -> None:
+        """Version command without --server shows client version only."""
+        result = cli_runner.invoke(cli, ["version"])
+
+        assert result.exit_code == 0
+        assert f"magpie {__version__}" in result.output
+        # Should NOT include server version
+        assert "server:" not in result.output
+
+    def test_version_with_server_flag_shows_both_versions(
+        self, cli_runner: CliRunner, api_client: TestClient
+    ) -> None:
+        """Version command with --server flag shows both client and server versions."""
+        with patch("magpie.cli.get_client") as mock_get_client:
+            mock_get_client.return_value = api_client
+
+            result = cli_runner.invoke(
+                cli,
+                ["--server", "http://test", "version", "--server"],
+            )
+
+        assert result.exit_code == 0
+        assert f"magpie {__version__}" in result.output
+        assert "server:" in result.output
+        assert f"server: {__version__}" in result.output
+
+    def test_version_with_server_flag_handles_connection_error(self, cli_runner: CliRunner) -> None:
+        """Version command with --server flag handles connection errors gracefully."""
+        mock_client = Mock()
+        mock_client.get.side_effect = Exception("Connection refused")
+
+        with patch("magpie.cli.get_client") as mock_get_client:
+            mock_get_client.return_value = mock_client
+
+            result = cli_runner.invoke(
+                cli,
+                ["--server", "http://test", "version", "--server"],
+            )
+
+        # Should exit with error
+        assert result.exit_code == 1
+        # Should show client version and error message
+        assert f"magpie {__version__}" in result.output
+        assert "error" in result.output.lower()
+        assert "Connection refused" in result.output
+
+    def test_version_with_server_flag_handles_missing_version_field(
+        self, cli_runner: CliRunner
+    ) -> None:
+        """Version command with --server flag handles missing version field."""
+        mock_client = Mock()
+        mock_response = Mock()
+        mock_response.raise_for_status = Mock()
+        mock_response.json.return_value = {"status": "ok"}  # No version field
+        mock_client.get.return_value = mock_response
+
+        with patch("magpie.cli.get_client") as mock_get_client:
+            mock_get_client.return_value = mock_client
+
+            result = cli_runner.invoke(
+                cli,
+                ["--server", "http://test", "version", "--server"],
+            )
+
+        assert result.exit_code == 0
+        assert f"magpie {__version__}" in result.output
+        assert "server: unknown" in result.output

--- a/tests/unit/test_health_endpoint.py
+++ b/tests/unit/test_health_endpoint.py
@@ -1,0 +1,42 @@
+"""Tests for /health endpoint version field."""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from magpie import __version__
+from magpie.server.app import app
+
+
+class TestHealthEndpoint:
+    """Tests for /health endpoint."""
+
+    def test_health_returns_ok_status(self) -> None:
+        """Health endpoint returns status: ok."""
+        client = TestClient(app)
+        response = client.get("/health")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "ok"
+
+    def test_health_returns_version(self) -> None:
+        """Health endpoint returns version field."""
+        client = TestClient(app)
+        response = client.get("/health")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "version" in data
+        assert data["version"] == __version__
+
+    def test_health_endpoint_is_public(self) -> None:
+        """Health endpoint does not require authentication."""
+        client = TestClient(app)
+        # No auth headers
+        response = client.get("/health")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "ok"
+        assert "version" in data


### PR DESCRIPTION
## Summary

Implements issue #343 to allow clients to query the server version without admin authentication.

- Added `version` field to `/health` endpoint response with Pydantic model
- Added `--server-version` flag to `magpie version` command to query server version
- Server version is queried from the public `/health` endpoint (no authentication required)
- Gracefully handles connection errors, missing version field, and missing server configuration

## Changes

### API Changes
- `/health` endpoint now returns `HealthResponse` model with `{"status": "ok", "version": "x.y.z"}` instead of untyped dict

### CLI Changes
- `magpie version` - shows client version only (existing behavior)
- `magpie version --server-version` - shows both client and server versions

Example output:
```bash
$ magpie version
magpie 0.1.0

$ magpie version --server-version
magpie 0.1.0 (server: 0.1.0)
```

## Test Coverage

- Unit tests for health endpoint version field
- Integration tests for version command with --server-version flag
- Integration test for missing server configuration scenario
- E2E tests updated to verify version field presence
- Error handling tests for connection failures and missing version field

## Test Plan

- [x] Unit tests pass
- [x] Integration tests pass
- [x] Linting passes
- [x] Formatting passes
- [ ] E2E tests pass (will run in CI)

Closes #343

---
(AI-generated via Claude Code w/ Sonnet 4.5)