### PR TITLE
fix(cli): Use operation parameter in handle_network_error

### DIFF
--- a/src/magpie/cli/errors.py
+++ b/src/magpie/cli/errors.py
@@ -179,7 +179,9 @@ def format_network_error(exc: Exception, operation: str, server: str | None = No
         # Check for specific connection failure types by inspecting the cause
         cause = exc.__cause__
         if isinstance(cause, ConnectionRefusedError):
-            msg = f"{operation} failed: Could not connect to server '{hostname}': Connection refused"
+            msg = (
+                f"{operation} failed: Could not connect to server '{hostname}': Connection refused"
+            )
             hint = "Check that the server is running and the URL is correct."
             return f"{msg}\nHint: {hint}"
         if isinstance(cause, ConnectionResetError):

--- a/src/magpie/cli/errors.py
+++ b/src/magpie/cli/errors.py
@@ -152,11 +152,12 @@ def handle_response_error(
     handle_http_error(response, operation, token)
 
 
-def format_network_error(exc: Exception, server: str | None = None) -> str:
+def format_network_error(exc: Exception, operation: str, server: str | None = None) -> str:
     """Format a network exception into a user-friendly error message.
 
     Args:
         exc: The network exception to format.
+        operation: Description of the operation that failed.
         server: Optional server URL for context.
 
     Returns:
@@ -171,23 +172,23 @@ def format_network_error(exc: Exception, server: str | None = None) -> str:
     if isinstance(exc, httpx.ConnectError):
         # Check if it's a DNS resolution error
         if isinstance(exc.__cause__, socket.gaierror):
-            msg = f"Could not connect to server '{hostname}': DNS resolution failed"
+            msg = f"{operation} failed: Could not connect to server '{hostname}': DNS resolution failed"
             hint = "Check that the server hostname is correct and your network is connected."
             return f"{msg}\nHint: {hint}"
 
         # Check for specific connection failure types by inspecting the cause
         cause = exc.__cause__
         if isinstance(cause, ConnectionRefusedError):
-            msg = f"Could not connect to server '{hostname}': Connection refused"
+            msg = f"{operation} failed: Could not connect to server '{hostname}': Connection refused"
             hint = "Check that the server is running and the URL is correct."
             return f"{msg}\nHint: {hint}"
         if isinstance(cause, ConnectionResetError):
-            msg = f"Could not connect to server '{hostname}': Connection reset by peer"
+            msg = f"{operation} failed: Could not connect to server '{hostname}': Connection reset by peer"
             hint = "The server closed the connection. Check server logs or try again."
             return f"{msg}\nHint: {hint}"
         # Note: ssl.SSLError inherits from OSError, so it must be checked before OSError
         if isinstance(cause, ssl.SSLError):
-            msg = f"Could not connect to server '{hostname}': TLS handshake failed"
+            msg = f"{operation} failed: Could not connect to server '{hostname}': TLS handshake failed"
             hint = (
                 "Check server certificate configuration or try using http:// instead of https://."
             )
@@ -196,52 +197,52 @@ def format_network_error(exc: Exception, server: str | None = None) -> str:
             # Check errno for common network conditions
             errno_val = getattr(cause, "errno", None)
             if errno_val == errno.ENETUNREACH:
-                msg = f"Could not connect to server '{hostname}': Network unreachable"
+                msg = f"{operation} failed: Could not connect to server '{hostname}': Network unreachable"
                 hint = "Check your network connection and routing configuration."
                 return f"{msg}\nHint: {hint}"
             # Fall through to generic connection failed for other OSErrors
 
         # Generic connection failure for unrecognized causes
-        msg = f"Could not connect to server '{hostname}': Connection failed"
+        msg = f"{operation} failed: Could not connect to server '{hostname}': Connection failed"
         if cause:
             msg += f" ({cause})"
         hint = "Check that the server is running and the URL is correct."
         return f"{msg}\nHint: {hint}"
 
     if isinstance(exc, httpx.TimeoutException):
-        msg = f"Request to server '{hostname}' timed out"
+        msg = f"{operation} failed: Request to server '{hostname}' timed out"
         hint = "Check your network connection or try increasing the timeout with --timeout."
         return f"{msg}\nHint: {hint}"
 
     if isinstance(exc, httpx.ProxyError):
-        msg = f"Proxy error connecting to '{hostname}': {exc}"
+        msg = f"{operation} failed: Proxy error connecting to '{hostname}': {exc}"
         hint = "Check your proxy configuration and that the proxy is accessible."
         return f"{msg}\nHint: {hint}"
 
     if isinstance(exc, httpx.UnsupportedProtocol):
-        msg = f"Unsupported protocol connecting to '{hostname}': {exc}"
+        msg = f"{operation} failed: Unsupported protocol connecting to '{hostname}': {exc}"
         hint = "Check that the server URL uses a supported protocol (http/https)."
         return f"{msg}\nHint: {hint}"
 
     if isinstance(exc, httpx.ProtocolError):
-        msg = f"Protocol error connecting to '{hostname}': {exc}"
+        msg = f"{operation} failed: Protocol error connecting to '{hostname}': {exc}"
         hint = "The server sent an invalid response. Check server logs or try again."
         return f"{msg}\nHint: {hint}"
 
     if isinstance(exc, httpx.RequestError):
         # Generic request error (catches all other RequestError subclasses)
-        msg = f"Network error connecting to '{hostname}': {exc}"
+        msg = f"{operation} failed: Network error connecting to '{hostname}': {exc}"
         hint = "Check your network connection and server configuration."
         return f"{msg}\nHint: {hint}"
 
     if isinstance(exc, socket.gaierror):
         # Standalone DNS resolution error (not wrapped in httpx exception)
-        msg = f"Could not connect to server '{hostname}': DNS resolution failed"
+        msg = f"{operation} failed: Could not connect to server '{hostname}': DNS resolution failed"
         hint = "Check that the server hostname is correct and your network is connected."
         return f"{msg}\nHint: {hint}"
 
     # Fallback for unexpected network errors
-    return f"Network error: {exc}"
+    return f"{operation} failed: Network error: {exc}"
 
 
 def handle_network_error(exc: Exception, operation: str, server: str | None = None) -> None:
@@ -259,7 +260,7 @@ def handle_network_error(exc: Exception, operation: str, server: str | None = No
     # Import here to avoid circular imports
     from magpie.cli.formatting import ErrorCode, ExitCode, is_json_output, output_error
 
-    error_msg = format_network_error(exc, server)
+    error_msg = format_network_error(exc, operation, server)
 
     if is_json_output():
         output_error(ErrorCode.NETWORK_ERROR, error_msg, exit_code=ExitCode.NETWORK_ERROR)

--- a/tests/unit/test_cli_network_errors.py
+++ b/tests/unit/test_cli_network_errors.py
@@ -30,7 +30,9 @@ class TestFormatNetworkError:
         connect_error = httpx.ConnectError("Connection failed", request=MagicMock())
         connect_error.__cause__ = dns_error
 
-        result = format_network_error(connect_error, server="https://magpie.example.com")
+        result = format_network_error(connect_error, "test_operation", server="https://magpie.example.com")
+
+        assert "test_operation failed:" in result
 
         assert "magpie.example.com" in result
         assert "DNS resolution failed" in result
@@ -44,7 +46,9 @@ class TestFormatNetworkError:
         connect_error = httpx.ConnectError("Connection refused", request=MagicMock())
         connect_error.__cause__ = refused_error
 
-        result = format_network_error(connect_error, server="https://magpie.example.com")
+        result = format_network_error(connect_error, "test_operation", server="https://magpie.example.com")
+
+        assert "test_operation failed:" in result
 
         assert "magpie.example.com" in result
         assert "Connection refused" in result
@@ -58,7 +62,9 @@ class TestFormatNetworkError:
         connect_error = httpx.ConnectError("TLS handshake failed", request=MagicMock())
         connect_error.__cause__ = ssl_error
 
-        result = format_network_error(connect_error, server="https://magpie.example.com")
+        result = format_network_error(connect_error, "test_operation", server="https://magpie.example.com")
+
+        assert "test_operation failed:" in result
 
         assert "magpie.example.com" in result
         assert "TLS handshake failed" in result
@@ -72,7 +78,9 @@ class TestFormatNetworkError:
         connect_error = httpx.ConnectError("Network unreachable", request=MagicMock())
         connect_error.__cause__ = net_error
 
-        result = format_network_error(connect_error, server="https://magpie.example.com")
+        result = format_network_error(connect_error, "test_operation", server="https://magpie.example.com")
+
+        assert "test_operation failed:" in result
 
         assert "magpie.example.com" in result
         assert "Network unreachable" in result
@@ -86,7 +94,9 @@ class TestFormatNetworkError:
         connect_error = httpx.ConnectError("Connection reset", request=MagicMock())
         connect_error.__cause__ = reset_error
 
-        result = format_network_error(connect_error, server="https://magpie.example.com")
+        result = format_network_error(connect_error, "test_operation", server="https://magpie.example.com")
+
+        assert "test_operation failed:" in result
 
         assert "magpie.example.com" in result
         assert "Connection reset" in result
@@ -100,7 +110,9 @@ class TestFormatNetworkError:
         connect_error = httpx.ConnectError("Connection failed", request=MagicMock())
         connect_error.__cause__ = generic_error
 
-        result = format_network_error(connect_error, server="https://magpie.example.com")
+        result = format_network_error(connect_error, "test_operation", server="https://magpie.example.com")
+
+        assert "test_operation failed:" in result
 
         assert "magpie.example.com" in result
         assert "Connection failed" in result
@@ -113,7 +125,9 @@ class TestFormatNetworkError:
         # Explicitly set no cause
         connect_error.__cause__ = None
 
-        result = format_network_error(connect_error, server="https://magpie.example.com")
+        result = format_network_error(connect_error, "test_operation", server="https://magpie.example.com")
+
+        assert "test_operation failed:" in result
 
         assert "magpie.example.com" in result
         assert "Connection failed" in result
@@ -123,7 +137,9 @@ class TestFormatNetworkError:
         """Timeout error produces helpful error message."""
         timeout_error = httpx.TimeoutException("Request timed out", request=MagicMock())
 
-        result = format_network_error(timeout_error, server="https://magpie.example.com")
+        result = format_network_error(timeout_error, "test_operation", server="https://magpie.example.com")
+
+        assert "test_operation failed:" in result
 
         assert "magpie.example.com" in result
         assert "timed out" in result
@@ -134,7 +150,9 @@ class TestFormatNetworkError:
         """Generic request error produces error message."""
         request_error = httpx.RequestError("Network error", request=MagicMock())
 
-        result = format_network_error(request_error, server="https://magpie.example.com")
+        result = format_network_error(request_error, "test_operation", server="https://magpie.example.com")
+
+        assert "test_operation failed:" in result
 
         assert "magpie.example.com" in result
         assert "Network error" in result
@@ -146,7 +164,7 @@ class TestFormatNetworkError:
         connect_error.__cause__ = socket.gaierror("Name or service not known")
 
         result = format_network_error(
-            connect_error, server="https://artifacts.example.com:8443/api"
+            connect_error, "test_operation", server="https://artifacts.example.com:8443/api"
         )
 
         assert "artifacts.example.com:8443" in result
@@ -156,7 +174,9 @@ class TestFormatNetworkError:
         """Error message uses 'server' when no URL provided."""
         connect_error = httpx.ConnectError("Connection failed", request=MagicMock())
 
-        result = format_network_error(connect_error, server=None)
+        result = format_network_error(connect_error, "test_operation", server=None)
+
+        assert "test_operation failed:" in result
 
         assert "server" in result
 
@@ -164,7 +184,9 @@ class TestFormatNetworkError:
         """Standalone socket.gaierror produces helpful DNS error message."""
         dns_error = socket.gaierror("Name or service not known")
 
-        result = format_network_error(dns_error, server="https://magpie.example.com")
+        result = format_network_error(dns_error, "test_operation", server="https://magpie.example.com")
+
+        assert "test_operation failed:" in result
 
         assert "magpie.example.com" in result
         assert "DNS resolution failed" in result
@@ -175,7 +197,9 @@ class TestFormatNetworkError:
         """ProxyError produces helpful error message."""
         proxy_error = httpx.ProxyError("Proxy connection failed")
 
-        result = format_network_error(proxy_error, server="https://magpie.example.com")
+        result = format_network_error(proxy_error, "test_operation", server="https://magpie.example.com")
+
+        assert "test_operation failed:" in result
 
         assert "magpie.example.com" in result
         assert "Proxy error" in result
@@ -186,7 +210,9 @@ class TestFormatNetworkError:
         """UnsupportedProtocol produces helpful error message."""
         protocol_error = httpx.UnsupportedProtocol("Unsupported protocol 'ftp'")
 
-        result = format_network_error(protocol_error, server="ftp://magpie.example.com")
+        result = format_network_error(protocol_error, "test_operation", server="ftp://magpie.example.com")
+
+        assert "test_operation failed:" in result
 
         assert "magpie.example.com" in result
         assert "Unsupported protocol" in result
@@ -197,7 +223,9 @@ class TestFormatNetworkError:
         """ProtocolError produces helpful error message."""
         protocol_error = httpx.ProtocolError("Invalid HTTP response")
 
-        result = format_network_error(protocol_error, server="https://magpie.example.com")
+        result = format_network_error(protocol_error, "test_operation", server="https://magpie.example.com")
+
+        assert "test_operation failed:" in result
 
         assert "magpie.example.com" in result
         assert "Protocol error" in result

--- a/tests/unit/test_cli_network_errors.py
+++ b/tests/unit/test_cli_network_errors.py
@@ -30,7 +30,9 @@ class TestFormatNetworkError:
         connect_error = httpx.ConnectError("Connection failed", request=MagicMock())
         connect_error.__cause__ = dns_error
 
-        result = format_network_error(connect_error, "test_operation", server="https://magpie.example.com")
+        result = format_network_error(
+            connect_error, "test_operation", server="https://magpie.example.com"
+        )
 
         assert "test_operation failed:" in result
 
@@ -46,7 +48,9 @@ class TestFormatNetworkError:
         connect_error = httpx.ConnectError("Connection refused", request=MagicMock())
         connect_error.__cause__ = refused_error
 
-        result = format_network_error(connect_error, "test_operation", server="https://magpie.example.com")
+        result = format_network_error(
+            connect_error, "test_operation", server="https://magpie.example.com"
+        )
 
         assert "test_operation failed:" in result
 
@@ -62,7 +66,9 @@ class TestFormatNetworkError:
         connect_error = httpx.ConnectError("TLS handshake failed", request=MagicMock())
         connect_error.__cause__ = ssl_error
 
-        result = format_network_error(connect_error, "test_operation", server="https://magpie.example.com")
+        result = format_network_error(
+            connect_error, "test_operation", server="https://magpie.example.com"
+        )
 
         assert "test_operation failed:" in result
 
@@ -78,7 +84,9 @@ class TestFormatNetworkError:
         connect_error = httpx.ConnectError("Network unreachable", request=MagicMock())
         connect_error.__cause__ = net_error
 
-        result = format_network_error(connect_error, "test_operation", server="https://magpie.example.com")
+        result = format_network_error(
+            connect_error, "test_operation", server="https://magpie.example.com"
+        )
 
         assert "test_operation failed:" in result
 
@@ -94,7 +102,9 @@ class TestFormatNetworkError:
         connect_error = httpx.ConnectError("Connection reset", request=MagicMock())
         connect_error.__cause__ = reset_error
 
-        result = format_network_error(connect_error, "test_operation", server="https://magpie.example.com")
+        result = format_network_error(
+            connect_error, "test_operation", server="https://magpie.example.com"
+        )
 
         assert "test_operation failed:" in result
 
@@ -110,7 +120,9 @@ class TestFormatNetworkError:
         connect_error = httpx.ConnectError("Connection failed", request=MagicMock())
         connect_error.__cause__ = generic_error
 
-        result = format_network_error(connect_error, "test_operation", server="https://magpie.example.com")
+        result = format_network_error(
+            connect_error, "test_operation", server="https://magpie.example.com"
+        )
 
         assert "test_operation failed:" in result
 
@@ -125,7 +137,9 @@ class TestFormatNetworkError:
         # Explicitly set no cause
         connect_error.__cause__ = None
 
-        result = format_network_error(connect_error, "test_operation", server="https://magpie.example.com")
+        result = format_network_error(
+            connect_error, "test_operation", server="https://magpie.example.com"
+        )
 
         assert "test_operation failed:" in result
 
@@ -137,7 +151,9 @@ class TestFormatNetworkError:
         """Timeout error produces helpful error message."""
         timeout_error = httpx.TimeoutException("Request timed out", request=MagicMock())
 
-        result = format_network_error(timeout_error, "test_operation", server="https://magpie.example.com")
+        result = format_network_error(
+            timeout_error, "test_operation", server="https://magpie.example.com"
+        )
 
         assert "test_operation failed:" in result
 
@@ -150,7 +166,9 @@ class TestFormatNetworkError:
         """Generic request error produces error message."""
         request_error = httpx.RequestError("Network error", request=MagicMock())
 
-        result = format_network_error(request_error, "test_operation", server="https://magpie.example.com")
+        result = format_network_error(
+            request_error, "test_operation", server="https://magpie.example.com"
+        )
 
         assert "test_operation failed:" in result
 
@@ -184,7 +202,9 @@ class TestFormatNetworkError:
         """Standalone socket.gaierror produces helpful DNS error message."""
         dns_error = socket.gaierror("Name or service not known")
 
-        result = format_network_error(dns_error, "test_operation", server="https://magpie.example.com")
+        result = format_network_error(
+            dns_error, "test_operation", server="https://magpie.example.com"
+        )
 
         assert "test_operation failed:" in result
 
@@ -197,7 +217,9 @@ class TestFormatNetworkError:
         """ProxyError produces helpful error message."""
         proxy_error = httpx.ProxyError("Proxy connection failed")
 
-        result = format_network_error(proxy_error, "test_operation", server="https://magpie.example.com")
+        result = format_network_error(
+            proxy_error, "test_operation", server="https://magpie.example.com"
+        )
 
         assert "test_operation failed:" in result
 
@@ -210,7 +232,9 @@ class TestFormatNetworkError:
         """UnsupportedProtocol produces helpful error message."""
         protocol_error = httpx.UnsupportedProtocol("Unsupported protocol 'ftp'")
 
-        result = format_network_error(protocol_error, "test_operation", server="ftp://magpie.example.com")
+        result = format_network_error(
+            protocol_error, "test_operation", server="ftp://magpie.example.com"
+        )
 
         assert "test_operation failed:" in result
 
@@ -223,7 +247,9 @@ class TestFormatNetworkError:
         """ProtocolError produces helpful error message."""
         protocol_error = httpx.ProtocolError("Invalid HTTP response")
 
-        result = format_network_error(protocol_error, "test_operation", server="https://magpie.example.com")
+        result = format_network_error(
+            protocol_error, "test_operation", server="https://magpie.example.com"
+        )
 
         assert "test_operation failed:" in result
 


### PR DESCRIPTION
## Summary

Fixes #461 by using the `operation` parameter in `handle_network_error()` and `format_network_error()`.

The `operation` parameter was documented but never used in the function body. This change makes network error handling consistent with HTTP error handling by prefixing all error messages with `"{operation} failed:"` for better context.

## Changes

- Updated `format_network_error()` signature to accept `operation` parameter
- Prefixed all network error messages with operation context
- Updated all test calls to pass the operation parameter
- Added assertions to verify operation is included in error messages

## Test Plan

- All existing unit tests pass (40/40 in `test_cli_network_errors.py`)
- Added assertions to verify operation prefix is present in all error messages
- Linting passes with `uv run ruff check`

## Example

Before:
```
Could not connect to server 'magpie.example.com': Connection refused
```

After:
```
upload failed: Could not connect to server 'magpie.example.com': Connection refused
```

Generated with Claude Code (Sonnet 4.5)