### PR TITLE
fix(cli): Differentiate ConnectError subtypes for more specific error messages

### DIFF
--- a/src/magpie/cli/errors.py
+++ b/src/magpie/cli/errors.py
@@ -6,6 +6,7 @@ consistent error messages and exit codes across the application.
 
 from __future__ import annotations
 
+import errno
 import json
 import socket
 import ssl
@@ -180,6 +181,11 @@ def format_network_error(exc: Exception, server: str | None = None) -> str:
             msg = f"Could not connect to server '{hostname}': Connection refused"
             hint = "Check that the server is running and the URL is correct."
             return f"{msg}\nHint: {hint}"
+        if isinstance(cause, ConnectionResetError):
+            msg = f"Could not connect to server '{hostname}': Connection reset by peer"
+            hint = "The server closed the connection. Check server logs or try again."
+            return f"{msg}\nHint: {hint}"
+        # Note: ssl.SSLError inherits from OSError, so it must be checked before OSError
         if isinstance(cause, ssl.SSLError):
             msg = f"Could not connect to server '{hostname}': TLS handshake failed"
             hint = (
@@ -188,14 +194,10 @@ def format_network_error(exc: Exception, server: str | None = None) -> str:
             return f"{msg}\nHint: {hint}"
         if isinstance(cause, OSError):
             # Check errno for common network conditions
-            errno_msg = getattr(cause, "errno", None)
-            if errno_msg == 101:  # ENETUNREACH
+            errno_val = getattr(cause, "errno", None)
+            if errno_val == errno.ENETUNREACH:
                 msg = f"Could not connect to server '{hostname}': Network unreachable"
                 hint = "Check your network connection and routing configuration."
-                return f"{msg}\nHint: {hint}"
-            if errno_msg == 104:  # ECONNRESET
-                msg = f"Could not connect to server '{hostname}': Connection reset by peer"
-                hint = "The server closed the connection. Check server logs or try again."
                 return f"{msg}\nHint: {hint}"
             # Fall through to generic connection failed for other OSErrors
 

--- a/src/magpie/cli/errors.py
+++ b/src/magpie/cli/errors.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import socket
+import ssl
 from functools import wraps
 from typing import Callable, TypeVar
 
@@ -173,8 +174,35 @@ def format_network_error(exc: Exception, server: str | None = None) -> str:
             hint = "Check that the server hostname is correct and your network is connected."
             return f"{msg}\nHint: {hint}"
 
-        # Connection refused or similar
-        msg = f"Could not connect to server '{hostname}': Connection refused"
+        # Check for specific connection failure types by inspecting the cause
+        cause = exc.__cause__
+        if isinstance(cause, ConnectionRefusedError):
+            msg = f"Could not connect to server '{hostname}': Connection refused"
+            hint = "Check that the server is running and the URL is correct."
+            return f"{msg}\nHint: {hint}"
+        if isinstance(cause, ssl.SSLError):
+            msg = f"Could not connect to server '{hostname}': TLS handshake failed"
+            hint = (
+                "Check server certificate configuration or try using http:// instead of https://."
+            )
+            return f"{msg}\nHint: {hint}"
+        if isinstance(cause, OSError):
+            # Check errno for common network conditions
+            errno_msg = getattr(cause, "errno", None)
+            if errno_msg == 101:  # ENETUNREACH
+                msg = f"Could not connect to server '{hostname}': Network unreachable"
+                hint = "Check your network connection and routing configuration."
+                return f"{msg}\nHint: {hint}"
+            if errno_msg == 104:  # ECONNRESET
+                msg = f"Could not connect to server '{hostname}': Connection reset by peer"
+                hint = "The server closed the connection. Check server logs or try again."
+                return f"{msg}\nHint: {hint}"
+            # Fall through to generic connection failed for other OSErrors
+
+        # Generic connection failure for unrecognized causes
+        msg = f"Could not connect to server '{hostname}': Connection failed"
+        if cause:
+            msg += f" ({cause})"
         hint = "Check that the server is running and the URL is correct."
         return f"{msg}\nHint: {hint}"
 

--- a/tests/unit/test_cli_network_errors.py
+++ b/tests/unit/test_cli_network_errors.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import socket
+import ssl
 from unittest.mock import MagicMock, patch
 
 import click
@@ -37,7 +38,10 @@ class TestFormatNetworkError:
 
     def test_connection_refused(self) -> None:
         """Connection refused produces helpful error message."""
+        # Create ConnectError with ConnectionRefusedError as cause
+        refused_error = ConnectionRefusedError("Connection refused")
         connect_error = httpx.ConnectError("Connection refused", request=MagicMock())
+        connect_error.__cause__ = refused_error
 
         result = format_network_error(connect_error, server="https://magpie.example.com")
 
@@ -45,6 +49,74 @@ class TestFormatNetworkError:
         assert "Connection refused" in result
         assert "Hint:" in result
         assert "server is running" in result
+
+    def test_tls_handshake_failure(self) -> None:
+        """TLS handshake failure produces helpful error message."""
+        # Create ConnectError with ssl.SSLError as cause
+        ssl_error = ssl.SSLError("certificate verify failed")
+        connect_error = httpx.ConnectError("TLS handshake failed", request=MagicMock())
+        connect_error.__cause__ = ssl_error
+
+        result = format_network_error(connect_error, server="https://magpie.example.com")
+
+        assert "magpie.example.com" in result
+        assert "TLS handshake failed" in result
+        assert "Hint:" in result
+        assert "certificate" in result.lower()
+
+    def test_network_unreachable(self) -> None:
+        """Network unreachable produces helpful error message."""
+        # Create ConnectError with OSError errno 101 (ENETUNREACH) as cause
+        net_error = OSError(101, "Network is unreachable")
+        connect_error = httpx.ConnectError("Network unreachable", request=MagicMock())
+        connect_error.__cause__ = net_error
+
+        result = format_network_error(connect_error, server="https://magpie.example.com")
+
+        assert "magpie.example.com" in result
+        assert "Network unreachable" in result
+        assert "Hint:" in result
+        assert "routing" in result.lower()
+
+    def test_connection_reset(self) -> None:
+        """Connection reset by peer produces helpful error message."""
+        # Create ConnectError with OSError errno 104 (ECONNRESET) as cause
+        reset_error = OSError(104, "Connection reset by peer")
+        connect_error = httpx.ConnectError("Connection reset", request=MagicMock())
+        connect_error.__cause__ = reset_error
+
+        result = format_network_error(connect_error, server="https://magpie.example.com")
+
+        assert "magpie.example.com" in result
+        assert "Connection reset" in result
+        assert "Hint:" in result
+        assert "server" in result.lower()
+
+    def test_generic_connect_error(self) -> None:
+        """Generic ConnectError with unrecognized cause shows cause details."""
+        # Create ConnectError with generic exception as cause
+        generic_error = RuntimeError("Some unexpected error")
+        connect_error = httpx.ConnectError("Connection failed", request=MagicMock())
+        connect_error.__cause__ = generic_error
+
+        result = format_network_error(connect_error, server="https://magpie.example.com")
+
+        assert "magpie.example.com" in result
+        assert "Connection failed" in result
+        assert "Some unexpected error" in result
+        assert "Hint:" in result
+
+    def test_connect_error_no_cause(self) -> None:
+        """ConnectError without a cause falls back to generic message."""
+        connect_error = httpx.ConnectError("Connection failed", request=MagicMock())
+        # Explicitly set no cause
+        connect_error.__cause__ = None
+
+        result = format_network_error(connect_error, server="https://magpie.example.com")
+
+        assert "magpie.example.com" in result
+        assert "Connection failed" in result
+        assert "Hint:" in result
 
     def test_timeout_error(self) -> None:
         """Timeout error produces helpful error message."""
@@ -185,7 +257,7 @@ class TestWithNetworkErrorHandlingDecorator:
         with pytest.raises(ClickException) as exc_info:
             failing_command()
 
-        assert "Connection refused" in str(exc_info.value)
+        assert "Connection failed" in str(exc_info.value)
 
     def test_catches_timeout_error(self) -> None:
         """Decorator catches TimeoutException and converts to user-friendly error."""
@@ -326,7 +398,7 @@ class TestCliRunnerIntegration:
 
         # Verify exit code is NETWORK_ERROR (2), not GENERAL_ERROR (1)
         assert result.exit_code == ExitCode.NETWORK_ERROR
-        assert "Connection refused" in result.output
+        assert "Connection failed" in result.output
 
     def test_timeout_error_exit_code_with_runner(self) -> None:
         """Timeout error in human mode produces exit code 2 (NETWORK_ERROR)."""

--- a/tests/unit/test_cli_network_errors.py
+++ b/tests/unit/test_cli_network_errors.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import errno
 import socket
 import ssl
 from unittest.mock import MagicMock, patch
@@ -66,8 +67,8 @@ class TestFormatNetworkError:
 
     def test_network_unreachable(self) -> None:
         """Network unreachable produces helpful error message."""
-        # Create ConnectError with OSError errno 101 (ENETUNREACH) as cause
-        net_error = OSError(101, "Network is unreachable")
+        # Create ConnectError with OSError using errno.ENETUNREACH as cause
+        net_error = OSError(errno.ENETUNREACH, "Network is unreachable")
         connect_error = httpx.ConnectError("Network unreachable", request=MagicMock())
         connect_error.__cause__ = net_error
 
@@ -80,8 +81,8 @@ class TestFormatNetworkError:
 
     def test_connection_reset(self) -> None:
         """Connection reset by peer produces helpful error message."""
-        # Create ConnectError with OSError errno 104 (ECONNRESET) as cause
-        reset_error = OSError(104, "Connection reset by peer")
+        # Create ConnectError with ConnectionResetError as cause
+        reset_error = ConnectionResetError("Connection reset by peer")
         connect_error = httpx.ConnectError("Connection reset", request=MagicMock())
         connect_error.__cause__ = reset_error
 


### PR DESCRIPTION
## Summary

Fixes misleading "Connection refused" error messages when `httpx.ConnectError` is caused by other connection failures like TLS handshake errors, network unreachable, or connection reset.

Changes:
- Inspect `exc.__cause__` to identify specific connection failure types
- Add handling for `ConnectionRefusedError` (explicit connection refused)
- Add handling for `ssl.SSLError` (TLS handshake failures)
- Add handling for `OSError` errno 101 (network unreachable)
- Add handling for `OSError` errno 104 (connection reset by peer)
- Fall back to generic "Connection failed" with cause details for unrecognized errors
- Add comprehensive test coverage for all new error cases
- Update existing tests to expect new generic "Connection failed" message

## Test Plan

- [x] All unit tests pass (881 tests)
- [x] New tests added for TLS failures, network unreachable, connection reset
- [x] Existing network error tests updated and passing
- [x] Linting passes (`ruff check`)
- [x] Formatting passes (`ruff format --check`)

## Examples

Before:
```
Could not connect to server 'magpie.example.com': Connection refused
Hint: Check that the server is running and the URL is correct.
```

After (for TLS error):
```
Could not connect to server 'magpie.example.com': TLS handshake failed
Hint: Check server certificate configuration or try using http:// instead of https://.
```

After (for network unreachable):
```
Could not connect to server 'magpie.example.com': Network unreachable
Hint: Check your network connection and routing configuration.
```

After (for actual connection refused):
```
Could not connect to server 'magpie.example.com': Connection refused
Hint: Check that the server is running and the URL is correct.
```

Closes #460

Generated with Claude Code w/ Opus 4.6