### PR TITLE
chore: bump version to 0.1.3-rc2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "magpie"
-version = "0.1.3-rc1"
+version = "0.1.3-rc2"
 description = "Content-addressed artifact storage with mutable tags"
 authors = [{ name = "SWCCDC Team" }]
 readme = "README.md"


### PR DESCRIPTION
## Summary

- Bumps `pyproject.toml` version from `0.1.3-rc1` to `0.1.3-rc2` following the merge of #507

## Test plan

- [x] `uv run ruff check src/ tests/` passes
- [x] `uv run ruff format --check src/ tests/` passes

(AI-generated via Claude Code w/ Sonnet 4.6)