### PR TITLE
fix: add required capabilities for entrypoint init under cap_drop ALL

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -132,9 +132,17 @@ services:
       timeout: 10s
       retries: 3
       start_period: 10s
-    # Security hardening
+    # Security hardening: drop all capabilities, then add back only what the
+    # entrypoint needs to write to the /data bind mount (owned by a non-root
+    # host user), create directories, and drop privileges via gosu.  After
+    # gosu switches to the target UID/GID these capabilities have no effect.
     cap_drop:
       - ALL
+    cap_add:
+      - CHOWN         # Adjust directory ownership during init
+      - DAC_OVERRIDE  # Write to /data bind mount owned by non-root host user
+      - SETUID        # Required by gosu to switch UID
+      - SETGID        # Required by gosu to switch GID
     # Filesystem is read-only for security; writable paths:
     # - /data: bind mount for artifact storage and database
     # - /run: tmpfs for entrypoint runtime files (magpie-user UID/GID marker)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -35,6 +35,16 @@ mkdir -p /run
 echo "$RUN_UID:$RUN_GID" > /run/magpie-user
 chmod 644 /run/magpie-user
 
+# Ensure the storage directory exists before lock file resolution.
+# On first boot, /data/artifacts won't exist yet, causing the lock directory
+# to fall back to /data.  Creating it early keeps the lock file co-located
+# with artifacts.
+STORAGE_DIR="${MAGPIE_STORAGE_PATH:-/data/artifacts}"
+if [ ! -d "$STORAGE_DIR" ]; then
+    mkdir -p "$STORAGE_DIR"
+    chown "$RUN_UID:$RUN_GID" "$STORAGE_DIR"
+fi
+
 # Auto-initialize database if it doesn't exist
 # This runs before starting the main service
 # Uses a lock file (held via flock on FD 200) to prevent race conditions when multiple


### PR DESCRIPTION
# Known Impacted Versions
- bf1e0d3ef22865d53cb6e2296ab84b23e08644c9
- v0.1.2

## Problem

Test runs with different cap than what's required.

```
/entrypoint.sh: line 112: /data/.magpie-init.lock: Permission denied
```

## Root Cause

`docker-compose.prod.yml` specifies `cap_drop: ALL` for security hardening, which removes **all** Linux capabilities — including ones essential for the entrypoint's "start as root → init → drop privileges" pattern:

- `CAP_DAC_OVERRIDE` — needed for root to write to the `/data` bind mount owned by a non-root host user
- `CAP_SETUID` / `CAP_SETGID` — needed by `gosu` to drop privileges
- `CAP_CHOWN` — needed to set correct ownership on directories created during init

## Fix

### `docker-compose.prod.yml`
Added `cap_add` with the 4 minimum capabilities needed after `cap_drop: ALL`:
- `CHOWN`, `DAC_OVERRIDE`, `SETUID`, `SETGID`

This follows the same pattern already used by the Caddy service in the same file.

### `entrypoint.sh`
Added early creation of the storage directory (`/data/artifacts`) before the lock file resolution logic. On first boot, the directory doesn't exist yet, causing the lock file to fall back to `/data`. Creating it early keeps the lock file in the correct location.

## Security

These capabilities are only effective during the brief root initialization phase of the entrypoint. After `gosu` switches to the target UID/GID, they have no effect. The container retains `read_only: true`, all other capabilities remain dropped, and the application runs with zero capabilities.

## Testing

- All 977 unit tests pass
- Ruff lint/format clean
- Shellcheck clean on both shell scripts
- Code review approved

(AI-generated via Claude Code w/ Opus 4.5)

## Manual testing
* upon initialization of magpie on a fresh install of ubuntu 24.04, the magpie container failed to start. After building with these changes, the container made it further in the initialization process.