### PR TITLE
chore: bump version to 0.1.2

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -21,7 +21,7 @@ For Authentik setup, see [authentik-setup.md](authentik-setup.md). For Ansible, 
 
 ```bash
 # With uv (recommended)
-uv pip install git+https://github.com/SouthwestCCDC/magpie.git@v0.1.1
+uv pip install git+https://github.com/SouthwestCCDC/magpie.git@v0.1.2
 ```
 
 ### Configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "magpie"
-version = "0.1.1"
+version = "0.1.2"
 description = "Content-addressed artifact storage with mutable tags"
 authors = [{ name = "SWCCDC Team" }]
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -382,7 +382,7 @@ wheels = [
 
 [[package]]
 name = "magpie"
-version = "0.1.1rc1"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

Version bump in preparation for v0.1.2 release.

- Updated version in `pyproject.toml` from 0.1.1 to 0.1.2
- Updated installation instructions in `docs/user-guide.md`
- Updated lockfile

The CHANGELOG will be handled by the release process.

Generated with [Claude Code](https://claude.com/claude-code) w/ Sonnet 4.5