### PR TITLE
Refactor CLI exception handling to use specific httpx exceptions

### DIFF
--- a/src/magpie/cli/errors.py
+++ b/src/magpie/cli/errors.py
@@ -278,25 +278,33 @@ def with_network_error_handling(func: F) -> F:
     @wraps(func)
     def wrapper(*args: object, **kwargs: object) -> object:
         # Import here to avoid circular imports
-        from magpie.cli.formatting import ErrorCode, ExitCode, is_json_output, output_error
+        from magpie.cli.formatting import (
+            ErrorCode,
+            ExitCode,
+            http_status_to_exit_code,
+            is_json_output,
+            output_error,
+        )
 
         try:
             return func(*args, **kwargs)
         except httpx.HTTPStatusError as exc:
             # HTTP error responses (4xx, 5xx) raised by raise_for_status()
-            # Extract server and token from context if available
+            # NOTE: This handler is defensive/future-proofing. Currently no CLI code
+            # calls raise_for_status() - all code manually checks response.status_code
+            # and calls handle_response_error() directly. If someone adds
+            # raise_for_status() in the future, this will handle it correctly.
+
+            # Extract token from context if available
             ctx = click.get_current_context(silent=True)
-            server = None
             token = None
-            if ctx and ctx.obj:
-                if hasattr(ctx.obj, "server"):
-                    server = ctx.obj.server
-                if hasattr(ctx.obj, "token"):
-                    token = ctx.obj.token
+            if ctx and ctx.obj and hasattr(ctx.obj, "token"):
+                token = ctx.obj.token
 
             # Use handle_response_error for consistent error formatting
             handle_response_error(exc.response, operation=func.__name__, token=token)
-            raise SystemExit(ExitCode.NETWORK_ERROR)  # pragma: no cover
+            # Unreachable: handle_response_error never returns
+            raise SystemExit(http_status_to_exit_code(exc.response.status_code))  # pragma: no cover
         except httpx.RequestError as exc:
             # Catch all RequestError subclasses (TransportError, DecodingError, TooManyRedirects, etc.)
             # format_network_error() handles specific types with custom messages

--- a/src/magpie/cli/errors.py
+++ b/src/magpie/cli/errors.py
@@ -243,11 +243,12 @@ def handle_network_error(exc: Exception, operation: str, server: str | None = No
 
 
 def with_network_error_handling(func: F) -> F:
-    """Decorator to wrap CLI commands with network error handling.
+    """Decorator to wrap CLI commands with network and response parsing error handling.
 
     This decorator catches network-related exceptions (RequestError and all subclasses
     including ConnectError, TimeoutException, ProxyError, ProtocolError, etc.) and
-    converts them to user-friendly error messages with appropriate exit codes.
+    response parsing errors, converting them to user-friendly error messages with
+    appropriate exit codes.
 
     Coverage includes:
     - httpx.RequestError: Base class for all request errors
@@ -259,7 +260,12 @@ def with_network_error_handling(func: F) -> F:
         - httpx.ProtocolError: HTTP protocol violations
       - httpx.DecodingError: Response decoding failures
       - httpx.TooManyRedirects: Redirect loop detection
+    - httpx.HTTPStatusError: HTTP error status codes (4xx, 5xx) raised by raise_for_status()
+    - json.JSONDecodeError: Response JSON parsing errors
     - socket.gaierror: DNS errors that occur outside httpx
+
+    Unexpected exceptions (AttributeError, KeyError, etc.) are allowed to propagate
+    so they're visible in debug mode and captured by Sentry for diagnosis.
 
     Usage:
         @click.command()
@@ -272,10 +278,25 @@ def with_network_error_handling(func: F) -> F:
     @wraps(func)
     def wrapper(*args: object, **kwargs: object) -> object:
         # Import here to avoid circular imports
-        from magpie.cli.formatting import ExitCode
+        from magpie.cli.formatting import ErrorCode, ExitCode, is_json_output, output_error
 
         try:
             return func(*args, **kwargs)
+        except httpx.HTTPStatusError as exc:
+            # HTTP error responses (4xx, 5xx) raised by raise_for_status()
+            # Extract server and token from context if available
+            ctx = click.get_current_context(silent=True)
+            server = None
+            token = None
+            if ctx and ctx.obj:
+                if hasattr(ctx.obj, "server"):
+                    server = ctx.obj.server
+                if hasattr(ctx.obj, "token"):
+                    token = ctx.obj.token
+
+            # Use handle_response_error for consistent error formatting
+            handle_response_error(exc.response, operation=func.__name__, token=token)
+            raise SystemExit(ExitCode.NETWORK_ERROR)  # pragma: no cover
         except httpx.RequestError as exc:
             # Catch all RequestError subclasses (TransportError, DecodingError, TooManyRedirects, etc.)
             # format_network_error() handles specific types with custom messages
@@ -287,6 +308,19 @@ def with_network_error_handling(func: F) -> F:
             handle_network_error(exc, operation=func.__name__, server=server)
             # handle_network_error raises ClickException, but for type checker:
             raise SystemExit(ExitCode.NETWORK_ERROR)  # pragma: no cover
+        except json.JSONDecodeError as exc:
+            # Response parsing errors - server returned invalid JSON
+            error_msg = f"Invalid JSON response from server: {exc.msg} at line {exc.lineno} column {exc.colno}"
+            hint = "The server may be misconfigured or returned an error page. Check server logs."
+            full_msg = f"{error_msg}\nHint: {hint}"
+
+            if is_json_output():
+                output_error(ErrorCode.NETWORK_ERROR, full_msg, exit_code=ExitCode.NETWORK_ERROR)
+                return  # pragma: no cover - output_error never returns
+
+            click_exc = click.ClickException(full_msg)
+            click_exc.exit_code = ExitCode.NETWORK_ERROR
+            raise click_exc
         except socket.gaierror as exc:
             # DNS resolution errors can occur outside of httpx
             ctx = click.get_current_context(silent=True)

--- a/tests/unit/test_cli_network_errors.py
+++ b/tests/unit/test_cli_network_errors.py
@@ -510,3 +510,65 @@ class TestCliRunnerIntegration:
         # Verify exit code is NOT_FOUND (3) for 404 errors
         assert result.exit_code == ExitCode.NOT_FOUND
         assert "404" in result.output
+
+    @patch("magpie.cli.formatting.is_json_output")
+    @patch("magpie.cli.formatting.output_error")
+    def test_json_decode_error_json_mode(
+        self, mock_output_error: MagicMock, mock_is_json: MagicMock
+    ) -> None:
+        """JSONDecodeError in JSON mode calls output_error with network error code."""
+        import json
+
+        mock_is_json.return_value = True
+        mock_output_error.side_effect = SystemExit(ExitCode.NETWORK_ERROR)
+
+        @click.command()
+        @with_network_error_handling
+        def test_command() -> None:
+            """Test command that raises a JSON decode error."""
+            raise json.JSONDecodeError("Expecting value", "invalid json", 0)
+
+        runner = CliRunner()
+        result = runner.invoke(test_command)
+
+        # Verify exit code is NETWORK_ERROR (2)
+        assert result.exit_code == ExitCode.NETWORK_ERROR
+        # Verify output_error was called with correct parameters
+        mock_output_error.assert_called_once()
+        call_args = mock_output_error.call_args
+        assert call_args[0][0] == "NETWORK_ERROR"
+        assert "Invalid JSON response from server" in call_args[0][1]
+        assert call_args[1]["exit_code"] == ExitCode.NETWORK_ERROR
+
+    @patch("magpie.cli.formatting.is_json_output")
+    @patch("magpie.cli.formatting.output_error")
+    def test_http_status_error_json_mode(
+        self, mock_output_error: MagicMock, mock_is_json: MagicMock
+    ) -> None:
+        """HTTPStatusError in JSON mode calls output_error with appropriate error code."""
+        mock_is_json.return_value = True
+        mock_output_error.side_effect = SystemExit(ExitCode.NOT_FOUND)
+
+        @click.command()
+        @with_network_error_handling
+        def test_command() -> None:
+            """Test command that raises an HTTPStatusError."""
+            mock_request = MagicMock()
+            mock_response = MagicMock()
+            mock_response.status_code = 404
+            mock_response.json.return_value = {"detail": "Not found"}
+            raise httpx.HTTPStatusError(
+                "404 Not Found", request=mock_request, response=mock_response
+            )
+
+        runner = CliRunner()
+        result = runner.invoke(test_command)
+
+        # Verify exit code is NOT_FOUND (3) for 404 errors
+        assert result.exit_code == ExitCode.NOT_FOUND
+        # Verify output_error was called with correct parameters
+        mock_output_error.assert_called_once()
+        call_args = mock_output_error.call_args
+        assert call_args[0][0] == "NOT_FOUND"
+        assert "Not found" in call_args[0][1]
+        assert call_args[1]["exit_code"] == ExitCode.NOT_FOUND

--- a/tests/unit/test_cli_network_errors.py
+++ b/tests/unit/test_cli_network_errors.py
@@ -272,6 +272,42 @@ class TestWithNetworkErrorHandlingDecorator:
 
         assert "Protocol error" in str(exc_info.value)
 
+    def test_catches_json_decode_error(self) -> None:
+        """Decorator catches JSONDecodeError and converts to user-friendly error."""
+        import json
+
+        from click.exceptions import ClickException
+
+        @with_network_error_handling
+        def failing_command() -> None:
+            raise json.JSONDecodeError("Expecting value", "invalid json", 0)
+
+        with pytest.raises(ClickException) as exc_info:
+            failing_command()
+
+        assert "Invalid JSON response from server" in str(exc_info.value)
+        assert "Expecting value" in str(exc_info.value)
+        assert "Hint:" in str(exc_info.value)
+
+    def test_catches_http_status_error(self) -> None:
+        """Decorator catches HTTPStatusError and converts to user-friendly error."""
+        from click.exceptions import ClickException
+
+        @with_network_error_handling
+        def failing_command() -> None:
+            mock_request = MagicMock()
+            mock_response = MagicMock()
+            mock_response.status_code = 404
+            mock_response.json.return_value = {"detail": "Not found"}
+            raise httpx.HTTPStatusError(
+                "404 Not Found", request=mock_request, response=mock_response
+            )
+
+        with pytest.raises(ClickException) as exc_info:
+            failing_command()
+
+        assert "404" in str(exc_info.value)
+
 
 class TestExitCodes:
     """Tests for exit codes in error scenarios."""
@@ -434,3 +470,43 @@ class TestCliRunnerIntegration:
         # Verify exit code is GENERAL_ERROR (1)
         assert result.exit_code == ExitCode.GENERAL_ERROR
         assert "Test operation failed (500)" in result.output
+
+    def test_json_decode_error_exit_code_with_runner(self) -> None:
+        """JSONDecodeError in human mode produces exit code 2 (NETWORK_ERROR)."""
+        import json
+
+        @click.command()
+        @with_network_error_handling
+        def test_command() -> None:
+            """Test command that raises a JSON decode error."""
+            raise json.JSONDecodeError("Expecting value", "invalid json", 0)
+
+        runner = CliRunner()
+        result = runner.invoke(test_command)
+
+        # Verify exit code is NETWORK_ERROR (2)
+        assert result.exit_code == ExitCode.NETWORK_ERROR
+        assert "Invalid JSON response from server" in result.output
+        assert "Hint:" in result.output
+
+    def test_http_status_error_exit_code_with_runner(self) -> None:
+        """HTTPStatusError in human mode produces appropriate exit code."""
+
+        @click.command()
+        @with_network_error_handling
+        def test_command() -> None:
+            """Test command that raises an HTTPStatusError."""
+            mock_request = MagicMock()
+            mock_response = MagicMock()
+            mock_response.status_code = 404
+            mock_response.json.return_value = {"detail": "Not found"}
+            raise httpx.HTTPStatusError(
+                "404 Not Found", request=mock_request, response=mock_response
+            )
+
+        runner = CliRunner()
+        result = runner.invoke(test_command)
+
+        # Verify exit code is NOT_FOUND (3) for 404 errors
+        assert result.exit_code == ExitCode.NOT_FOUND
+        assert "404" in result.output


### PR DESCRIPTION
## Summary

- Enhanced `with_network_error_handling` decorator to catch specific exception types
- Added `httpx.HTTPStatusError` handling for HTTP error status codes
- Added `json.JSONDecodeError` handling with user-friendly error messages
- Updated comprehensive decorator documentation
- Added test coverage for new exception types

## Context

Follow-up from PR #415 review where broad `except Exception` blocks were identified as problematic because they catch both expected errors (connection failures, timeouts, HTTP errors) and unexpected programming errors (attribute errors, bugs in parsing), making debugging harder and potentially hiding bugs.

## Changes

### Exception Handling Improvements

1. **HTTPStatusError handling**: Added catch block for `httpx.HTTPStatusError` which is raised when using `raise_for_status()`. Routes through existing `handle_response_error()` for consistent formatting.

2. **JSONDecodeError handling**: Added catch block for `json.JSONDecodeError` to handle cases where server returns invalid JSON (e.g., error pages, misconfiguration). Provides helpful error message with hint about checking server logs.

3. **Documentation**: Updated decorator docstring to clearly document all exception types handled and note that unexpected exceptions are allowed to propagate for visibility in debug mode and Sentry.

### Design Rationale

- **Specific exception types**: Only catches known, expected exception types from httpx and json modules
- **Unexpected exceptions propagate**: Programming errors (AttributeError, KeyError, TypeError, etc.) are not caught, allowing them to be visible in debug mode and captured by Sentry for diagnosis
- **Consistent error formatting**: Uses existing error handling functions for consistent user experience
- **Comprehensive coverage**: Handles all expected error scenarios from HTTP requests and response parsing

## Test Plan

- [x] All existing unit tests pass (880 tests)
- [x] Added test for JSONDecodeError handling in decorator
- [x] Added test for HTTPStatusError handling in decorator
- [x] Added CLI runner integration test for JSONDecodeError exit codes
- [x] Added CLI runner integration test for HTTPStatusError exit codes
- [x] Verified linting passes (ruff)
- [x] Manual verification that unexpected exceptions still propagate (test_passes_through_non_network_errors)

## References

- Original issue: #417
- PR review comment: https://github.com/SouthwestCCDC/magpie/pull/415#discussion_r2744280873

Closes #417

Generated with Claude Code (Opus 4.6)