### PR TITLE
refactor: use regex for token extraction in unit tests

### DIFF
--- a/tests/unit/test_ctl_init_gc.py
+++ b/tests/unit/test_ctl_init_gc.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import patch
@@ -155,12 +156,10 @@ class TestInitCommand:
             # First init creates token
             result1 = cli_runner.invoke(cli, ["init"])
             assert result1.exit_code == 0
-            # Extract first token
-            first_token = None
-            for line in result1.output.split("\n"):
-                if line.startswith("mgp_ADMIN_"):
-                    first_token = line.strip()
-                    break
+            # Extract first token using regex
+            match1 = re.search(r"mgp_ADMIN_[A-Za-z0-9_-]+", result1.output)
+            assert match1 is not None, "Failed to find admin token in output"
+            first_token = match1.group(0)
 
             # Reset token
             result2 = cli_runner.invoke(cli, ["init", "--reset-admin-token"])
@@ -168,16 +167,12 @@ class TestInitCommand:
             assert "NEW ADMIN TOKEN" in result2.output
             assert "Revoked existing" in result2.output
 
-            # Extract second token
-            second_token = None
-            for line in result2.output.split("\n"):
-                if line.startswith("mgp_ADMIN_"):
-                    second_token = line.strip()
-                    break
+            # Extract second token using regex
+            match2 = re.search(r"mgp_ADMIN_[A-Za-z0-9_-]+", result2.output)
+            assert match2 is not None, "Failed to find new admin token in output"
+            second_token = match2.group(0)
 
             # Tokens should be different
-            assert first_token is not None
-            assert second_token is not None
             assert first_token != second_token
 
     def test_init_with_custom_admin_token(

--- a/tests/unit/test_ctl_token.py
+++ b/tests/unit/test_ctl_token.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from unittest.mock import patch
 
@@ -165,12 +166,9 @@ class TestTokenList:
             create_result = cli_runner.invoke(
                 cli, ["token", "create", "--name", "secret", "--scope", "read"]
             )
-            # Extract the token from create output
-            token_line = None
-            for line in create_result.output.split("\n"):
-                if line.startswith("mgp_"):
-                    token_line = line.strip()
-                    break
+            # Extract the token from create output using regex
+            match = re.search(r"mgp_[A-Za-z0-9_-]+", create_result.output)
+            token_line = match.group(0) if match else None
 
             # List tokens
             result = cli_runner.invoke(cli, ["token", "list"])
@@ -180,8 +178,6 @@ class TestTokenList:
         if token_line:
             assert token_line not in result.output
         # No 64-character hex strings (SHA-256 hashes)
-        import re
-
         hash_pattern = re.compile(r"[a-f0-9]{64}", re.IGNORECASE)
         assert not hash_pattern.search(result.output)
 
@@ -229,12 +225,10 @@ class TestTokenRotate:
             )
             assert create_result.exit_code == 0
 
-            # Extract original token
-            original_token = None
-            for line in create_result.output.split("\n"):
-                if line.startswith("mgp_"):
-                    original_token = line.strip()
-                    break
+            # Extract original token using regex
+            match = re.search(r"mgp_[A-Za-z0-9_-]+", create_result.output)
+            assert match is not None, "Failed to find token in create output"
+            original_token = match.group(0)
 
             # Rotate it
             rotate_result = cli_runner.invoke(cli, ["token", "rotate", "to-rotate"])
@@ -243,14 +237,10 @@ class TestTokenRotate:
             assert "to-rotate" in rotate_result.output
             assert "write" in rotate_result.output
 
-            # Extract new token
-            new_token = None
-            for line in rotate_result.output.split("\n"):
-                if line.startswith("mgp_"):
-                    new_token = line.strip()
-                    break
-
-            assert new_token is not None
+            # Extract new token using regex
+            match = re.search(r"mgp_[A-Za-z0-9_-]+", rotate_result.output)
+            assert match is not None, "Failed to find token in rotate output"
+            new_token = match.group(0)
             assert new_token != original_token
             assert new_token.startswith("mgp_")
 
@@ -267,12 +257,10 @@ class TestTokenRotate:
             )
             assert create_result.exit_code == 0
 
-            # Extract original token
-            original_token = None
-            for line in create_result.output.split("\n"):
-                if line.startswith("mgp_"):
-                    original_token = line.strip()
-                    break
+            # Extract original token using regex
+            match = re.search(r"mgp_[A-Za-z0-9_-]+", create_result.output)
+            assert match is not None, "Failed to find token in create output"
+            original_token = match.group(0)
 
             # Verify original token works
             token_service = TokenService(test_settings)

--- a/tests/unit/test_ctl_token.py
+++ b/tests/unit/test_ctl_token.py
@@ -166,17 +166,19 @@ class TestTokenList:
             create_result = cli_runner.invoke(
                 cli, ["token", "create", "--name", "secret", "--scope", "read"]
             )
+            assert create_result.exit_code == 0, f"Output: {create_result.output}"
+
             # Extract the token from create output using regex
             match = re.search(r"mgp_[A-Za-z0-9_-]+", create_result.output)
-            token_line = match.group(0) if match else None
+            assert match is not None, "Failed to find token in create output"
+            token_line = match.group(0)
 
             # List tokens
             result = cli_runner.invoke(cli, ["token", "list"])
 
         assert result.exit_code == 0
         # Token value should not appear in list
-        if token_line:
-            assert token_line not in result.output
+        assert token_line not in result.output
         # No 64-character hex strings (SHA-256 hashes)
         hash_pattern = re.compile(r"[a-f0-9]{64}", re.IGNORECASE)
         assert not hash_pattern.search(result.output)


### PR DESCRIPTION
## Summary
Refactored fragile token extraction in unit tests to use regex matching instead of line-by-line iteration. This makes the tests resilient to output format changes (e.g., additional blank lines, different formatting).

## Changes
- **tests/unit/test_ctl_init_gc.py**: Replaced line-by-line token extraction with regex in `test_init_reset_admin_token_regenerates`
- **tests/unit/test_ctl_token.py**: Replaced line-by-line token extraction with regex in multiple tests:
  - `test_token_list_never_shows_hashes`
  - `test_token_rotate_returns_new_token`
  - `test_token_rotate_invalidates_old_token`

## Pattern Used
Following the same regex pattern already used in integration tests (from PR #423):
```python
match = re.search(r"mgp_[A-Za-z0-9_-]+", result.output)
assert match is not None, "Failed to find token in output"
token = match.group(0)
```

## Testing
- All 928 unit tests pass
- Integration tests continue to pass
- Linting passes (ruff)

## Related
- Fixes #427
- Follow-up to PR #423 review comments

---
*(AI-generated via Claude Code w/ Sonnet 4.5)*