### PR TITLE
chore: set version to 0.1.1rc1 for release candidate

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -21,7 +21,7 @@ For Authentik setup, see [authentik-setup.md](authentik-setup.md). For Ansible, 
 
 ```bash
 # With uv (recommended)
-uv pip install git+https://github.com/SouthwestCCDC/magpie.git@v0.1.1
+uv pip install git+https://github.com/SouthwestCCDC/magpie.git@v0.1.1rc1
 ```
 
 ### Configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "magpie"
-version = "0.1.1"
+version = "0.1.1rc1"
 description = "Content-addressed artifact storage with mutable tags"
 authors = [{ name = "SWCCDC Team" }]
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -382,7 +382,7 @@ wheels = [
 
 [[package]]
 name = "magpie"
-version = "0.1.1"
+version = "0.1.1rc1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

- Update version in `pyproject.toml` to `0.1.1rc1` (PEP 440 release candidate format)
- Update installation example in `docs/user-guide.md` to reference `v0.1.1rc1` tag
- Regenerate `uv.lock` with updated version metadata

## Context

This release candidate will be tagged as `v0.1.1rc1` (no hyphen, per PEP 440). The version suffix ensures the installed package identifies itself correctly as a pre-release version.

## Test Plan

- [x] All linting passes (`just lint`)
- [x] All unit tests pass (`just test-unit`)
- [x] Version correctly shows as `0.1.1rc1` in installed package metadata

---

Generated with [Claude Code](https://claude.com/claude-code) (Sonnet 4.5)