### PR TITLE
Add commented examples for optional environment variables in docker-compose.prod.yml

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -78,16 +78,19 @@ services:
       # IMPORTANT: Keep debug mode disabled in production. Enabling it exposes
       # detailed error messages and stack traces that could leak sensitive info.
       - MAGPIE_DEBUG=false
-      # S3/AWS configuration for magpie-ctl sync command
+      # S3/AWS configuration for magpie-ctl sync command (optional)
+      # Uncomment and configure to enable S3 backup functionality
       - MAGPIE_S3_BUCKET=${MAGPIE_S3_BUCKET:-}
       - MAGPIE_S3_PREFIX=${MAGPIE_S3_PREFIX:-}
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-}
       - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN:-}
       - AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-}
-      # Observability configuration
+      # Observability configuration (optional)
+      # Sentry error tracking - set MAGPIE_SENTRY_DSN to enable
       - MAGPIE_SENTRY_DSN=${MAGPIE_SENTRY_DSN:-}
       - MAGPIE_SENTRY_TRACES_SAMPLE_RATE=${MAGPIE_SENTRY_TRACES_SAMPLE_RATE:-1.0}
+      # OpenTelemetry - set MAGPIE_OTEL_ENABLED=true and MAGPIE_OTEL_ENDPOINT to enable
       - MAGPIE_OTEL_ENABLED=${MAGPIE_OTEL_ENABLED:-false}
       - MAGPIE_OTEL_ENDPOINT=${MAGPIE_OTEL_ENDPOINT:-}
       - MAGPIE_OTEL_SERVICE_NAME=${MAGPIE_OTEL_SERVICE_NAME:-magpie}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -79,18 +79,30 @@ services:
       # detailed error messages and stack traces that could leak sensitive info.
       - MAGPIE_DEBUG=false
       # S3/AWS configuration for magpie-ctl sync command (optional)
-      # Uncomment and configure to enable S3 backup functionality
+      # Set these variables in your .env file to enable S3 backup functionality
       - MAGPIE_S3_BUCKET=${MAGPIE_S3_BUCKET:-}
       - MAGPIE_S3_PREFIX=${MAGPIE_S3_PREFIX:-}
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-}
       - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN:-}
       - AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-}
+      # Upload limits (optional)
+      # Set MAGPIE_MAX_UPLOAD_SIZE in bytes to limit upload size (default: unlimited)
+      - MAGPIE_MAX_UPLOAD_SIZE=${MAGPIE_MAX_UPLOAD_SIZE:-}
+      # Logging configuration (optional)
+      # Set MAGPIE_LOG_FORMAT to "console" for human-readable logs (default: json)
+      - MAGPIE_LOG_FORMAT=${MAGPIE_LOG_FORMAT:-json}
+      # Artifact retention (optional)
+      # Set MAGPIE_RETENTION_DAYS for garbage collection retention period (default: 90)
+      - MAGPIE_RETENTION_DAYS=${MAGPIE_RETENTION_DAYS:-90}
+      # Temporary file storage (optional)
+      # Set MAGPIE_TEMP_PATH to override default temp directory (default: /data/artifacts/.tmp)
+      - MAGPIE_TEMP_PATH=${MAGPIE_TEMP_PATH:-}
       # Observability configuration (optional)
-      # Sentry error tracking - set MAGPIE_SENTRY_DSN to enable
+      # Sentry error tracking - set MAGPIE_SENTRY_DSN in .env to enable
       - MAGPIE_SENTRY_DSN=${MAGPIE_SENTRY_DSN:-}
       - MAGPIE_SENTRY_TRACES_SAMPLE_RATE=${MAGPIE_SENTRY_TRACES_SAMPLE_RATE:-1.0}
-      # OpenTelemetry - set MAGPIE_OTEL_ENABLED=true and MAGPIE_OTEL_ENDPOINT to enable
+      # OpenTelemetry - set MAGPIE_OTEL_ENABLED=true and MAGPIE_OTEL_ENDPOINT in .env to enable
       - MAGPIE_OTEL_ENABLED=${MAGPIE_OTEL_ENABLED:-false}
       - MAGPIE_OTEL_ENDPOINT=${MAGPIE_OTEL_ENDPOINT:-}
       - MAGPIE_OTEL_SERVICE_NAME=${MAGPIE_OTEL_SERVICE_NAME:-magpie}


### PR DESCRIPTION
## Summary

Add inline comments to improve discoverability of optional environment variables in docker-compose.prod.yml.

- Mark S3/AWS configuration section as optional with usage instructions
- Add all optional configuration variables from config.py (upload limits, logging, retention, temp path)
- Split observability configuration into Sentry and OpenTelemetry subsections with inline comments
- Fix misleading "Uncomment and configure" wording - these variables are already active with empty defaults

## Changes

- **docker-compose.prod.yml**: Added inline comments for all optional environment variables
  - S3/AWS backup configuration
  - Upload size limits
  - Logging format
  - Retention policy
  - Temporary file path override
  - Observability (Sentry and OpenTelemetry)

## Why

These optional features were already present in the compose file or config.py, but without inline comments explaining their purpose or when to configure them. This made them less discoverable for users reviewing the production configuration.

## Note on Issue #429

Issue #429 mentions `MAGPIE_TLS_CONFIG` for manual TLS certificates, but this environment variable does not exist in the codebase. TLS configuration is handled via Caddyfile.prod (see lines 166-170), not through environment variables.

This PR instead adds the genuinely optional environment variables that exist in config.py but were missing from the production compose file (observability, upload limits, logging, retention, temp path).

## Testing

- Validated docker-compose.prod.yml syntax with `docker compose config`
- Ran unit tests: all 876 tests pass
- Ran ruff linting: all checks pass

## Related

Partially addresses #429 (adds optional env vars, but MAGPIE_TLS_CONFIG does not exist)

---
Generated with Claude Code (Opus 4.6)
