### PR TITLE
deps: security sweep (9 packages, closes #533)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,11 +8,11 @@ requires-python = ">=3.13"
 dependencies = [
     "fastapi",
     "uvicorn[standard]",
-    "click",
+    "click>=8.3.3",
     "httpx",
-    "pydantic-settings",
+    "pydantic-settings>=2.14.2",
     "aiofiles",
-    "python-multipart>=0.0.22",
+    "python-multipart>=0.0.30",
     "sentry-sdk[fastapi]",
     "opentelemetry-instrumentation-fastapi",
     "opentelemetry-exporter-otlp",
@@ -20,8 +20,13 @@ dependencies = [
     "tomli_w",
     "structlog",
     "truststore>=0.8.0",
-    "protobuf>=6.33.4",
+    "protobuf>=6.33.5,<7",
     "packaging",
+    "requests>=2.33.0",
+    "urllib3>=2.7.0",
+    "idna>=3.15",
+    "pygments>=2.20.0",
+    "python-dotenv>=1.2.2",
 ]
 
 [project.scripts]
@@ -31,7 +36,7 @@ magpie-ctl = "magpie.ctl:main"
 [dependency-groups]
 dev = [
     "ruff",
-    "pytest",
+    "pytest>=9.0.3",
     "pytest-asyncio",
     "pytest-cov",
     "bandit[toml]",

--- a/src/magpie/server/routes/upload.py
+++ b/src/magpie/server/routes/upload.py
@@ -14,6 +14,7 @@ from typing import Annotated
 import structlog
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request, status
 from pydantic import BaseModel
+from python_multipart.exceptions import ParseError
 from python_multipart.multipart import MultipartParser
 
 from magpie.config import MagpieSettings
@@ -471,6 +472,17 @@ async def upload_artifact(
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=str(e),
+        )
+    except ParseError as e:
+        # Outer backstop from python-multipart itself (see build_multipart_parser):
+        # its own max_header_count/max_header_size guards, or any other malformed
+        # input the library rejects before magpie's own checks run. Translate the
+        # same way as magpie's own HeaderLimitExceededError/MalformedMultipartError
+        # so callers see a clean 400 instead of an unhandled 500.
+        handler.cleanup()
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Malformed multipart payload: {e}",
         )
     except Exception:
         handler.cleanup()

--- a/src/magpie/server/routes/upload.py
+++ b/src/magpie/server/routes/upload.py
@@ -39,6 +39,26 @@ class MalformedMultipartError(Exception):
     """Raised when multipart payload is malformed or missing required headers."""
 
 
+def build_multipart_parser(
+    boundary: bytes, handler: "StreamingMultipartHandler"
+) -> MultipartParser:
+    """Construct a MultipartParser with library-level header guards above magpie's own.
+
+    python-multipart's own max_header_count/max_header_size defaults (8 headers,
+    ~4KB) are tighter than StreamingMultipartHandler's configured limits
+    (MAX_HEADERS_PER_PART, MAX_HEADER_SIZE) and would otherwise raise the library's
+    MultipartParseError before the handler's callbacks raise HeaderLimitExceededError.
+    Setting the library limits to a multiple of magpie's own keeps magpie's checks
+    authoritative while still providing an outer backstop.
+    """
+    return MultipartParser(
+        boundary,
+        handler.get_callbacks(),
+        max_header_count=StreamingMultipartHandler.MAX_HEADERS_PER_PART * 2,
+        max_header_size=StreamingMultipartHandler.MAX_HEADER_SIZE * 2,
+    )
+
+
 class StreamingMultipartHandler:
     """Handler for streaming multipart/form-data without buffering.
 
@@ -391,7 +411,7 @@ async def upload_artifact(
 
     # Set up streaming multipart handler
     handler = StreamingMultipartHandler(temp_dir, max_size)
-    parser = MultipartParser(boundary, handler.get_callbacks())
+    parser = build_multipart_parser(boundary, handler)
 
     # Stream request body through multipart parser in a single background thread
     # Bridge async stream → sync parser using a queue (avoids per-chunk thread overhead)

--- a/tests/integration/test_upload_endpoint.py
+++ b/tests/integration/test_upload_endpoint.py
@@ -279,3 +279,38 @@ class TestAuthHeaderHandling:
         # Verify anonymous was used as default
         info = test_storage_service.get_artifact_info("auth/anonymous-test", "latest")
         assert info.uploaded_by == "anonymous"
+
+
+class TestMalformedMultipartHandling:
+    """Tests for python-multipart parser errors surfacing as clean 4xx responses.
+
+    magpie's own StreamingMultipartHandler only validates conditions it
+    explicitly checks (header size/count, Content-Disposition presence, single
+    file part). Generic RFC 2046 syntax violations are instead caught by
+    python-multipart's own parser (MultipartParseError) and must be translated
+    to a 400 rather than bubbling out as an unhandled 500.
+    """
+
+    def test_invalid_header_character_returns_400(self, client_no_raise: TestClient) -> None:
+        """A header with an invalid token character returns 400, not 500."""
+        boundary = "test-boundary"
+        # "Invalid Header" contains a space, which is not a valid RFC 7230 token
+        # character for a header field name -- only python-multipart's own
+        # parser catches this, not magpie's handler callbacks.
+        body = (
+            f"--{boundary}\r\n"
+            "Invalid Header: value\r\n"
+            'Content-Disposition: form-data; name="file"; filename="artifact.bin"\r\n'
+            "\r\n"
+            "test content\r\n"
+            f"--{boundary}--\r\n"
+        ).encode()
+
+        response = client_no_raise.post(
+            "/api/v1/upload/malformed/header-test",
+            content=body,
+            headers={"Content-Type": f"multipart/form-data; boundary={boundary}"},
+        )
+
+        assert response.status_code == 400
+        assert "Malformed multipart payload" in response.json()["detail"]

--- a/tests/unit/test_streaming_multipart_handler.py
+++ b/tests/unit/test_streaming_multipart_handler.py
@@ -32,9 +32,10 @@ from magpie.server.routes.upload import (
 class TestBoundaryExtraction:
     """Tests for boundary extraction from Content-Type headers.
 
-    NOTE: These tests verify the boundary extraction logic that's implemented
-    in upload.py (lines 347-373). The handler itself doesn't parse Content-Type,
-    so we test the actual regex patterns used by the upload endpoint.
+    NOTE: These tests verify the boundary extraction logic in the
+    upload_artifact() endpoint's Content-Type parsing. The handler itself
+    doesn't parse Content-Type, so we test the actual regex patterns used
+    by the upload endpoint.
     """
 
     @pytest.fixture
@@ -828,6 +829,51 @@ class TestHeaderSizeLimits:
         # Should succeed
         result = handler.get_result()
         assert result is not None
+
+        handler.cleanup()
+
+
+class TestLibraryParseErrorBackstop:
+    """Tests for python-multipart's own MultipartParseError guard.
+
+    magpie's own checks (HeaderLimitExceededError, MalformedMultipartError) only
+    cover conditions the handler explicitly validates (header size/count,
+    Content-Disposition presence, single file part). Generic RFC 2046 syntax
+    violations -- e.g. an invalid character in a header field name -- are never
+    seen by magpie's callbacks and are instead caught by python-multipart's own
+    parser, which raises MultipartParseError. This confirms that path is
+    actually reachable so upload_artifact()'s translation of it is exercised.
+    """
+
+    @pytest.fixture
+    def temp_dir(self, tmp_path: Path) -> Path:
+        """Create a temporary directory for handler temp files."""
+        return tmp_path
+
+    def test_invalid_header_character_raises_library_parse_error(self, temp_dir: Path) -> None:
+        """A header field name with an invalid token character raises MultipartParseError."""
+        from python_multipart.exceptions import MultipartParseError
+
+        handler = StreamingMultipartHandler(temp_dir, max_size=None)
+        boundary = b"test-boundary"
+
+        # "Invalid Header" contains a space, which is not a valid RFC 7230 token
+        # character for a header field name -- magpie never inspects header
+        # field name syntax itself, so this is only caught by the library.
+        payload = (
+            b"--test-boundary\r\n"
+            b"Invalid Header: value\r\n"
+            b'Content-Disposition: form-data; name="file"\r\n'
+            b"\r\n"
+            b"test content\r\n"
+            b"--test-boundary--\r\n"
+        )
+
+        parser = build_multipart_parser(boundary, handler)
+
+        with pytest.raises(MultipartParseError, match="invalid character"):
+            parser.write(payload)
+            parser.finalize()
 
         handler.cleanup()
 

--- a/tests/unit/test_streaming_multipart_handler.py
+++ b/tests/unit/test_streaming_multipart_handler.py
@@ -19,13 +19,13 @@ import re
 from pathlib import Path
 
 import pytest
-from python_multipart.multipart import MultipartParser
 
 from magpie.server.routes.upload import (
     HeaderLimitExceededError,
     MalformedMultipartError,
     StreamingMultipartHandler,
     UploadSizeExceededError,
+    build_multipart_parser,
 )
 
 
@@ -68,7 +68,7 @@ class TestBoundaryExtraction:
                 b"--" + boundary + b"--\r\n"
             )
 
-            parser = MultipartParser(boundary, handler.get_callbacks())
+            parser = build_multipart_parser(boundary, handler)
             parser.write(payload)
             parser.finalize()
             handler.finalize()
@@ -96,7 +96,7 @@ class TestBoundaryExtraction:
             b"------WebKitFormBoundary--\r\n"
         )
 
-        parser = MultipartParser(boundary, handler.get_callbacks())
+        parser = build_multipart_parser(boundary, handler)
         parser.write(payload)
         parser.finalize()
         handler.finalize()
@@ -129,7 +129,7 @@ class TestBoundaryExtraction:
             b"--simple-boundary-123--\r\n"
         )
 
-        parser = MultipartParser(boundary, handler.get_callbacks())
+        parser = build_multipart_parser(boundary, handler)
         parser.write(payload)
         parser.finalize()
         handler.finalize()
@@ -163,7 +163,7 @@ class TestBoundaryExtraction:
                 b"--test--\r\n"
             )
 
-            parser = MultipartParser(boundary, handler.get_callbacks())
+            parser = build_multipart_parser(boundary, handler)
             parser.write(payload)
             parser.finalize()
             handler.finalize()
@@ -199,7 +199,7 @@ class TestMultipleFilePartsRejection:
             b"--test-boundary--\r\n"
         )
 
-        parser = MultipartParser(boundary, handler.get_callbacks())
+        parser = build_multipart_parser(boundary, handler)
 
         # Handler should detect the second file part and raise MalformedMultipartError,
         # which is propagated out of parser.write()/parser.finalize().
@@ -223,7 +223,7 @@ class TestMultipleFilePartsRejection:
             b"--test-boundary--\r\n"
         )
 
-        parser = MultipartParser(boundary, handler.get_callbacks())
+        parser = build_multipart_parser(boundary, handler)
         parser.write(payload)
         parser.finalize()
         handler.finalize()
@@ -257,7 +257,7 @@ class TestSizeLimitEnforcement:
             b"--test-boundary--\r\n"
         )
 
-        parser = MultipartParser(boundary, handler.get_callbacks())
+        parser = build_multipart_parser(boundary, handler)
         parser.write(payload)
         parser.finalize()
         handler.finalize()
@@ -284,7 +284,7 @@ class TestSizeLimitEnforcement:
             b"--test-boundary--\r\n"
         )
 
-        parser = MultipartParser(boundary, handler.get_callbacks())
+        parser = build_multipart_parser(boundary, handler)
 
         with pytest.raises(UploadSizeExceededError, match="exceeds maximum size"):
             parser.write(payload)
@@ -307,7 +307,7 @@ class TestSizeLimitEnforcement:
             b"--test-boundary--\r\n"
         )
 
-        parser = MultipartParser(boundary, handler.get_callbacks())
+        parser = build_multipart_parser(boundary, handler)
 
         # Write in chunks to simulate incremental parsing
         chunk_size = 50
@@ -335,7 +335,7 @@ class TestSizeLimitEnforcement:
             b"--test-boundary--\r\n"
         )
 
-        parser = MultipartParser(boundary, handler.get_callbacks())
+        parser = build_multipart_parser(boundary, handler)
 
         with pytest.raises(UploadSizeExceededError):
             parser.write(payload)
@@ -357,7 +357,7 @@ class TestSizeLimitEnforcement:
             b"--test-boundary--\r\n"
         )
 
-        parser = MultipartParser(boundary, handler.get_callbacks())
+        parser = build_multipart_parser(boundary, handler)
         parser.write(payload)
         parser.finalize()
         handler.finalize()
@@ -378,7 +378,7 @@ class TestSizeLimitEnforcement:
             b"--test-boundary--\r\n"
         )
 
-        parser = MultipartParser(boundary, handler.get_callbacks())
+        parser = build_multipart_parser(boundary, handler)
         parser.write(payload)
         parser.finalize()
         handler.finalize()
@@ -399,7 +399,7 @@ class TestSizeLimitEnforcement:
             b"--test-boundary--\r\n"
         )
 
-        parser = MultipartParser(boundary, handler.get_callbacks())
+        parser = build_multipart_parser(boundary, handler)
 
         with pytest.raises(UploadSizeExceededError):
             parser.write(payload)
@@ -441,7 +441,7 @@ class TestCleanupOnError:
             b"--test-boundary--\r\n"
         )
 
-        parser = MultipartParser(boundary, handler.get_callbacks())
+        parser = build_multipart_parser(boundary, handler)
 
         # This should raise MalformedMultipartError on the malformed second part.
         with pytest.raises(MalformedMultipartError, match="missing required Content-Disposition"):
@@ -477,7 +477,7 @@ class TestCleanupOnError:
             b"--test-boundary--\r\n"
         )
 
-        parser = MultipartParser(boundary, handler.get_callbacks())
+        parser = build_multipart_parser(boundary, handler)
 
         # This should raise UploadSizeExceededError
         with pytest.raises(UploadSizeExceededError, match="exceeds maximum size"):
@@ -509,7 +509,7 @@ class TestCleanupOnError:
             b"--test-boundary--\r\n"
         )
 
-        parser = MultipartParser(boundary, handler.get_callbacks())
+        parser = build_multipart_parser(boundary, handler)
         parser.write(payload)
         parser.finalize()
 
@@ -546,7 +546,7 @@ class TestCleanupOnError:
             b"--test-boundary--\r\n"
         )
 
-        parser = MultipartParser(boundary, handler.get_callbacks())
+        parser = build_multipart_parser(boundary, handler)
 
         # Size limit should be exceeded during parsing
         with pytest.raises(UploadSizeExceededError, match="exceeds maximum size"):
@@ -584,7 +584,7 @@ class TestCleanupOnError:
             b"--test-boundary--\r\n"
         )
 
-        parser = MultipartParser(boundary, handler.get_callbacks())
+        parser = build_multipart_parser(boundary, handler)
         parser.write(payload)
         parser.finalize()
 
@@ -618,7 +618,7 @@ class TestContentDispositionParsing:
             b"--test-boundary--\r\n"
         )
 
-        parser = MultipartParser(boundary, handler.get_callbacks())
+        parser = build_multipart_parser(boundary, handler)
         parser.write(payload)
         parser.finalize()
         handler.finalize()
@@ -639,7 +639,7 @@ class TestContentDispositionParsing:
             b"--test-boundary--\r\n"
         )
 
-        parser = MultipartParser(boundary, handler.get_callbacks())
+        parser = build_multipart_parser(boundary, handler)
         parser.write(payload)
         parser.finalize()
         handler.finalize()
@@ -660,7 +660,7 @@ class TestContentDispositionParsing:
             b"--test-boundary--\r\n"
         )
 
-        parser = MultipartParser(boundary, handler.get_callbacks())
+        parser = build_multipart_parser(boundary, handler)
         parser.write(payload)
         parser.finalize()
         handler.finalize()
@@ -696,7 +696,7 @@ class TestContentDispositionParsing:
         # Part without Content-Disposition header
         payload = b"--test-boundary\r\n\r\ntest content\r\n--test-boundary--\r\n"
 
-        parser = MultipartParser(boundary, handler.get_callbacks())
+        parser = build_multipart_parser(boundary, handler)
 
         with pytest.raises(MalformedMultipartError, match="missing required Content-Disposition"):
             parser.write(payload)
@@ -719,7 +719,7 @@ class TestContentDispositionParsing:
             b"--test-boundary--\r\n"
         )
 
-        parser = MultipartParser(boundary, handler.get_callbacks())
+        parser = build_multipart_parser(boundary, handler)
 
         # The handler should raise when it processes the header end callback
         # because the Content-Disposition is missing the required 'name' parameter
@@ -796,7 +796,7 @@ class TestHeaderSizeLimits:
             b"--test-boundary--\r\n"
         )
 
-        parser = MultipartParser(boundary, handler.get_callbacks())
+        parser = build_multipart_parser(boundary, handler)
 
         with pytest.raises(HeaderLimitExceededError, match="more than .* headers"):
             parser.write(payload)
@@ -820,7 +820,7 @@ class TestHeaderSizeLimits:
             b"--test-boundary--\r\n"
         )
 
-        parser = MultipartParser(boundary, handler.get_callbacks())
+        parser = build_multipart_parser(boundary, handler)
         parser.write(payload)
         parser.finalize()
         handler.finalize()
@@ -854,7 +854,7 @@ class TestHandlerGetResult:
             b"--test-boundary--\r\n"
         )
 
-        parser = MultipartParser(boundary, handler.get_callbacks())
+        parser = build_multipart_parser(boundary, handler)
         parser.write(payload)
         parser.finalize()
         handler.finalize()
@@ -877,7 +877,7 @@ class TestHandlerGetResult:
             b"--test-boundary--\r\n"
         )
 
-        parser = MultipartParser(boundary, handler.get_callbacks())
+        parser = build_multipart_parser(boundary, handler)
         parser.write(payload)
         parser.finalize()
         handler.finalize()
@@ -904,7 +904,7 @@ class TestHandlerGetResult:
             b"--test-boundary--\r\n"
         )
 
-        parser = MultipartParser(boundary, handler.get_callbacks())
+        parser = build_multipart_parser(boundary, handler)
         parser.write(payload)
         parser.finalize()
         handler.finalize()
@@ -942,7 +942,7 @@ class TestHandlerGetResult:
             b"--test-boundary--\r\n"
         )
 
-        parser = MultipartParser(boundary, handler.get_callbacks())
+        parser = build_multipart_parser(boundary, handler)
 
         # Write payload in small chunks to force incremental parsing
         chunk_size = 100
@@ -980,7 +980,7 @@ class TestHandlerGetResult:
             b"--test-boundary--\r\n"
         )
 
-        parser = MultipartParser(boundary, handler.get_callbacks())
+        parser = build_multipart_parser(boundary, handler)
         parser.write(payload)
         parser.finalize()
         handler.finalize()

--- a/uv.lock
+++ b/uv.lock
@@ -126,14 +126,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.3.1"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
 ]
 
 [[package]]
@@ -352,11 +352,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -382,24 +382,29 @@ wheels = [
 
 [[package]]
 name = "magpie"
-version = "0.1.2"
+version = "0.1.3rc2"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },
     { name = "click" },
     { name = "fastapi" },
     { name = "httpx" },
+    { name = "idna" },
     { name = "opentelemetry-exporter-otlp" },
     { name = "opentelemetry-instrumentation-fastapi" },
     { name = "packaging" },
     { name = "protobuf" },
     { name = "pydantic-settings" },
+    { name = "pygments" },
+    { name = "python-dotenv" },
     { name = "python-multipart" },
+    { name = "requests" },
     { name = "rich" },
     { name = "sentry-sdk", extra = ["fastapi"] },
     { name = "structlog" },
     { name = "tomli-w" },
     { name = "truststore" },
+    { name = "urllib3" },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
@@ -416,20 +421,25 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiofiles" },
-    { name = "click" },
+    { name = "click", specifier = ">=8.3.3" },
     { name = "fastapi" },
     { name = "httpx" },
+    { name = "idna", specifier = ">=3.15" },
     { name = "opentelemetry-exporter-otlp" },
     { name = "opentelemetry-instrumentation-fastapi" },
     { name = "packaging" },
-    { name = "protobuf", specifier = ">=6.33.4" },
-    { name = "pydantic-settings" },
-    { name = "python-multipart", specifier = ">=0.0.22" },
+    { name = "protobuf", specifier = ">=6.33.5,<7" },
+    { name = "pydantic-settings", specifier = ">=2.14.2" },
+    { name = "pygments", specifier = ">=2.20.0" },
+    { name = "python-dotenv", specifier = ">=1.2.2" },
+    { name = "python-multipart", specifier = ">=0.0.30" },
+    { name = "requests", specifier = ">=2.33.0" },
     { name = "rich" },
     { name = "sentry-sdk", extras = ["fastapi"] },
     { name = "structlog" },
     { name = "tomli-w" },
     { name = "truststore", specifier = ">=0.8.0" },
+    { name = "urllib3", specifier = ">=2.7.0" },
     { name = "uvicorn", extras = ["standard"] },
 ]
 
@@ -437,7 +447,7 @@ requires-dist = [
 dev = [
     { name = "bandit", extras = ["toml"] },
     { name = "pre-commit" },
-    { name = "pytest" },
+    { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "ruff" },
@@ -687,17 +697,17 @@ wheels = [
 
 [[package]]
 name = "protobuf"
-version = "6.33.4"
+version = "6.33.6"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/53/b8/cda15d9d46d03d4aa3a67cb6bffe05173440ccf86a9541afaf7ac59a1b6b/protobuf-6.33.4.tar.gz", hash = "sha256:dc2e61bca3b10470c1912d166fe0af67bfc20eb55971dcef8dfa48ce14f0ed91", size = 444346, upload-time = "2026-01-12T18:33:40.109Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/70/e908e9c5e52ef7c3a6c7902c9dfbb34c7e29c25d2f81ade3856445fd5c94/protobuf-6.33.6.tar.gz", hash = "sha256:a6768d25248312c297558af96a9f9c929e8c4cee0659cb07e780731095f38135", size = 444531, upload-time = "2026-03-18T19:05:00.988Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/be/24ef9f3095bacdf95b458543334d0c4908ccdaee5130420bf064492c325f/protobuf-6.33.4-cp310-abi3-win32.whl", hash = "sha256:918966612c8232fc6c24c78e1cd89784307f5814ad7506c308ee3cf86662850d", size = 425612, upload-time = "2026-01-12T18:33:29.656Z" },
-    { url = "https://files.pythonhosted.org/packages/31/ad/e5693e1974a28869e7cd244302911955c1cebc0161eb32dfa2b25b6e96f0/protobuf-6.33.4-cp310-abi3-win_amd64.whl", hash = "sha256:8f11ffae31ec67fc2554c2ef891dcb561dae9a2a3ed941f9e134c2db06657dbc", size = 436962, upload-time = "2026-01-12T18:33:31.345Z" },
-    { url = "https://files.pythonhosted.org/packages/66/15/6ee23553b6bfd82670207ead921f4d8ef14c107e5e11443b04caeb5ab5ec/protobuf-6.33.4-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:2fe67f6c014c84f655ee06f6f66213f9254b3a8b6bda6cda0ccd4232c73c06f0", size = 427612, upload-time = "2026-01-12T18:33:32.646Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/48/d301907ce6d0db75f959ca74f44b475a9caa8fcba102d098d3c3dd0f2d3f/protobuf-6.33.4-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:757c978f82e74d75cba88eddec479df9b99a42b31193313b75e492c06a51764e", size = 324484, upload-time = "2026-01-12T18:33:33.789Z" },
-    { url = "https://files.pythonhosted.org/packages/92/1c/e53078d3f7fe710572ab2dcffd993e1e3b438ae71cfc031b71bae44fcb2d/protobuf-6.33.4-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:c7c64f259c618f0bef7bee042075e390debbf9682334be2b67408ec7c1c09ee6", size = 339256, upload-time = "2026-01-12T18:33:35.231Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/8e/971c0edd084914f7ee7c23aa70ba89e8903918adca179319ee94403701d5/protobuf-6.33.4-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:3df850c2f8db9934de4cf8f9152f8dc2558f49f298f37f90c517e8e5c84c30e9", size = 323311, upload-time = "2026-01-12T18:33:36.305Z" },
-    { url = "https://files.pythonhosted.org/packages/75/b1/1dc83c2c661b4c62d56cc081706ee33a4fc2835bd90f965baa2663ef7676/protobuf-6.33.4-py3-none-any.whl", hash = "sha256:1fe3730068fcf2e595816a6c34fe66eeedd37d51d0400b72fabc848811fdc1bc", size = 170532, upload-time = "2026-01-12T18:33:39.199Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/9f/2f509339e89cfa6f6a4c4ff50438db9ca488dec341f7e454adad60150b00/protobuf-6.33.6-cp310-abi3-win32.whl", hash = "sha256:7d29d9b65f8afef196f8334e80d6bc1d5d4adedb449971fefd3723824e6e77d3", size = 425739, upload-time = "2026-03-18T19:04:48.373Z" },
+    { url = "https://files.pythonhosted.org/packages/76/5d/683efcd4798e0030c1bab27374fd13a89f7c2515fb1f3123efdfaa5eab57/protobuf-6.33.6-cp310-abi3-win_amd64.whl", hash = "sha256:0cd27b587afca21b7cfa59a74dcbd48a50f0a6400cfb59391340ad729d91d326", size = 437089, upload-time = "2026-03-18T19:04:50.381Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/01/a3c3ed5cd186f39e7880f8303cc51385a198a81469d53d0fdecf1f64d929/protobuf-6.33.6-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:9720e6961b251bde64edfdab7d500725a2af5280f3f4c87e57c0208376aa8c3a", size = 427737, upload-time = "2026-03-18T19:04:51.866Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/90/b3c01fdec7d2f627b3a6884243ba328c1217ed2d978def5c12dc50d328a3/protobuf-6.33.6-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:e2afbae9b8e1825e3529f88d514754e094278bb95eadc0e199751cdd9a2e82a2", size = 324610, upload-time = "2026-03-18T19:04:53.096Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ca/25afc144934014700c52e05103c2421997482d561f3101ff352e1292fb81/protobuf-6.33.6-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:c96c37eec15086b79762ed265d59ab204dabc53056e3443e702d2681f4b39ce3", size = 339381, upload-time = "2026-03-18T19:04:54.616Z" },
+    { url = "https://files.pythonhosted.org/packages/16/92/d1e32e3e0d894fe00b15ce28ad4944ab692713f2e7f0a99787405e43533a/protobuf-6.33.6-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:e9db7e292e0ab79dd108d7f1a94fe31601ce1ee3f7b79e0692043423020b0593", size = 323436, upload-time = "2026-03-18T19:04:55.768Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/72/02445137af02769918a93807b2b7890047c32bfb9f90371cbc12688819eb/protobuf-6.33.6-py3-none-any.whl", hash = "sha256:77179e006c476e69bf8e8ce866640091ec42e1beb80b213c3900006ecfba6901", size = 170656, upload-time = "2026-03-18T19:04:59.826Z" },
 ]
 
 [[package]]
@@ -770,30 +780,30 @@ wheels = [
 
 [[package]]
 name = "pydantic-settings"
-version = "2.12.0"
+version = "2.14.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/43/4b/ac7e0aae12027748076d72a8764ff1c9d82ca75a7a52622e67ed3f765c54/pydantic_settings-2.12.0.tar.gz", hash = "sha256:005538ef951e3c2a68e1c08b292b5f2e71490def8589d4221b95dab00dafcfd0", size = 194184, upload-time = "2025-11-10T14:25:47.013Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/60/5d4751ba3f4a40a6891f24eec885f51afd78d208498268c734e256fb13c4/pydantic_settings-2.12.0-py3-none-any.whl", hash = "sha256:fddb9fd99a5b18da837b29710391e945b1e30c135477f484084ee513adb93809", size = 51880, upload-time = "2025-11-10T14:25:45.546Z" },
+    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
 ]
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
 ]
 
 [[package]]
 name = "pytest"
-version = "9.0.2"
+version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -802,9 +812,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]
@@ -835,20 +845,20 @@ wheels = [
 
 [[package]]
 name = "python-dotenv"
-version = "1.2.1"
+version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f0/26/19cadc79a718c5edbec86fd4919a6b6d3f681039a2f6d66d14be94e75fb9/python_dotenv-1.2.1.tar.gz", hash = "sha256:42667e897e16ab0d66954af0e60a9caa94f0fd4ecf3aaf6d2d260eec1aa36ad6", size = 44221, upload-time = "2025-10-26T15:12:10.434Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/1b/a298b06749107c305e1fe0f814c6c74aea7b2f1e10989cb30f544a1b3253/python_dotenv-1.2.1-py3-none-any.whl", hash = "sha256:b81ee9561e9ca4004139c6cbba3a238c32b03e4894671e181b671e8cb8425d61", size = 21230, upload-time = "2025-10-26T15:12:09.109Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
 ]
 
 [[package]]
 name = "python-multipart"
-version = "0.0.22"
+version = "0.0.32"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/01/979e98d542a70714b0cb2b6728ed0b7c46792b695e3eaec3e20711271ca3/python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58", size = 37612, upload-time = "2026-01-25T10:15:56.219Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/d0/397f9626e711ff749a95d96b7af99b9c566a9bb5129b8e4c10fc4d100304/python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155", size = 24579, upload-time = "2026-01-25T10:15:54.811Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
 ]
 
 [[package]]
@@ -889,7 +899,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.32.5"
+version = "2.34.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -897,9 +907,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
 ]
 
 [[package]]
@@ -1030,11 +1040,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Bumps the nine packages listed in #533 to their fixed versions, plus one
more found along the way:

| Package | Before | After | Advisory |
|---|---|---|---|
| click | 8.3.1 | 8.4.2 | PYSEC-2026-2132 |
| requests | 2.32.5 | 2.34.2 | PYSEC-2026-2275 |
| urllib3 | 2.6.3 | 2.7.0 | PYSEC-2026-142, PYSEC-2026-141 |
| idna | 3.11 | 3.18 | PYSEC-2026-215 |
| pytest | 9.0.2 | 9.1.1 | PYSEC-2026-1845 |
| pygments | 2.19.2 | 2.20.0 | PYSEC-2026-2987 |
| python-dotenv | 1.2.1 | 1.2.2 | PYSEC-2026-2270 |
| pydantic-settings | 2.12.0 | 2.14.2 | GHSA-4xgf-cpjx-pc3j |
| python-multipart | 0.0.22 | 0.0.32 | PYSEC-2026-3037/3038 |
| protobuf (not in #533) | 6.33.4 | 6.33.6 | PYSEC-2026-1805 |

`fastapi`/`starlette` are **intentionally untouched** here -- that's #534.
Used targeted `uv lock --upgrade-package <name>` per package (not a blanket
`uv lock --upgrade`) specifically to avoid pulling in the unpinned fastapi's
latest resolution, which would have dragged starlette along with it.

**protobuf**: baseline `pip-audit` on `default` (before any changes) found an
11th vulnerable package not listed in #533: protobuf 6.33.4 carries
PYSEC-2026-1805, fixed in 6.33.5. Folded a `protobuf>=6.33.5,<7` floor-pin
into this PR since it's a trivial patch-level fix and the goal is a fully
clean `pip-audit` on the packages this PR *can* clear. The `<7` upper bound
is intentional -- an unconstrained bump would let the resolver jump to
protobuf 7.x (a major version), which is out of scope here.

## Reconciling with existing PRs

- Supersedes dependabot #524 (`python-multipart>=0.0.28`) -- insufficient,
  PYSEC-2026-3037 needs `>=0.0.30`; this PR pins `>=0.0.30` and locks to
  0.0.32.
- Overlaps PR #517's `requests>=2.33.0` / `pygments>=2.20.0` additions to
  `pyproject.toml`. Harmless duplication -- whichever of the two PRs merges
  second will just see those two lines already present and lockfile deltas
  limited to whatever changed since. No action needed on either PR.
- Supersedes dependabot #519 (`protobuf>=7.34.1`) for this release. #519
  proposes a major-version jump; this PR intentionally takes the minimal
  same-series patch (`>=6.33.5,<7`) instead, since that's sufficient to
  clear PYSEC-2026-1805 with far less risk on a release-blocking PR. #519
  can stay open and be evaluated separately as a deliberate major-version
  upgrade outside the security-fix path.

## Multipart regression found and fixed

Bumping `python-multipart` past 0.0.22 pulled in library-level DoS guards
(`max_header_count` default 8, `max_header_size` default ~4KB) that are
*tighter* than magpie's own configured limits (`MAX_HEADERS_PER_PART=50`,
`MAX_HEADER_SIZE=16KB` in `StreamingMultipartHandler`). The library's own
`MultipartParseError` started firing before magpie's callback-based checks
could raise its `HeaderLimitExceededError`, breaking
`tests/unit/test_streaming_multipart_handler.py::TestHeaderSizeLimits::test_too_many_headers_per_part_rejected`
and
`tests/unit/test_upload_security_hardening.py::TestHeaderSizeLimits::test_oversized_header_rejected`.

Fixed by adding `build_multipart_parser()` in
`src/magpie/server/routes/upload.py`, which passes the library its own
`max_header_count`/`max_header_size` set to 2x magpie's configured limits --
keeping magpie's own limits and error messages authoritative while the
library's (now-mandatory) guards serve as an outer backstop. Both the route
and the unit tests that construct a `MultipartParser` directly now go
through this shared factory instead of duplicating the construction call.

## Test plan

- [x] `just lint` -- clean
- [x] `just fmt-check` -- clean (after `just fmt`)
- [x] `just security` (bandit) -- no issues
- [x] `uv run pytest -m "not e2e" --cov=src/magpie` -- 1423 passed, 1 skipped
      (matches the count on `default`/#532)
- [x] `pip-audit` before: 11 vulnerable packages (the nine from #533 +
      protobuf + starlette). After: only starlette remains (tracked by
      #534).
- [x] CI: lint/test/e2e green on this PR; `security` fails as expected --
      the 7 remaining advisories are all starlette, unchanged by this PR
      by design (deferred to #534/#538). Verified this PR's changes are
      also validated by CI end-to-end via #538 (stacked on this branch),
      where all four jobs including `security` and `e2e` pass once both
      PRs' changes are combined.

## AI disclosure

Implemented via Claude Code (Fable 5), including the pip-audit
investigation, the multipart regression diagnosis/fix, and this PR
description.

Closes #533
