### PR TITLE
chore: bump version to 0.1.1

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -21,7 +21,7 @@ For Authentik setup, see [authentik-setup.md](authentik-setup.md). For Ansible, 
 
 ```bash
 # With uv (recommended)
-uv pip install git+https://github.com/SouthwestCCDC/magpie.git@v0.1.0
+uv pip install git+https://github.com/SouthwestCCDC/magpie.git@v0.1.1
 ```
 
 ### Configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "magpie"
-version = "0.1.0"
+version = "0.1.1"
 description = "Content-addressed artifact storage with mutable tags"
 authors = [{ name = "SWCCDC Team" }]
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -382,7 +382,7 @@ wheels = [
 
 [[package]]
 name = "magpie"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

Bump version from 0.1.0 to 0.1.1 in preparation for the v0.1.1 release tag.

This PR updates:
- `pyproject.toml`: version field
- `docs/user-guide.md`: installation example command
- `uv.lock`: regenerated with new version

The v0.1.1 milestone is complete and this version bump is needed before creating the release tag. This will also serve as a test to verify that the release CI correctly sets the hardcoded version in the installer.

## Test plan

- [ ] Verify version is 0.1.1 in all modified files
- [ ] CI passes (lint, tests)
- [ ] After merge and tag, verify release CI sets correct version in installer

Generated with Claude Code w/ Sonnet 4.5