### PR TITLE
Isolate release candidate container tags from stable release tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,10 +76,10 @@ jobs:
           tags: |
             # Tag with version (v1.0.0 -> 1.0.0)
             type=semver,pattern={{version}}
-            # Tag with major.minor (v1.0.0 -> 1.0)
-            type=semver,pattern={{major}}.{{minor}}
-            # Tag with major (v1.0.0 -> 1)
-            type=semver,pattern={{major}}
+            # Tag with major.minor (v1.0.0 -> 1.0) - stable releases only
+            type=semver,pattern={{major}}.{{minor}},enable=${{ needs.validate.outputs.is_prerelease == 'false' }}
+            # Tag with major (v1.0.0 -> 1) - stable releases only
+            type=semver,pattern={{major}},enable=${{ needs.validate.outputs.is_prerelease == 'false' }}
             # Tag latest only for stable releases (not prereleases)
             type=raw,value=latest,enable=${{ needs.validate.outputs.is_prerelease == 'false' }}
 


### PR DESCRIPTION
## Summary
- Add `enable` conditions to Docker metadata action to exclude major/minor semver patterns for prereleases
- Prevents release candidates from updating mutable major/minor container tags
- Aligns workflow behavior with documented tagging policy

## Changes
Modified `.github/workflows/release.yml`:
- Added `enable=${{ needs.validate.outputs.is_prerelease == 'false' }}` to major.minor pattern
- Added `enable=${{ needs.validate.outputs.is_prerelease == 'false' }}` to major pattern
- Updated comments to clarify stable-only tags

## Behavior Change
**Before:**
- `v2.0.0-rc1` creates tags: `2.0.0-rc1`, `2.0`, `2` (no `latest`)
- `v2.0.0-rc2` updates tags: `2.0.0-rc2`, `2.0`, `2` (no `latest`)

**After:**
- `v2.0.0-rc1` creates tag: `2.0.0-rc1` only
- `v2.0.0-rc2` creates tag: `2.0.0-rc2` only
- `v2.0.0` creates tags: `2.0.0`, `2.0`, `2`, `latest`

## Testing
- [x] YAML syntax validation passes

## Follow-up
After merge, issue #487 mentions updating `docs/releases.md` to remove RC warnings and restore cleaner isolation model.

Closes #487

---
Generated with Claude Code w/ Opus 4.6