### PR TITLE
refactor(cli): Remove redundant @sentry_wrapper from version command

### DIFF
--- a/src/magpie/cli/__init__.py
+++ b/src/magpie/cli/__init__.py
@@ -154,7 +154,6 @@ def cli(
 )
 @pass_context
 @with_network_error_handling
-@sentry_wrapper
 def version(ctx: CLIContext, server_version: bool) -> None:
     """Show version.
 


### PR DESCRIPTION
## Summary

Removes redundant `@sentry_wrapper` decorator from the `version` command.

The CLI entrypoint already wraps the entire `cli` group via `main = sentry_wrapper(cli)`, so all commands (including `version`) are already wrapped at the top level. The per-command decorator created unnecessary double-wrapping.

## Changes

- Removed `@sentry_wrapper` decorator from `version` command in `src/magpie/cli/__init__.py`
- All commands continue to be wrapped via the top-level `main = sentry_wrapper(cli)`

## Test Plan

- [x] All unit tests pass: `uv run pytest tests/unit/ -v`
- [x] Version command integration tests pass: `uv run pytest tests/integration/test_cli_version.py -v`
- [x] Lint checks pass: `uv run ruff check src/ tests/`
- [x] Format checks pass: `uv run ruff format src/ tests/`

## Related Issues

Fixes #462

Generated with Claude Code w/ Sonnet 4.5