### PR TITLE
fix(cli): Handle network errors gracefully with distinct exit codes

### DIFF
--- a/src/magpie/cli/__init__.py
+++ b/src/magpie/cli/__init__.py
@@ -9,6 +9,7 @@ import click
 
 from magpie.cli.client import get_client
 from magpie.cli.config import get_ca_cert, get_server, get_timeout, get_token
+from magpie.cli.errors import with_network_error_handling
 from magpie.cli.formatting import OutputFormat
 from magpie.config import get_settings
 
@@ -152,13 +153,18 @@ def cli(
     help="Show server version in addition to client version.",
 )
 @pass_context
+@with_network_error_handling
 @sentry_wrapper
 def version(ctx: CLIContext, server_version: bool) -> None:
     """Show version.
 
     Exit code behavior:
     - Without --server-version flag: Always exits 0 (shows client version only)
-    - With --server-version flag: Exits 1 if server unreachable (explicit server version request)
+    - With --server-version flag: Exits with appropriate error code if server unreachable
+
+    Network errors (connection failures, timeouts, etc.) are handled by the
+    with_network_error_handling decorator, which provides consistent error messages
+    and exit codes (exit code 2) across all CLI commands.
 
     This design treats --server-version as a strict requirement: if the user explicitly requests
     server version and it cannot be obtained, the command fails to indicate the requirement
@@ -176,20 +182,15 @@ def version(ctx: CLIContext, server_version: bool) -> None:
         raise click.ClickException(msg)
 
     # Query server version from /health endpoint
-    try:
-        # /health is a public endpoint, so we create an unauthenticated client
-        # to avoid unnecessarily sending tokens
-        with get_client(ctx.server, token=None, timeout=ctx.timeout, ca_cert=ctx.ca_cert) as client:
-            response = client.get("/health")
-            response.raise_for_status()
-            data = response.json()
-            server_ver = data.get("version", "unknown")
-            click.echo(f"magpie {__version__} (server: {server_ver})")
-    except Exception as e:
-        # Exit 1 when --server-version flag used but server unreachable (design decision)
-        # See issue #343 for rationale
-        msg = f"Failed to fetch server version: {e}"
-        raise click.ClickException(msg) from e
+    # Network errors will be caught by @with_network_error_handling decorator
+    # /health is a public endpoint, so we create an unauthenticated client
+    # to avoid unnecessarily sending tokens
+    with get_client(ctx.server, token=None, timeout=ctx.timeout, ca_cert=ctx.ca_cert) as client:
+        response = client.get("/health")
+        response.raise_for_status()
+        data = response.json()
+        server_ver = data.get("version", "unknown")
+        click.echo(f"magpie {__version__} (server: {server_ver})")
 
 
 # Register subcommands

--- a/src/magpie/cli/__init__.py
+++ b/src/magpie/cli/__init__.py
@@ -9,7 +9,7 @@ import click
 
 from magpie.cli.client import get_client
 from magpie.cli.config import get_ca_cert, get_server, get_timeout, get_token
-from magpie.cli.errors import with_network_error_handling
+from magpie.cli.errors import handle_response_error, with_network_error_handling
 from magpie.cli.formatting import OutputFormat
 from magpie.config import get_settings
 
@@ -187,7 +187,10 @@ def version(ctx: CLIContext, server_version: bool) -> None:
     # to avoid unnecessarily sending tokens
     with get_client(ctx.server, token=None, timeout=ctx.timeout, ca_cert=ctx.ca_cert) as client:
         response = client.get("/health")
-        response.raise_for_status()
+
+        if response.status_code != 200:
+            handle_response_error(response, "Version check")
+
         data = response.json()
         server_ver = data.get("version", "unknown")
         click.echo(f"magpie {__version__} (server: {server_ver})")

--- a/src/magpie/cli/__init__.py
+++ b/src/magpie/cli/__init__.py
@@ -152,6 +152,7 @@ def cli(
     help="Show server version in addition to client version.",
 )
 @pass_context
+@sentry_wrapper
 def version(ctx: CLIContext, server_version: bool) -> None:
     """Show version.
 

--- a/src/magpie/cli/commands/amend.py
+++ b/src/magpie/cli/commands/amend.py
@@ -6,7 +6,7 @@ import click
 
 from magpie.cli import CLIContext
 from magpie.cli.commands.parse import ParseError, parse_artifact_ref
-from magpie.cli.errors import handle_response_error
+from magpie.cli.errors import handle_response_error, with_network_error_handling
 from magpie.cli.formatting import (
     CommandResult,
     ErrorCode,
@@ -20,6 +20,7 @@ from magpie.cli.formatting import (
 @click.argument("artifact_ref")
 @click.option("--source-uri", help="Update source URI (use empty string to clear).")
 @click.pass_obj
+@with_network_error_handling
 def amend(ctx: CLIContext, artifact_ref: str, source_uri: str | None) -> None:
     """Amend metadata for an artifact.
 

--- a/src/magpie/cli/commands/flush_tag.py
+++ b/src/magpie/cli/commands/flush_tag.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import click
 
 from magpie.cli import CLIContext
-from magpie.cli.errors import handle_response_error
+from magpie.cli.errors import handle_response_error, with_network_error_handling
 from magpie.cli.formatting import (
     CommandResult,
     ErrorCode,
@@ -41,6 +41,7 @@ PROTECTED_TAGS = frozenset({"latest", "stable", "production", "prod", "release"}
     help="Required to flush protected tags (latest, stable, production, etc).",
 )
 @click.pass_obj
+@with_network_error_handling
 def flush_tag(ctx: CLIContext, tag_name: str, dry_run: bool, yes: bool, force: bool) -> None:
     """Remove a tag from all artifacts globally.
 

--- a/src/magpie/cli/commands/gc.py
+++ b/src/magpie/cli/commands/gc.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import click
 
 from magpie.cli import CLIContext
-from magpie.cli.errors import handle_response_error, mask_token
+from magpie.cli.errors import handle_response_error, mask_token, with_network_error_handling
 from magpie.cli.formatting import (
     CommandResult,
     ErrorCode,
@@ -24,6 +24,7 @@ from magpie.utils.formatting import format_size
     help="Preview what would be deleted without making changes.",
 )
 @click.pass_obj
+@with_network_error_handling
 def gc(ctx: CLIContext, dry_run: bool) -> None:
     """Trigger remote garbage collection (requires admin token).
 

--- a/src/magpie/cli/commands/get.py
+++ b/src/magpie/cli/commands/get.py
@@ -9,7 +9,7 @@ import click
 
 from magpie.cli import CLIContext
 from magpie.cli.commands.parse import ParseError, parse_artifact_ref
-from magpie.cli.errors import handle_response_error
+from magpie.cli.errors import handle_response_error, with_network_error_handling
 from magpie.cli.formatting import (
     CommandResult,
     ErrorCode,
@@ -33,6 +33,7 @@ from magpie.storage.hash import compute_hash
     help="Overwrite existing output file without prompting, and re-download even if local hash matches.",
 )
 @click.pass_obj
+@with_network_error_handling
 def get(
     ctx: CLIContext,
     artifact_ref: str,

--- a/src/magpie/cli/commands/info.py
+++ b/src/magpie/cli/commands/info.py
@@ -6,7 +6,7 @@ import click
 
 from magpie.cli import CLIContext
 from magpie.cli.commands.parse import ParseError, parse_artifact_ref
-from magpie.cli.errors import handle_response_error
+from magpie.cli.errors import handle_response_error, with_network_error_handling
 from magpie.cli.formatting import (
     CommandResult,
     ErrorCode,
@@ -19,6 +19,7 @@ from magpie.cli.formatting import (
 @click.command()
 @click.argument("artifact_ref")
 @click.pass_obj
+@with_network_error_handling
 def info(ctx: CLIContext, artifact_ref: str) -> None:
     """Show detailed metadata for an artifact.
 

--- a/src/magpie/cli/commands/ls.py
+++ b/src/magpie/cli/commands/ls.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 
 from magpie.cli import CLIContext
 from magpie.cli.commands.parse import ParseError, parse_artifact_path
-from magpie.cli.errors import handle_response_error
+from magpie.cli.errors import handle_response_error, with_network_error_handling
 from magpie.cli.formatting import (
     CommandResult,
     ErrorCode,
@@ -30,6 +30,7 @@ from magpie.cli.formatting import (
     help="List artifacts recursively (default: only current level)",
 )
 @click.pass_obj
+@with_network_error_handling
 def ls(ctx: CLIContext, artifact_path: str | None, recursive: bool) -> None:
     """List artifacts or versions.
 

--- a/src/magpie/cli/commands/push.py
+++ b/src/magpie/cli/commands/push.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from rich.progress import Progress, TaskID
 
 from magpie.cli import CLIContext
-from magpie.cli.errors import handle_response_error
+from magpie.cli.errors import handle_response_error, with_network_error_handling
 from magpie.cli.formatting import (
     CommandResult,
     ErrorCode,
@@ -105,6 +105,7 @@ def _show_processing_status(
 @click.option("--no-latest", is_flag=True, help="Don't auto-tag as latest.")
 @click.option("--quiet", "-q", is_flag=True, help="Suppress progress output.")
 @click.pass_obj
+@with_network_error_handling
 def push(
     ctx: CLIContext,
     file: Path,

--- a/src/magpie/cli/commands/status.py
+++ b/src/magpie/cli/commands/status.py
@@ -7,7 +7,7 @@ import json
 import click
 
 from magpie.cli import CLIContext
-from magpie.cli.errors import handle_http_error
+from magpie.cli.errors import handle_http_error, with_network_error_handling
 from magpie.cli.formatting import (
     CommandResult,
     ErrorCode,
@@ -21,6 +21,7 @@ from magpie.utils.formatting import format_size
 
 @click.command()
 @click.pass_obj
+@with_network_error_handling
 def status(ctx: CLIContext) -> None:
     """Check server health, connectivity, and status (admin only).
 

--- a/src/magpie/cli/commands/status.py
+++ b/src/magpie/cli/commands/status.py
@@ -2,16 +2,13 @@
 
 from __future__ import annotations
 
-import json
-
 import click
 
 from magpie.cli import CLIContext
-from magpie.cli.errors import handle_http_error, with_network_error_handling
+from magpie.cli.errors import handle_response_error, with_network_error_handling
 from magpie.cli.formatting import (
     CommandResult,
     ErrorCode,
-    http_status_to_error_code,
     is_json_output,
     output_error,
     output_result,
@@ -55,14 +52,7 @@ def status(ctx: CLIContext) -> None:
         response = client.get("/api/v1/status")
 
         if response.status_code != 200:
-            if is_json_output():
-                try:
-                    detail = response.json().get("detail", response.text)
-                except (json.JSONDecodeError, ValueError, KeyError):
-                    detail = response.text
-                output_error(http_status_to_error_code(response.status_code), detail)
-                return
-            handle_http_error(response, "Status check", ctx.token)
+            handle_response_error(response, "Status check", ctx.token)
 
         data = response.json()
 

--- a/src/magpie/cli/commands/status.py
+++ b/src/magpie/cli/commands/status.py
@@ -52,14 +52,7 @@ def status(ctx: CLIContext) -> None:
         if ctx.debug:
             click.echo(f"Checking status of {ctx.server}...", err=True)
 
-        try:
-            response = client.get("/api/v1/status")
-        except Exception as e:
-            msg = f"Failed to connect to server: {e}"
-            if is_json_output():
-                output_error(ErrorCode.NETWORK_ERROR, msg)
-                return
-            raise click.ClickException(msg)
+        response = client.get("/api/v1/status")
 
         if response.status_code != 200:
             if is_json_output():

--- a/src/magpie/cli/commands/tag.py
+++ b/src/magpie/cli/commands/tag.py
@@ -6,7 +6,7 @@ import click
 
 from magpie.cli import CLIContext
 from magpie.cli.commands.parse import ParseError, parse_artifact_ref
-from magpie.cli.errors import handle_response_error
+from magpie.cli.errors import handle_response_error, with_network_error_handling
 from magpie.cli.formatting import (
     CommandResult,
     ErrorCode,
@@ -20,6 +20,7 @@ from magpie.cli.formatting import (
 @click.argument("artifact_ref")
 @click.option("--as", "tag_name", required=True, help="Tag name to create.")
 @click.pass_obj
+@with_network_error_handling
 def tag(ctx: CLIContext, artifact_ref: str, tag_name: str) -> None:
     """Create a tag pointing to an artifact version.
 

--- a/src/magpie/cli/commands/token.py
+++ b/src/magpie/cli/commands/token.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import click
 
 from magpie.cli import CLIContext
-from magpie.cli.errors import handle_response_error
+from magpie.cli.errors import handle_response_error, with_network_error_handling
 from magpie.cli.formatting import (
     CommandResult,
     ErrorCode,
@@ -32,6 +32,7 @@ def token() -> None:
     help="Token scope (default: read).",
 )
 @click.pass_obj
+@with_network_error_handling
 def create_token(ctx: CLIContext, name: str, scope: str) -> None:
     """Create a new authentication token.
 
@@ -91,6 +92,7 @@ def create_token(ctx: CLIContext, name: str, scope: str) -> None:
 @token.command(name="rotate")
 @click.argument("name")
 @click.pass_obj
+@with_network_error_handling
 def rotate_token(ctx: CLIContext, name: str) -> None:
     """Rotate an authentication token.
 

--- a/src/magpie/cli/commands/untag.py
+++ b/src/magpie/cli/commands/untag.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import click
 
 from magpie.cli import CLIContext
-from magpie.cli.errors import handle_response_error
+from magpie.cli.errors import handle_response_error, with_network_error_handling
 from magpie.cli.formatting import (
     CommandResult,
     ErrorCode,
@@ -21,6 +21,7 @@ from magpie.storage.paths import normalize_artifact_path
 @click.argument("artifact_path")
 @click.argument("tag_name")
 @click.pass_obj
+@with_network_error_handling
 def untag(ctx: CLIContext, artifact_path: str, tag_name: str) -> None:
     """Remove a tag from an artifact.
 

--- a/src/magpie/cli/commands/url.py
+++ b/src/magpie/cli/commands/url.py
@@ -6,7 +6,7 @@ import click
 
 from magpie.cli import CLIContext
 from magpie.cli.commands.parse import ParseError, parse_artifact_ref
-from magpie.cli.errors import handle_response_error
+from magpie.cli.errors import handle_response_error, with_network_error_handling
 from magpie.cli.formatting import (
     CommandResult,
     ErrorCode,
@@ -19,6 +19,7 @@ from magpie.cli.formatting import (
 @click.command()
 @click.argument("artifact_ref")
 @click.pass_obj
+@with_network_error_handling
 def url(ctx: CLIContext, artifact_ref: str) -> None:
     """Output download URL for scripting (curl/wget).
 

--- a/src/magpie/cli/errors.py
+++ b/src/magpie/cli/errors.py
@@ -223,9 +223,9 @@ def handle_network_error(exc: Exception, operation: str, server: str | None = No
 
     # For human output, raise ClickException which will be caught by Click
     # and will exit with the code we specify
-    exc = click.ClickException(error_msg)
-    exc.exit_code = ExitCode.NETWORK_ERROR
-    raise exc
+    click_exc = click.ClickException(error_msg)
+    click_exc.exit_code = ExitCode.NETWORK_ERROR
+    raise click_exc
 
 
 def with_network_error_handling(func: F) -> F:

--- a/src/magpie/cli/errors.py
+++ b/src/magpie/cli/errors.py
@@ -7,12 +7,17 @@ consistent error messages and exit codes across the application.
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING
+import socket
+from functools import wraps
+from typing import TYPE_CHECKING, Callable, TypeVar
 
 import click
+import httpx
 
 if TYPE_CHECKING:
-    import httpx
+    pass
+
+F = TypeVar("F", bound=Callable[..., object])
 
 # Standard mask for hiding sensitive token values
 TOKEN_MASK = "********"  # nosec B105 - display placeholder, not a real password
@@ -73,7 +78,7 @@ def handle_http_error(
     operation: str,
     token: str | None = None,
 ) -> None:
-    """Handle HTTP error responses, raising ClickException.
+    """Handle HTTP error responses, raising ClickException with appropriate exit code.
 
     This is the unified error handler for all CLI commands. It extracts
     error details from HTTP responses and formats them consistently.
@@ -88,8 +93,19 @@ def handle_http_error(
 
     Raises:
         click.ClickException: Always raised with formatted error message.
+        SystemExit: Exits with appropriate error code.
     """
-    raise click.ClickException(format_auth_error(response, operation, token))
+    # Import here to avoid circular imports
+    from magpie.cli.formatting import http_status_to_exit_code
+
+    error_msg = format_auth_error(response, operation, token)
+    exit_code = http_status_to_exit_code(response.status_code)
+
+    # ClickException defaults to exit code 1, but we want specific codes
+    # So we raise ClickException (which formats the error) then exit with our code
+    exc = click.ClickException(error_msg)
+    exc.exit_code = exit_code
+    raise exc
 
 
 def handle_response_error(
@@ -117,6 +133,7 @@ def handle_response_error(
     # Import here to avoid circular imports
     from magpie.cli.formatting import (
         http_status_to_error_code,
+        http_status_to_exit_code,
         is_json_output,
         output_error,
     )
@@ -126,8 +143,126 @@ def handle_response_error(
             detail = response.json().get("detail", response.text)
         except (json.JSONDecodeError, ValueError, KeyError):
             detail = response.text
-        output_error(http_status_to_error_code(response.status_code), detail)
+        output_error(
+            http_status_to_error_code(response.status_code),
+            detail,
+            exit_code=http_status_to_exit_code(response.status_code),
+        )
         # output_error never returns (calls sys.exit), but this makes it explicit
         return  # pragma: no cover
 
     handle_http_error(response, operation, token)
+
+
+def format_network_error(exc: Exception, server: str | None = None) -> str:
+    """Format a network exception into a user-friendly error message.
+
+    Args:
+        exc: The network exception to format.
+        server: Optional server URL for context.
+
+    Returns:
+        User-friendly error message with optional hint.
+    """
+    # Extract hostname from server URL for clearer messages
+    hostname = server if server else "server"
+    if server and "://" in server:
+        hostname = server.split("://", 1)[1].split("/", 1)[0]
+
+    # Handle different network error types
+    if isinstance(exc, httpx.ConnectError):
+        # Check if it's a DNS resolution error
+        if isinstance(exc.__cause__, socket.gaierror):
+            msg = f"Could not connect to server '{hostname}': DNS resolution failed"
+            hint = "Check that the server hostname is correct and your network is connected."
+            return f"{msg}\nHint: {hint}"
+
+        # Connection refused or similar
+        msg = f"Could not connect to server '{hostname}': Connection refused"
+        hint = "Check that the server is running and the URL is correct."
+        return f"{msg}\nHint: {hint}"
+
+    if isinstance(exc, httpx.TimeoutException):
+        msg = f"Request to server '{hostname}' timed out"
+        hint = "Check your network connection or try increasing the timeout with --timeout."
+        return f"{msg}\nHint: {hint}"
+
+    if isinstance(exc, httpx.RequestError):
+        # Generic request error
+        msg = f"Network error connecting to '{hostname}': {exc}"
+        hint = "Check your network connection and server configuration."
+        return f"{msg}\nHint: {hint}"
+
+    # Fallback for unexpected network errors
+    return f"Network error: {exc}"
+
+
+def handle_network_error(exc: Exception, operation: str, server: str | None = None) -> None:
+    """Handle network exceptions with user-friendly messages and appropriate exit codes.
+
+    Args:
+        exc: The network exception to handle.
+        operation: Description of the operation that failed.
+        server: Optional server URL for context in error messages.
+
+    Raises:
+        click.ClickException: Always raised with formatted error message.
+        SystemExit: Exits with appropriate network error code.
+    """
+    # Import here to avoid circular imports
+    from magpie.cli.formatting import ErrorCode, ExitCode, is_json_output, output_error
+
+    error_msg = format_network_error(exc, server)
+
+    if is_json_output():
+        output_error(ErrorCode.NETWORK_ERROR, error_msg, exit_code=ExitCode.NETWORK_ERROR)
+        return  # pragma: no cover - output_error never returns
+
+    # For human output, raise ClickException which will be caught by Click
+    # and will exit with the code we specify
+    raise click.ClickException(error_msg)
+
+
+def with_network_error_handling(func: F) -> F:
+    """Decorator to wrap CLI commands with network error handling.
+
+    This decorator catches network-related exceptions (ConnectError, TimeoutException,
+    RequestError, etc.) and converts them to user-friendly error messages with
+    appropriate exit codes.
+
+    Usage:
+        @click.command()
+        @with_network_error_handling
+        def my_command(ctx):
+            # Command implementation that makes HTTP calls
+            ...
+    """
+
+    @wraps(func)
+    def wrapper(*args: object, **kwargs: object) -> object:
+        # Import here to avoid circular imports
+        from magpie.cli.formatting import ExitCode
+
+        try:
+            return func(*args, **kwargs)
+        except (httpx.ConnectError, httpx.TimeoutException, httpx.RequestError) as exc:
+            # Extract server from context if available
+            ctx = click.get_current_context(silent=True)
+            server = None
+            if ctx and ctx.obj and hasattr(ctx.obj, "server"):
+                server = ctx.obj.server
+
+            handle_network_error(exc, operation=func.__name__, server=server)
+            # handle_network_error raises ClickException, but for type checker:
+            raise SystemExit(ExitCode.NETWORK_ERROR)  # pragma: no cover
+        except socket.gaierror as exc:
+            # DNS resolution errors can occur outside of httpx
+            ctx = click.get_current_context(silent=True)
+            server = None
+            if ctx and ctx.obj and hasattr(ctx.obj, "server"):
+                server = ctx.obj.server
+
+            handle_network_error(exc, operation=func.__name__, server=server)
+            raise SystemExit(ExitCode.NETWORK_ERROR)  # pragma: no cover
+
+    return wrapper  # type: ignore[return-value]

--- a/src/magpie/cli/errors.py
+++ b/src/magpie/cli/errors.py
@@ -184,8 +184,23 @@ def format_network_error(exc: Exception, server: str | None = None) -> str:
         hint = "Check your network connection or try increasing the timeout with --timeout."
         return f"{msg}\nHint: {hint}"
 
+    if isinstance(exc, httpx.ProxyError):
+        msg = f"Proxy error connecting to '{hostname}': {exc}"
+        hint = "Check your proxy configuration and that the proxy is accessible."
+        return f"{msg}\nHint: {hint}"
+
+    if isinstance(exc, httpx.UnsupportedProtocol):
+        msg = f"Unsupported protocol connecting to '{hostname}': {exc}"
+        hint = "Check that the server URL uses a supported protocol (http/https)."
+        return f"{msg}\nHint: {hint}"
+
+    if isinstance(exc, httpx.ProtocolError):
+        msg = f"Protocol error connecting to '{hostname}': {exc}"
+        hint = "The server sent an invalid response. Check server logs or try again."
+        return f"{msg}\nHint: {hint}"
+
     if isinstance(exc, httpx.RequestError):
-        # Generic request error
+        # Generic request error (catches all other RequestError subclasses)
         msg = f"Network error connecting to '{hostname}': {exc}"
         hint = "Check your network connection and server configuration."
         return f"{msg}\nHint: {hint}"
@@ -231,9 +246,21 @@ def handle_network_error(exc: Exception, operation: str, server: str | None = No
 def with_network_error_handling(func: F) -> F:
     """Decorator to wrap CLI commands with network error handling.
 
-    This decorator catches network-related exceptions (ConnectError, TimeoutException,
-    RequestError, etc.) and converts them to user-friendly error messages with
-    appropriate exit codes.
+    This decorator catches network-related exceptions (RequestError and all subclasses
+    including ConnectError, TimeoutException, ProxyError, ProtocolError, etc.) and
+    converts them to user-friendly error messages with appropriate exit codes.
+
+    Coverage includes:
+    - httpx.RequestError: Base class for all request errors
+      - httpx.TransportError: All transport-level errors
+        - httpx.ConnectError: Connection failures, DNS errors
+        - httpx.TimeoutException: Request timeouts
+        - httpx.ProxyError: Proxy configuration or connectivity issues
+        - httpx.UnsupportedProtocol: Invalid protocol in URL
+        - httpx.ProtocolError: HTTP protocol violations
+      - httpx.DecodingError: Response decoding failures
+      - httpx.TooManyRedirects: Redirect loop detection
+    - socket.gaierror: DNS errors that occur outside httpx
 
     Usage:
         @click.command()
@@ -250,8 +277,9 @@ def with_network_error_handling(func: F) -> F:
 
         try:
             return func(*args, **kwargs)
-        except (httpx.ConnectError, httpx.TimeoutException, httpx.RequestError) as exc:
-            # Extract server from context if available
+        except httpx.RequestError as exc:
+            # Catch all RequestError subclasses (TransportError, DecodingError, TooManyRedirects, etc.)
+            # format_network_error() handles specific types with custom messages
             ctx = click.get_current_context(silent=True)
             server = None
             if ctx and ctx.obj and hasattr(ctx.obj, "server"):

--- a/src/magpie/cli/errors.py
+++ b/src/magpie/cli/errors.py
@@ -9,13 +9,10 @@ from __future__ import annotations
 import json
 import socket
 from functools import wraps
-from typing import TYPE_CHECKING, Callable, TypeVar
+from typing import Callable, TypeVar
 
 import click
 import httpx
-
-if TYPE_CHECKING:
-    pass
 
 F = TypeVar("F", bound=Callable[..., object])
 
@@ -191,6 +188,12 @@ def format_network_error(exc: Exception, server: str | None = None) -> str:
         # Generic request error
         msg = f"Network error connecting to '{hostname}': {exc}"
         hint = "Check your network connection and server configuration."
+        return f"{msg}\nHint: {hint}"
+
+    if isinstance(exc, socket.gaierror):
+        # Standalone DNS resolution error (not wrapped in httpx exception)
+        msg = f"Could not connect to server '{hostname}': DNS resolution failed"
+        hint = "Check that the server hostname is correct and your network is connected."
         return f"{msg}\nHint: {hint}"
 
     # Fallback for unexpected network errors

--- a/src/magpie/cli/errors.py
+++ b/src/magpie/cli/errors.py
@@ -90,7 +90,6 @@ def handle_http_error(
 
     Raises:
         click.ClickException: Always raised with formatted error message.
-        SystemExit: Exits with appropriate error code.
     """
     # Import here to avoid circular imports
     from magpie.cli.formatting import http_status_to_exit_code

--- a/src/magpie/cli/errors.py
+++ b/src/magpie/cli/errors.py
@@ -220,7 +220,9 @@ def handle_network_error(exc: Exception, operation: str, server: str | None = No
 
     # For human output, raise ClickException which will be caught by Click
     # and will exit with the code we specify
-    raise click.ClickException(error_msg)
+    exc = click.ClickException(error_msg)
+    exc.exit_code = ExitCode.NETWORK_ERROR
+    raise exc
 
 
 def with_network_error_handling(func: F) -> F:

--- a/src/magpie/cli/formatting.py
+++ b/src/magpie/cli/formatting.py
@@ -188,6 +188,25 @@ def output_error(code: str, message: str, exit_code: int = 1) -> NoReturn:
     sys.exit(exit_code)
 
 
+# Exit codes for CLI commands
+class ExitCode:
+    """Standard exit codes for consistent CLI behavior.
+
+    These exit codes allow scripts to differentiate between error types:
+    - 0: Success
+    - 1: General/unspecified error
+    - 2: Network/connection error (DNS, connection refused, timeout)
+    - 3: Not found (artifact doesn't exist)
+    - 4: Authentication error (invalid/expired token)
+    """
+
+    SUCCESS = 0
+    GENERAL_ERROR = 1
+    NETWORK_ERROR = 2
+    NOT_FOUND = 3
+    AUTH_ERROR = 4
+
+
 # Standard error codes for consistency across commands
 class ErrorCode:
     """Standard error codes for JSON output."""
@@ -224,3 +243,20 @@ def http_status_to_error_code(status_code: int) -> str:
     if status_code >= 500:
         return ErrorCode.SERVER_ERROR
     return ErrorCode.VALIDATION_ERROR
+
+
+def http_status_to_exit_code(status_code: int) -> int:
+    """Map HTTP status code to CLI exit code.
+
+    Args:
+        status_code: HTTP response status code.
+
+    Returns:
+        Corresponding exit code.
+    """
+    mapping: Mapping[int, int] = {
+        401: ExitCode.AUTH_ERROR,
+        403: ExitCode.AUTH_ERROR,
+        404: ExitCode.NOT_FOUND,
+    }
+    return mapping.get(status_code, ExitCode.GENERAL_ERROR)

--- a/tests/integration/test_cli_version.py
+++ b/tests/integration/test_cli_version.py
@@ -115,7 +115,7 @@ class TestVersionCommand:
         """Version command with --server-version flag handles missing version field."""
         mock_client = Mock()
         mock_response = Mock()
-        mock_response.raise_for_status = Mock()
+        mock_response.status_code = 200
         mock_response.json.return_value = {"status": "ok"}  # No version field
         mock_client.get.return_value = mock_response
         mock_client.__enter__ = Mock(return_value=mock_client)

--- a/tests/integration/test_cli_version.py
+++ b/tests/integration/test_cli_version.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 from unittest.mock import Mock, patch
 
+import httpx
 from click.testing import CliRunner
 from fastapi.testclient import TestClient
 
 from magpie import __version__
 from magpie.cli import cli
+from magpie.cli.formatting import ExitCode
 
 
 class TestVersionCommand:
@@ -40,10 +42,12 @@ class TestVersionCommand:
         assert "server:" in result.output
         assert f"server: {__version__}" in result.output
 
-    def test_version_with_server_flag_handles_connection_error(self, cli_runner: CliRunner) -> None:
-        """Version command with --server-version flag handles connection errors gracefully."""
+    def test_version_with_server_flag_handles_network_error(self, cli_runner: CliRunner) -> None:
+        """Version command with --server-version flag handles network errors with exit code 2."""
         mock_client = Mock()
-        mock_client.get.side_effect = Exception("Connection refused")
+        # Raise httpx.ConnectError to test network error handling
+        mock_request = Mock()
+        mock_client.get.side_effect = httpx.ConnectError("Connection refused", request=mock_request)
         mock_client.__enter__ = Mock(return_value=mock_client)
         mock_client.__exit__ = Mock(return_value=False)
 
@@ -55,11 +59,55 @@ class TestVersionCommand:
                 ["--server", "http://test", "version", "--server-version"],
             )
 
-        # Should exit with error
-        assert result.exit_code == 1
-        # Should show error message with details
-        assert "Failed to fetch server version" in result.output
-        assert "Connection refused" in result.output
+        # Should exit with NETWORK_ERROR code (2), not generic error (1)
+        assert result.exit_code == ExitCode.NETWORK_ERROR
+        # Should show user-friendly network error message
+        assert (
+            "Could not connect to server" in result.output or "Connection refused" in result.output
+        )
+
+    def test_version_with_server_flag_handles_timeout_error(self, cli_runner: CliRunner) -> None:
+        """Version command with --server-version flag handles timeout errors with exit code 2."""
+        mock_client = Mock()
+        mock_request = Mock()
+        mock_client.get.side_effect = httpx.TimeoutException(
+            "Request timed out", request=mock_request
+        )
+        mock_client.__enter__ = Mock(return_value=mock_client)
+        mock_client.__exit__ = Mock(return_value=False)
+
+        with patch("magpie.cli.get_client") as mock_get_client:
+            mock_get_client.return_value = mock_client
+
+            result = cli_runner.invoke(
+                cli,
+                ["--server", "http://test", "version", "--server-version"],
+            )
+
+        # Should exit with NETWORK_ERROR code (2)
+        assert result.exit_code == ExitCode.NETWORK_ERROR
+        # Should show timeout-specific message
+        assert "timed out" in result.output
+
+    def test_version_with_server_flag_handles_proxy_error(self, cli_runner: CliRunner) -> None:
+        """Version command with --server-version flag handles proxy errors with exit code 2."""
+        mock_client = Mock()
+        mock_client.get.side_effect = httpx.ProxyError("Proxy connection failed")
+        mock_client.__enter__ = Mock(return_value=mock_client)
+        mock_client.__exit__ = Mock(return_value=False)
+
+        with patch("magpie.cli.get_client") as mock_get_client:
+            mock_get_client.return_value = mock_client
+
+            result = cli_runner.invoke(
+                cli,
+                ["--server", "http://test", "version", "--server-version"],
+            )
+
+        # Should exit with NETWORK_ERROR code (2)
+        assert result.exit_code == ExitCode.NETWORK_ERROR
+        # Should show proxy-specific message
+        assert "Proxy error" in result.output
 
     def test_version_with_server_flag_handles_missing_version_field(
         self, cli_runner: CliRunner

--- a/tests/unit/test_cli_network_errors.py
+++ b/tests/unit/test_cli_network_errors.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 import socket
 from unittest.mock import MagicMock, patch
 
+import click
 import httpx
 import pytest
+from click.testing import CliRunner
 
 from magpie.cli.errors import (
     format_network_error,
@@ -222,3 +224,73 @@ class TestExitCodes:
 
         # Check that the exception has the correct exit code
         assert exc_info.value.exit_code == ExitCode.NOT_FOUND
+
+
+class TestCliRunnerIntegration:
+    """Integration tests using Click's CliRunner to verify exit codes end-to-end."""
+
+    def test_network_error_exit_code_with_runner(self) -> None:
+        """Network error in human mode produces exit code 2 (NETWORK_ERROR)."""
+
+        @click.command()
+        @with_network_error_handling
+        def test_command() -> None:
+            """Test command that raises a network error."""
+            raise httpx.ConnectError("Connection failed", request=MagicMock())
+
+        runner = CliRunner()
+        result = runner.invoke(test_command)
+
+        # Verify exit code is NETWORK_ERROR (2), not GENERAL_ERROR (1)
+        assert result.exit_code == ExitCode.NETWORK_ERROR
+        assert "Connection refused" in result.output
+
+    def test_timeout_error_exit_code_with_runner(self) -> None:
+        """Timeout error in human mode produces exit code 2 (NETWORK_ERROR)."""
+
+        @click.command()
+        @with_network_error_handling
+        def test_command() -> None:
+            """Test command that raises a timeout error."""
+            raise httpx.TimeoutException("Request timed out", request=MagicMock())
+
+        runner = CliRunner()
+        result = runner.invoke(test_command)
+
+        # Verify exit code is NETWORK_ERROR (2)
+        assert result.exit_code == ExitCode.NETWORK_ERROR
+        assert "timed out" in result.output
+
+    def test_dns_error_exit_code_with_runner(self) -> None:
+        """DNS error in human mode produces exit code 2 (NETWORK_ERROR)."""
+
+        @click.command()
+        @with_network_error_handling
+        def test_command() -> None:
+            """Test command that raises a DNS error."""
+            dns_error = socket.gaierror("Name or service not known")
+            connect_error = httpx.ConnectError("DNS failed", request=MagicMock())
+            connect_error.__cause__ = dns_error
+            raise connect_error
+
+        runner = CliRunner()
+        result = runner.invoke(test_command)
+
+        # Verify exit code is NETWORK_ERROR (2)
+        assert result.exit_code == ExitCode.NETWORK_ERROR
+        assert "DNS resolution failed" in result.output
+
+    def test_non_network_error_exit_code_with_runner(self) -> None:
+        """Non-network errors still exit with code 1 (GENERAL_ERROR)."""
+
+        @click.command()
+        @with_network_error_handling
+        def test_command() -> None:
+            """Test command that raises a non-network error."""
+            raise ValueError("Not a network error")
+
+        runner = CliRunner()
+        result = runner.invoke(test_command)
+
+        # Verify exit code is GENERAL_ERROR (1) for unhandled exceptions
+        assert result.exit_code == ExitCode.GENERAL_ERROR

--- a/tests/unit/test_cli_network_errors.py
+++ b/tests/unit/test_cli_network_errors.py
@@ -87,6 +87,17 @@ class TestFormatNetworkError:
 
         assert "server" in result
 
+    def test_standalone_socket_gaierror(self) -> None:
+        """Standalone socket.gaierror produces helpful DNS error message."""
+        dns_error = socket.gaierror("Name or service not known")
+
+        result = format_network_error(dns_error, server="https://magpie.example.com")
+
+        assert "magpie.example.com" in result
+        assert "DNS resolution failed" in result
+        assert "Hint:" in result
+        assert "hostname is correct" in result
+
 
 class TestHandleNetworkError:
     """Tests for handle_network_error function."""
@@ -294,3 +305,60 @@ class TestCliRunnerIntegration:
 
         # Verify exit code is GENERAL_ERROR (1) for unhandled exceptions
         assert result.exit_code == ExitCode.GENERAL_ERROR
+
+    def test_http_404_error_exit_code_with_runner(self) -> None:
+        """HTTP 404 error in human mode produces exit code 3 (NOT_FOUND)."""
+        from magpie.cli.errors import handle_http_error
+
+        @click.command()
+        def test_command() -> None:
+            """Test command that raises an HTTP 404 error."""
+            mock_response = MagicMock()
+            mock_response.status_code = 404
+            mock_response.json.return_value = {"detail": "Not found"}
+            handle_http_error(mock_response, "Test operation")
+
+        runner = CliRunner()
+        result = runner.invoke(test_command)
+
+        # Verify exit code is NOT_FOUND (3)
+        assert result.exit_code == ExitCode.NOT_FOUND
+        assert "Test operation failed (404)" in result.output
+
+    def test_http_401_error_exit_code_with_runner(self) -> None:
+        """HTTP 401 error in human mode produces exit code 4 (AUTH_ERROR)."""
+        from magpie.cli.errors import handle_http_error
+
+        @click.command()
+        def test_command() -> None:
+            """Test command that raises an HTTP 401 error."""
+            mock_response = MagicMock()
+            mock_response.status_code = 401
+            mock_response.json.return_value = {"detail": "Unauthorized"}
+            handle_http_error(mock_response, "Test operation")
+
+        runner = CliRunner()
+        result = runner.invoke(test_command)
+
+        # Verify exit code is AUTH_ERROR (4)
+        assert result.exit_code == ExitCode.AUTH_ERROR
+        assert "Test operation failed (401)" in result.output
+
+    def test_http_500_error_exit_code_with_runner(self) -> None:
+        """HTTP 500 error in human mode produces exit code 1 (GENERAL_ERROR)."""
+        from magpie.cli.errors import handle_http_error
+
+        @click.command()
+        def test_command() -> None:
+            """Test command that raises an HTTP 500 error."""
+            mock_response = MagicMock()
+            mock_response.status_code = 500
+            mock_response.json.return_value = {"detail": "Internal server error"}
+            handle_http_error(mock_response, "Test operation")
+
+        runner = CliRunner()
+        result = runner.invoke(test_command)
+
+        # Verify exit code is GENERAL_ERROR (1)
+        assert result.exit_code == ExitCode.GENERAL_ERROR
+        assert "Test operation failed (500)" in result.output

--- a/tests/unit/test_cli_network_errors.py
+++ b/tests/unit/test_cli_network_errors.py
@@ -1,0 +1,225 @@
+"""Unit tests for CLI network error handling."""
+
+from __future__ import annotations
+
+import socket
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+from click.testing import CliRunner
+
+from magpie.cli.errors import (
+    format_network_error,
+    handle_network_error,
+    with_network_error_handling,
+)
+from magpie.cli.formatting import ExitCode
+
+
+class TestFormatNetworkError:
+    """Tests for format_network_error function."""
+
+    def test_dns_resolution_failure(self) -> None:
+        """DNS resolution failure produces helpful error message."""
+        # Create ConnectError with DNS failure as cause
+        dns_error = socket.gaierror("Name or service not known")
+        connect_error = httpx.ConnectError("Connection failed", request=MagicMock())
+        connect_error.__cause__ = dns_error
+
+        result = format_network_error(connect_error, server="https://magpie.example.com")
+
+        assert "magpie.example.com" in result
+        assert "DNS resolution failed" in result
+        assert "Hint:" in result
+        assert "hostname is correct" in result
+
+    def test_connection_refused(self) -> None:
+        """Connection refused produces helpful error message."""
+        connect_error = httpx.ConnectError("Connection refused", request=MagicMock())
+
+        result = format_network_error(connect_error, server="https://magpie.example.com")
+
+        assert "magpie.example.com" in result
+        assert "Connection refused" in result
+        assert "Hint:" in result
+        assert "server is running" in result
+
+    def test_timeout_error(self) -> None:
+        """Timeout error produces helpful error message."""
+        timeout_error = httpx.TimeoutException("Request timed out", request=MagicMock())
+
+        result = format_network_error(timeout_error, server="https://magpie.example.com")
+
+        assert "magpie.example.com" in result
+        assert "timed out" in result
+        assert "Hint:" in result
+        assert "timeout" in result
+
+    def test_generic_request_error(self) -> None:
+        """Generic request error produces error message."""
+        request_error = httpx.RequestError("Network error", request=MagicMock())
+
+        result = format_network_error(request_error, server="https://magpie.example.com")
+
+        assert "magpie.example.com" in result
+        assert "Network error" in result
+        assert "Hint:" in result
+
+    def test_hostname_extraction_from_url(self) -> None:
+        """Hostname is extracted correctly from server URL."""
+        connect_error = httpx.ConnectError("Connection failed", request=MagicMock())
+        connect_error.__cause__ = socket.gaierror("Name or service not known")
+
+        result = format_network_error(
+            connect_error, server="https://artifacts.example.com:8443/api"
+        )
+
+        assert "artifacts.example.com:8443" in result
+        assert "https://" not in result
+
+    def test_no_server_url_provided(self) -> None:
+        """Error message uses 'server' when no URL provided."""
+        connect_error = httpx.ConnectError("Connection failed", request=MagicMock())
+
+        result = format_network_error(connect_error, server=None)
+
+        assert "server" in result
+
+
+class TestHandleNetworkError:
+    """Tests for handle_network_error function."""
+
+    def test_raises_click_exception(self) -> None:
+        """handle_network_error raises ClickException with formatted message."""
+        from click.exceptions import ClickException
+
+        connect_error = httpx.ConnectError("Connection failed", request=MagicMock())
+        connect_error.__cause__ = socket.gaierror("Name or service not known")
+
+        with pytest.raises(ClickException) as exc_info:
+            handle_network_error(
+                connect_error, operation="push", server="https://magpie.example.com"
+            )
+
+        assert "DNS resolution failed" in str(exc_info.value)
+        assert "magpie.example.com" in str(exc_info.value)
+
+    @patch("magpie.cli.formatting.is_json_output")
+    @patch("magpie.cli.formatting.output_error")
+    def test_json_output_mode(self, mock_output_error: MagicMock, mock_is_json: MagicMock) -> None:
+        """In JSON mode, calls output_error with network error code."""
+        mock_is_json.return_value = True
+        mock_output_error.side_effect = SystemExit(ExitCode.NETWORK_ERROR)
+
+        connect_error = httpx.ConnectError("Connection failed", request=MagicMock())
+
+        with pytest.raises(SystemExit) as exc_info:
+            handle_network_error(
+                connect_error, operation="push", server="https://magpie.example.com"
+            )
+
+        assert exc_info.value.code == ExitCode.NETWORK_ERROR
+        mock_output_error.assert_called_once()
+        call_args = mock_output_error.call_args
+        assert call_args[0][0] == "NETWORK_ERROR"
+        assert call_args[1]["exit_code"] == ExitCode.NETWORK_ERROR
+
+
+class TestWithNetworkErrorHandlingDecorator:
+    """Tests for with_network_error_handling decorator."""
+
+    def test_catches_connect_error(self) -> None:
+        """Decorator catches ConnectError and converts to user-friendly error."""
+        from click.exceptions import ClickException
+
+        @with_network_error_handling
+        def failing_command() -> None:
+            raise httpx.ConnectError("Connection failed", request=MagicMock())
+
+        with pytest.raises(ClickException) as exc_info:
+            failing_command()
+
+        assert "Connection refused" in str(exc_info.value)
+
+    def test_catches_timeout_error(self) -> None:
+        """Decorator catches TimeoutException and converts to user-friendly error."""
+        from click.exceptions import ClickException
+
+        @with_network_error_handling
+        def failing_command() -> None:
+            raise httpx.TimeoutException("Timeout", request=MagicMock())
+
+        with pytest.raises(ClickException) as exc_info:
+            failing_command()
+
+        assert "timed out" in str(exc_info.value)
+
+    def test_catches_socket_gaierror(self) -> None:
+        """Decorator catches socket.gaierror (DNS errors outside httpx)."""
+        from click.exceptions import ClickException
+
+        @with_network_error_handling
+        def failing_command() -> None:
+            raise socket.gaierror("Name or service not known")
+
+        with pytest.raises(ClickException):
+            failing_command()
+
+    def test_passes_through_non_network_errors(self) -> None:
+        """Decorator doesn't catch non-network exceptions."""
+
+        @with_network_error_handling
+        def failing_command() -> None:
+            raise ValueError("Not a network error")
+
+        with pytest.raises(ValueError) as exc_info:
+            failing_command()
+
+        assert "Not a network error" in str(exc_info.value)
+
+    def test_successful_execution(self) -> None:
+        """Decorator allows successful execution."""
+
+        @with_network_error_handling
+        def successful_command() -> str:
+            return "success"
+
+        result = successful_command()
+        assert result == "success"
+
+
+class TestExitCodes:
+    """Tests for exit codes in error scenarios."""
+
+    def test_http_status_to_exit_code_mapping(self) -> None:
+        """HTTP status codes map to appropriate exit codes."""
+        from magpie.cli.formatting import http_status_to_exit_code
+
+        # Auth errors should map to AUTH_ERROR exit code
+        assert http_status_to_exit_code(401) == ExitCode.AUTH_ERROR
+        assert http_status_to_exit_code(403) == ExitCode.AUTH_ERROR
+
+        # Not found should map to NOT_FOUND exit code
+        assert http_status_to_exit_code(404) == ExitCode.NOT_FOUND
+
+        # Other errors should map to GENERAL_ERROR
+        assert http_status_to_exit_code(400) == ExitCode.GENERAL_ERROR
+        assert http_status_to_exit_code(500) == ExitCode.GENERAL_ERROR
+
+    def test_click_exception_exit_code_assignment(self) -> None:
+        """ClickException objects get appropriate exit codes assigned."""
+        from click.exceptions import ClickException
+
+        from magpie.cli.errors import handle_http_error
+
+        # Mock response with 404 status
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+        mock_response.json.return_value = {"detail": "Not found"}
+
+        with pytest.raises(ClickException) as exc_info:
+            handle_http_error(mock_response, "Test operation")
+
+        # Check that the exception has the correct exit code
+        assert exc_info.value.exit_code == ExitCode.NOT_FOUND

--- a/tests/unit/test_cli_network_errors.py
+++ b/tests/unit/test_cli_network_errors.py
@@ -98,6 +98,39 @@ class TestFormatNetworkError:
         assert "Hint:" in result
         assert "hostname is correct" in result
 
+    def test_proxy_error(self) -> None:
+        """ProxyError produces helpful error message."""
+        proxy_error = httpx.ProxyError("Proxy connection failed")
+
+        result = format_network_error(proxy_error, server="https://magpie.example.com")
+
+        assert "magpie.example.com" in result
+        assert "Proxy error" in result
+        assert "Hint:" in result
+        assert "proxy configuration" in result
+
+    def test_unsupported_protocol_error(self) -> None:
+        """UnsupportedProtocol produces helpful error message."""
+        protocol_error = httpx.UnsupportedProtocol("Unsupported protocol 'ftp'")
+
+        result = format_network_error(protocol_error, server="ftp://magpie.example.com")
+
+        assert "magpie.example.com" in result
+        assert "Unsupported protocol" in result
+        assert "Hint:" in result
+        assert "supported protocol" in result
+
+    def test_protocol_error(self) -> None:
+        """ProtocolError produces helpful error message."""
+        protocol_error = httpx.ProtocolError("Invalid HTTP response")
+
+        result = format_network_error(protocol_error, server="https://magpie.example.com")
+
+        assert "magpie.example.com" in result
+        assert "Protocol error" in result
+        assert "Hint:" in result
+        assert "invalid response" in result
+
 
 class TestHandleNetworkError:
     """Tests for handle_network_error function."""
@@ -199,6 +232,45 @@ class TestWithNetworkErrorHandlingDecorator:
 
         result = successful_command()
         assert result == "success"
+
+    def test_catches_proxy_error(self) -> None:
+        """Decorator catches ProxyError and converts to user-friendly error."""
+        from click.exceptions import ClickException
+
+        @with_network_error_handling
+        def failing_command() -> None:
+            raise httpx.ProxyError("Proxy connection failed")
+
+        with pytest.raises(ClickException) as exc_info:
+            failing_command()
+
+        assert "Proxy error" in str(exc_info.value)
+
+    def test_catches_unsupported_protocol_error(self) -> None:
+        """Decorator catches UnsupportedProtocol and converts to user-friendly error."""
+        from click.exceptions import ClickException
+
+        @with_network_error_handling
+        def failing_command() -> None:
+            raise httpx.UnsupportedProtocol("Unsupported protocol")
+
+        with pytest.raises(ClickException) as exc_info:
+            failing_command()
+
+        assert "Unsupported protocol" in str(exc_info.value)
+
+    def test_catches_protocol_error(self) -> None:
+        """Decorator catches ProtocolError and converts to user-friendly error."""
+        from click.exceptions import ClickException
+
+        @with_network_error_handling
+        def failing_command() -> None:
+            raise httpx.ProtocolError("Invalid response")
+
+        with pytest.raises(ClickException) as exc_info:
+            failing_command()
+
+        assert "Protocol error" in str(exc_info.value)
 
 
 class TestExitCodes:

--- a/tests/unit/test_cli_network_errors.py
+++ b/tests/unit/test_cli_network_errors.py
@@ -7,7 +7,6 @@ from unittest.mock import MagicMock, patch
 
 import httpx
 import pytest
-from click.testing import CliRunner
 
 from magpie.cli.errors import (
     format_network_error,

--- a/tests/unit/test_cli_utils.py
+++ b/tests/unit/test_cli_utils.py
@@ -227,7 +227,8 @@ class TestHandleResponseError:
 
         runner = CliRunner()
         result = runner.invoke(test_cmd, ["--format", "human"])
-        assert result.exit_code == 1
+        # 401 should produce exit code 4 (AUTH_ERROR)
+        assert result.exit_code == 4
         assert "token: ********3456" in result.output
 
     def test_json_mode_outputs_error_envelope(self) -> None:
@@ -243,7 +244,8 @@ class TestHandleResponseError:
 
         runner = CliRunner()
         result = runner.invoke(test_cmd, ["--format", "json"])
-        assert result.exit_code == 1
+        # 404 should produce exit code 3 (NOT_FOUND)
+        assert result.exit_code == 3
 
         output = json.loads(result.output)
         assert output["status"] == "error"


### PR DESCRIPTION
## Summary

Fixes network error handling in the CLI by converting raw Python stack traces into user-friendly error messages and introducing distinct exit codes for different error classes.

Previously, network errors (DNS failures, connection refused, timeouts) produced massive stack traces that confused users. Now they display clear, actionable error messages with hints for resolution.

## Changes

### Exit Codes

Introduced standardized exit codes for scriptability:

| Exit Code | Meaning | Example |
|-----------|---------|---------|
| 0 | Success | Command completed |
| 1 | General/unspecified error | Unknown error |
| 2 | Network/connection error | DNS failure, connection refused, timeout |
| 3 | Not found | Artifact doesn't exist |
| 4 | Authentication error | Invalid/expired token |

### Network Error Handling

- Added `ExitCode` class to `src/magpie/cli/formatting.py` with standardized exit codes
- Created comprehensive network error handling in `src/magpie/cli/errors.py`:
  - `format_network_error()` - converts exceptions to user-friendly messages
  - `handle_network_error()` - handles errors with appropriate exit codes
  - `with_network_error_handling` decorator - wraps CLI commands

### Error Types Handled

- `httpx.ConnectError` - DNS failure, connection refused
- `httpx.TimeoutException` - request timeout
- `httpx.RequestError` - generic request errors
- `socket.gaierror` - DNS resolution failures outside httpx

### User Experience

Before:
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.13/site-packages/httpx/_transports/default.py", line 69, in map_httpcore_exceptions
    yield
    ...
socket.gaierror: [Errno -2] Name or service not known
```

After:
```
Error: Could not connect to server 'magpie.example.com': DNS resolution failed
Hint: Check that the server hostname is correct and your network is connected.
```

### Commands Updated

Applied `@with_network_error_handling` decorator to all network-using commands:
- push, get, ls, info, url
- tag, untag, flush-tag
- gc, status
- amend
- token (create, rotate)

### Tests

Added comprehensive unit test coverage in `tests/unit/test_cli_network_errors.py`:
- Network error message formatting
- Exit code mapping
- Decorator functionality
- JSON output mode support

Updated existing tests in `test_cli_utils.py` to expect correct exit codes.

## Test Plan

- [x] Run unit tests: `uv run pytest tests/unit/ -v`
- [x] All 860 unit tests pass
- [x] Lint checks pass: `uv run ruff check src/ tests/`
- [x] Format checks pass: `uv run ruff format src/ tests/`
- [x] Verify exit codes are correct for different error types
- [x] Test network error messages are user-friendly

## Related Issues

Fixes #443

Generated with Claude Code w/ Sonnet 4.5