### PR TITLE
deps: upgrade fastapi/starlette for PYSEC-2026-161 (closes #534)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [{ name = "SWCCDC Team" }]
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
-    "fastapi",
+    "fastapi>=0.139.2",
     "uvicorn[standard]",
     "click>=8.3.3",
     "httpx",

--- a/src/magpie/server/routes/upload.py
+++ b/src/magpie/server/routes/upload.py
@@ -48,7 +48,7 @@ def build_multipart_parser(
     python-multipart's own max_header_count/max_header_size defaults (8 headers,
     ~4KB) are tighter than StreamingMultipartHandler's configured limits
     (MAX_HEADERS_PER_PART, MAX_HEADER_SIZE) and would otherwise raise the library's
-    MultipartParseError before the handler's callbacks raise HeaderLimitExceededError.
+    ParseError before the handler's callbacks raise HeaderLimitExceededError.
     Setting the library limits to a multiple of magpie's own keeps magpie's checks
     authoritative while still providing an outer backstop.
     """
@@ -478,11 +478,14 @@ async def upload_artifact(
         # its own max_header_count/max_header_size guards, or any other malformed
         # input the library rejects before magpie's own checks run. Translate the
         # same way as magpie's own HeaderLimitExceededError/MalformedMultipartError
-        # so callers see a clean 400 instead of an unhandled 500.
+        # so callers see a clean 400 instead of an unhandled 500. The raw exception
+        # text is logged server-side only, not returned to the client, since it may
+        # echo attacker-controlled payload fragments.
         handler.cleanup()
+        logger.warning("multipart parse error", error=str(e))
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Malformed multipart payload: {e}",
+            detail="Malformed multipart payload",
         )
     except Exception:
         handler.cleanup()

--- a/src/magpie/server/routes/upload.py
+++ b/src/magpie/server/routes/upload.py
@@ -48,9 +48,10 @@ def build_multipart_parser(
     python-multipart's own max_header_count/max_header_size defaults (8 headers,
     ~4KB) are tighter than StreamingMultipartHandler's configured limits
     (MAX_HEADERS_PER_PART, MAX_HEADER_SIZE) and would otherwise raise the library's
-    ParseError before the handler's callbacks raise HeaderLimitExceededError.
-    Setting the library limits to a multiple of magpie's own keeps magpie's checks
-    authoritative while still providing an outer backstop.
+    MultipartParseError (a subclass of python-multipart's ParseError, which the
+    upload handler catches) before the handler's callbacks raise
+    HeaderLimitExceededError. Setting the library limits to a multiple of magpie's
+    own keeps magpie's checks authoritative while still providing an outer backstop.
     """
     return MultipartParser(
         boundary,

--- a/src/magpie/server/routes/upload.py
+++ b/src/magpie/server/routes/upload.py
@@ -483,7 +483,7 @@ async def upload_artifact(
         # text is logged server-side only, not returned to the client, since it may
         # echo attacker-controlled payload fragments.
         handler.cleanup()
-        logger.warning("multipart parse error", error=str(e))
+        logger.warning("multipart_parse_error", error=str(e))
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Malformed multipart payload",

--- a/tests/unit/test_streaming_multipart_handler.py
+++ b/tests/unit/test_streaming_multipart_handler.py
@@ -871,7 +871,9 @@ class TestLibraryParseErrorBackstop:
 
         parser = build_multipart_parser(boundary, handler)
 
-        with pytest.raises(MultipartParseError, match="invalid character"):
+        # Assert on the exception type only -- the library's message wording
+        # is not part of magpie's contract and has changed across releases.
+        with pytest.raises(MultipartParseError):
             parser.write(payload)
             parser.finalize()
 

--- a/uv.lock
+++ b/uv.lock
@@ -217,17 +217,18 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.128.0"
+version = "0.139.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
     { name = "pydantic" },
     { name = "starlette" },
     { name = "typing-extensions" },
+    { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/52/08/8c8508db6c7b9aae8f7175046af41baad690771c9bcde676419965e338c7/fastapi-0.128.0.tar.gz", hash = "sha256:1cc179e1cef10a6be60ffe429f79b829dce99d8de32d7acb7e6c8dfdf7f2645a", size = 365682, upload-time = "2025-12-27T15:21:13.714Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/95/d3f0ae10836324a2eab98a52b61210ac609f08200bf4bb0dc8132d32f78a/fastapi-0.139.2.tar.gz", hash = "sha256:333145a6891e9b5b3cfceb69baf817e8240cde4d4588ae5a10bf56ffacb6255e", size = 423428, upload-time = "2026-07-16T15:06:17.912Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5c/05/5cbb59154b093548acd0f4c7c474a118eda06da25aa75c616b72d8fcd92a/fastapi-0.128.0-py3-none-any.whl", hash = "sha256:aebd93f9716ee3b4f4fcfe13ffb7cf308d99c9f3ab5622d8877441072561582d", size = 103094, upload-time = "2025-12-27T15:21:12.154Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/c7/cb03251d9dfb177246a9809a76f189d21df32dbd4a845951881d11323b7f/fastapi-0.139.2-py3-none-any.whl", hash = "sha256:b9ad015a835173d59865e2f5d8296fbc2b317bf56a2ba1a5bfbdd03de2fd4b1c", size = 130234, upload-time = "2026-07-16T15:06:19.557Z" },
 ]
 
 [[package]]
@@ -422,7 +423,7 @@ dev = [
 requires-dist = [
     { name = "aiofiles" },
     { name = "click", specifier = ">=8.3.3" },
-    { name = "fastapi" },
+    { name = "fastapi", specifier = ">=0.139.2" },
     { name = "httpx" },
     { name = "idna", specifier = ">=3.15" },
     { name = "opentelemetry-exporter-otlp" },
@@ -971,14 +972,14 @@ fastapi = [
 
 [[package]]
 name = "starlette"
-version = "0.50.0"
+version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ba/b8/73a0e6a6e079a9d9cfa64113d771e421640b6f679a52eeb9b32f72d871a1/starlette-0.50.0.tar.gz", hash = "sha256:a2a17b22203254bcbc2e1f926d2d55f3f9497f769416b3190768befe598fa3ca", size = 2646985, upload-time = "2025-11-01T15:25:27.516Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d9/52/1064f510b141bd54025f9b55105e26d1fa970b9be67ad766380a3c9b74b0/starlette-0.50.0-py3-none-any.whl", hash = "sha256:9e5391843ec9b6e472eed1365a78c8098cfceb7a74bfd4d6b1c0c0095efb3bca", size = 74033, upload-time = "2025-11-01T15:25:25.461Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Stacked on #537

This branch is based on `issue-533-1784236898` (#537) to avoid `uv.lock`
conflicts, since both PRs touch `pyproject.toml`/`uv.lock`. Until #537
merges, this PR's diff will include #537's commits too -- once #537 merges
to `default`, this diff will narrow to just the fastapi/starlette change.
**Merge #537 first.**

## Summary

Bumps `fastapi` 0.128.0 -> 0.139.2, pulling in `starlette` 0.50.0 -> 1.3.1.
Clears:

- **PYSEC-2026-161** -- Host-header -> `request.url.path` auth-bypass
  (fixed >=1.0.1)
- PYSEC-2026-248/249 -- path/authority confusion (fixed >=1.3.0/1.3.1)
- PYSEC-2026-2280/2281 -- HTTPEndpoint method dispatch, StaticFiles Windows
  SSRF (fixed >=1.1.0)

## Feasibility

Confirmed a fastapi release supporting starlette 1.x already exists:
`uv lock --upgrade-package fastapi --upgrade-package starlette` resolves
cleanly with **no other package movement** (diff limited to fastapi +
starlette in `uv.lock`). Floor-pinned `fastapi>=0.139.2` in
`pyproject.toml` to document and hold the minimum version that pulls a
patched starlette.

## Exposure review for magpie specifically

Grepped `src/magpie` for `request.url` / `request.url.path`. All four
occurrences are in `src/magpie/server/middleware.py`:

- Three in structured logging calls (`logger.info(..., path=request.url.path)`)
  -- worst case if Host-header confusion occurs is a mislogged path, not an
  auth decision.
- One (`normalized_path = request.url.path.rstrip("/") or "/"`) gates a
  version-check exemption for `/health` -- low severity, not an
  authorization decision either way.

magpie's actual authorization is enforced via FastAPI's route-level
`Depends()` (`require_write_scope`, `require_admin_scope`, etc.) tied to
the already-matched route -- not by re-inspecting `request.url.path`
separately. So magpie doesn't appear to have a direct exploitable path for
the PYSEC-2026-161 bypass pattern specifically. Upgrading regardless per
release policy (no releases with known vulns) and as defense in depth,
since the vulnerability lives in the shared library and downstream code
paths (or future changes) could rely on it.

## Test plan

- [x] `just lint` -- clean
- [x] `just fmt-check` -- clean
- [x] `just security` (bandit) -- no issues
- [x] `uv run pytest -m "not e2e" --cov=src/magpie` -- 1423 passed, 1
      skipped (identical count to pre-upgrade baseline and to #537)
- [x] `pip-audit` -- **fully clean, 0 known vulnerabilities** (down from 7
      starlette advisories pre-upgrade)
- [ ] e2e -- **not run in this worktree.** `tests/e2e/conftest.py` /
      `docker-compose.yml` bind fixed host ports 8080/8443, which are
      occupied by another in-progress Docker stack in this shared
      environment, so running e2e here risked a port conflict or
      disrupting that other work. CI runs e2e in isolation -- please treat
      CI's e2e job as the authoritative signal for this PR before merging.

## Non-blocking observation

New `StarletteDeprecationWarning` surfaced during the test run: "Using
httpx with starlette.testclient is deprecated; install httpx2 instead."
Not addressed in this PR (out of scope for a security bump); worth a
follow-up issue if the project wants to track the httpx2 migration.

## AI disclosure

Implemented via Claude Code (Fable 5), including the feasibility check,
the `request.url.path` exposure review, and this PR description.

Closes #534