### PR TITLE
Standardize error message assertions in integration tests

### DIFF
--- a/tests/integration/test_ctl.py
+++ b/tests/integration/test_ctl.py
@@ -2,6 +2,10 @@
 
 These tests verify that magpie-ctl commands work correctly with actual filesystem
 and database operations (no mocking of storage or database access).
+
+Testing Conventions:
+- Error message assertions use exact casing (no .lower()) to catch unintended
+  message changes. This makes tests stricter and more precise.
 """
 
 from __future__ import annotations
@@ -1215,7 +1219,7 @@ class TestSync:
         result = runner.invoke(ctl_cli, ["sync", "gc-s3", "--help"])
         assert result.exit_code == 0
         assert "--execute" in result.output
-        assert "dry-run" in result.output.lower() or "preview" in result.output.lower()
+        assert "dry-run" in result.output or "preview" in result.output
 
     def test_sync_to_s3_nonexistent_storage_path(self, ctl_runner: tuple[CliRunner, Path]) -> None:
         """Sync to-s3 with nonexistent storage path shows error."""


### PR DESCRIPTION
## Summary
- Removed `.lower()` from the last remaining help text assertion
- Documented testing convention in module docstring

## Context
Follow-up from PR #423 review comments. Most `.lower()` instances were already removed during PR #423, but one remained at line 1218.

## Changes
- Removed `.lower()` from `test_sync_gc_s3_dry_run_by_default` help text assertion
- Added "Testing Conventions" section to module docstring documenting the decision to use exact casing

## Rationale
Using exact casing makes tests stricter and catches unintended changes to error messages and help text. The help output already uses consistent lowercase for "dry-run" and "preview", so `.lower()` was unnecessary.

## Testing
- All integration tests pass (48 passed, 1 skipped)
- Linting and formatting checks pass

Fixes #428

---
(AI-generated via Claude Code w/ Sonnet 4.5)