### PR TITLE
Release v0.1.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "magpie"
-version = "0.1.3-rc2"
+version = "0.1.3"
 description = "Content-addressed artifact storage with mutable tags"
 authors = [{ name = "SWCCDC Team" }]
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -383,7 +383,7 @@ wheels = [
 
 [[package]]
 name = "magpie"
-version = "0.1.3rc2"
+version = "0.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

Finalizes the v0.1.3 release: bumps `pyproject.toml` version from
`0.1.3-rc2` to `0.1.3` (rc -> final), per `docs/releases.md` Release
Process step 1. `uv.lock` regenerated to match (`uv lock`).

`src/magpie/__init__.py` derives `__version__` from package metadata via
`importlib.metadata.version("magpie")` -- confirmed there is no hardcoded
version there to update.

Other `0.1.3` occurrences found in the repo (`docs/user-guide.md`,
`src/magpie/server/middleware.py`, `docs/api-compatibility.md`,
`tests/unit/test_version_middleware.py`) are illustrative examples /
docstrings referencing the `0.1.3` series pattern, not version-source
references -- left unchanged. No CHANGELOG or release-notes file exists
in the repo, so none was added.

## MERGE ORDER -- READ BEFORE MERGING

**This PR must be merged LAST**, after all of the following are merged,
immediately before tagging `v0.1.3`:

- #512 -- fix: add required capabilities for entrypoint init under `cap_drop: ALL`
- #517 -- test(e2e): add cap_drop ALL entrypoint tests (closes #516)
- #511 -- test(e2e): add release validation tests for v0.1.3 risk areas

It is intentionally **not** to be merged before those land. Merging this
first would tag/release `v0.1.3` as final while the #516 cap_drop fix
chain and release-validation tests are still outstanding.

## Test plan

- [x] `just lint` -- clean
- [x] `just fmt-check` -- clean (160 files)
- [x] `just security` (bandit) -- 0 issues
- [x] `just test-ci` (CI recipe, excludes e2e) -- 1423 passed, 1 skipped
- [x] `just test-unit` -- 977 passed
- [ ] `just check` / e2e tests -- not run locally (require a live Docker
      Compose stack not available in this environment); CI will run these

(AI-generated via Claude Code w/ Fable 5)