### PR TITLE
feat(cli): Send User-Agent header with CLI version

### DIFF
--- a/src/magpie/cli/client.py
+++ b/src/magpie/cli/client.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import httpx
 import truststore
 
+from magpie import __version__
 from magpie.cli.config import DEFAULT_TIMEOUT
 
 # Short timeout for connection establishment (30 seconds)
@@ -64,7 +65,7 @@ def get_client(
     Returns:
         Configured httpx.Client instance.
     """
-    headers: dict[str, str] = {}
+    headers: dict[str, str] = {"User-Agent": f"magpie-cli/{__version__}"}
     if token:
         headers["Authorization"] = f"Bearer {token}"
     # Use short connect timeout, long read/write timeout for file transfers

--- a/tests/unit/test_cli_client.py
+++ b/tests/unit/test_cli_client.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 import httpx
 import pytest
 
+from magpie import __version__
 from magpie.cli.client import (
     DEFAULT_CONNECT_TIMEOUT,
     _create_ssl_context,
@@ -57,6 +58,23 @@ class TestGetClient:
         client = get_client("http://localhost:8000", token="")
         try:
             assert "Authorization" not in client.headers
+        finally:
+            client.close()
+
+    def test_sets_user_agent_header(self) -> None:
+        """Test that User-Agent header is set with CLI version."""
+        client = get_client("http://localhost:8000")
+        try:
+            assert client.headers.get("User-Agent") == f"magpie-cli/{__version__}"
+        finally:
+            client.close()
+
+    def test_user_agent_header_with_token(self) -> None:
+        """Test that User-Agent header is set when token is also provided."""
+        client = get_client("http://localhost:8000", token="mgp_testtoken")
+        try:
+            assert client.headers.get("User-Agent") == f"magpie-cli/{__version__}"
+            assert client.headers.get("Authorization") == "Bearer mgp_testtoken"
         finally:
             client.close()
 


### PR DESCRIPTION
## Summary

Add a `User-Agent: magpie-cli/{version}` header to all CLI HTTP requests.

- All CLI HTTP requests now include User-Agent header with CLI version
- Version is pulled from `magpie.__version__` (not hardcoded)
- Added tests verifying the header is set correctly

## Related Issue

Fixes #450

## Test Plan

- All existing unit tests pass (847 tests)
- Added 2 new tests:
  - `test_sets_user_agent_header`: Verifies User-Agent header format
  - `test_user_agent_header_with_token`: Verifies User-Agent is set alongside Authorization header
- Linting and formatting checks pass

Generated with Claude Code w/ Sonnet 4.5