### PR TITLE
chore: set version to 0.1.1-rc2 for release candidate

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "magpie"
-version = "0.1.1rc1"
+version = "0.1.1-rc2"
 description = "Content-addressed artifact storage with mutable tags"
 authors = [{ name = "SWCCDC Team" }]
 readme = "README.md"


### PR DESCRIPTION
## Summary

Bump version to 0.1.1-rc2 for the next release candidate.

## Changes

- Update pyproject.toml version from `0.1.1rc1` to `0.1.1-rc2`

Note: Using hyphen format (`-rc2`) for semver compliance. See #436 for versioning policy.

## After Merge

Once merged, tag the merge commit:
```bash
git fetch origin default
git tag v0.1.1-rc2 origin/default
git push origin v0.1.1-rc2
```

---

Generated with Claude Code w/ Opus 4.5