### PR TITLE
fix: set pyproject.toml version to 0.1.3-rc1 for RC release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "magpie"
-version = "0.1.3"
+version = "0.1.3-rc1"
 description = "Content-addressed artifact storage with mutable tags"
 authors = [{ name = "SWCCDC Team" }]
 readme = "README.md"


### PR DESCRIPTION
## Summary

- The release workflow requires an exact match between the git tag and `pyproject.toml` version (minus the `v` prefix)
- The tag is `v0.1.3-rc1` but `pyproject.toml` had `version = "0.1.3"`, missing the RC suffix
- Updated `pyproject.toml` to `version = "0.1.3-rc1"` to match the tag exactly

## Test plan

- [ ] Verify `pyproject.toml` version is `0.1.3-rc1`
- [ ] Confirm release workflow passes after merge and re-tagging

---

(AI-generated via Claude Code w/ Sonnet 4.5)