### PR TITLE
Remove CLI-side Sentry integration

### DIFF
--- a/src/magpie/cli/__init__.py
+++ b/src/magpie/cli/__init__.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-from functools import wraps
-from typing import TYPE_CHECKING, Callable, TypeVar
+from typing import TYPE_CHECKING
 
 import click
 
@@ -11,42 +10,9 @@ from magpie.cli.client import get_client
 from magpie.cli.config import get_ca_cert, get_server, get_timeout, get_token
 from magpie.cli.errors import handle_response_error, with_network_error_handling
 from magpie.cli.formatting import OutputFormat
-from magpie.config import get_settings
 
 if TYPE_CHECKING:
     import httpx
-
-F = TypeVar("F", bound=Callable[..., object])
-
-
-def sentry_wrapper(func: F) -> F:
-    """Wrap CLI command to capture exceptions in Sentry if configured.
-
-    Only initializes Sentry if MAGPIE_SENTRY_DSN is set.
-    """
-
-    @wraps(func)
-    def wrapper(*args: object, **kwargs: object) -> object:
-        settings = get_settings()
-
-        if not settings.sentry_dsn:
-            return func(*args, **kwargs)
-
-        import sentry_sdk
-
-        sentry_sdk.init(
-            dsn=settings.sentry_dsn,
-            environment="cli",
-            send_default_pii=False,
-        )
-
-        try:
-            return func(*args, **kwargs)
-        except Exception as exc:
-            sentry_sdk.capture_exception(exc)
-            raise
-
-    return wrapper  # type: ignore[return-value]
 
 
 class CLIContext:
@@ -228,4 +194,4 @@ cli.add_command(config_cmd, name="config")
 
 
 # Keep the old 'main' as an alias for backwards compatibility with entry point
-main = sentry_wrapper(cli)
+main = cli

--- a/src/magpie/config.py
+++ b/src/magpie/config.py
@@ -47,7 +47,7 @@ class MagpieSettings(BaseSettings):
     log_format: Literal["json", "console"] = "json"  # MAGPIE_LOG_FORMAT
 
     # Observability settings
-    sentry_dsn: str | None = None  # MAGPIE_SENTRY_DSN
+    sentry_dsn: str | None = None  # MAGPIE_SENTRY_DSN (server-side only)
     sentry_traces_sample_rate: float = Field(
         default=1.0, ge=0.0, le=1.0
     )  # MAGPIE_SENTRY_TRACES_SAMPLE_RATE


### PR DESCRIPTION
## Summary

Removes CLI-side Sentry error tracking based on evaluation that it provides minimal value compared to its downsides.

## Rationale

**Why CLI Sentry doesn't add value:**
- Users see errors directly in their terminal - no need for remote tracking
- User environments cannot be reproduced from Sentry events
- Network errors (expected operational conditions) create noisy Sentry alerts
- Decorator ordering issue: `sentry_wrapper` runs inside `@with_network_error_handling`, so routine connectivity failures get reported to Sentry before being converted to friendly error messages

**Why this is safe:**
- Server-side Sentry integration (PR #457) remains active and valuable for tracking actual server bugs
- The CLI is a user-facing tool where errors are immediately visible
- No actionable Sentry events from CLI usage have been observed

## Changes

- Removed `sentry_wrapper` function from `src/magpie/cli/__init__.py`
- Changed `main` entry point from `sentry_wrapper(cli)` to `cli`
- Updated `config.py` comment to clarify `sentry_dsn` is server-side only
- Cleaned up unused imports

## Testing

- All 954 unit tests pass
- All 380 integration tests pass
- No behavior changes for users (CLI works identically)

Fixes #467

🤖 Generated with [Claude Code](https://claude.com/claude-code) w/ Sonnet 4.5