### PR TITLE
fix(security): Bearer-gate flush-tag (closes #526)

### DIFF
--- a/src/magpie/server/routes/tags.py
+++ b/src/magpie/server/routes/tags.py
@@ -9,7 +9,8 @@ import structlog
 from fastapi import APIRouter, Depends, HTTPException, Path, Query, status
 from pydantic import BaseModel
 
-from magpie.server.deps import require_admin_scope_header
+from magpie.auth.service import TokenInfo
+from magpie.server.deps import require_admin_scope
 from magpie.server.subprocess_utils import CtlCommandError, run_ctl_command
 from magpie.validation import TAG_NAME_MAX_LENGTH, TAG_NAME_PATTERN
 
@@ -37,13 +38,13 @@ async def flush_tag(
         bool,
         Query(description="If true, return preview without actually removing tags"),
     ] = False,
-    _admin_scope_check: Annotated[None, Depends(require_admin_scope_header)] = None,
+    admin: Annotated[TokenInfo, Depends(require_admin_scope)] = None,
 ) -> FlushTagResponse:
     """Remove a tag from all artifacts globally.
 
-    Requires admin scope. This is a potentially destructive operation that walks
-    the entire storage tree and removes the specified tag from every artifact that
-    has it.
+    Requires admin scope, validated via Bearer token. This is a potentially
+    destructive operation that walks the entire storage tree and removes the
+    specified tag from every artifact that has it.
 
     The confirm_walk_filesystem parameter must be explicitly set to true to
     acknowledge that this operation will scan the entire storage filesystem.
@@ -54,12 +55,14 @@ async def flush_tag(
         tag_name: Name of the tag to remove globally.
         confirm_walk_filesystem: Must be true to proceed with the operation.
         dry_run: If true, return affected artifacts without actually removing tags.
+        admin: Validated admin token (injected by dependency).
 
     Returns:
         FlushTagResponse with list of affected artifacts and count.
 
     Raises:
-        HTTPException 401: If X-Magpie-Scope header is missing (unauthenticated).
+        HTTPException 401: If the Authorization Bearer token is missing, malformed,
+            invalid, or disabled.
         HTTPException 403: If token doesn't have admin scope.
         HTTPException 400: If confirm_walk_filesystem is not true.
     """

--- a/tests/integration/test_flush_endpoint.py
+++ b/tests/integration/test_flush_endpoint.py
@@ -4,7 +4,97 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, patch
 
+import pytest
 from fastapi.testclient import TestClient
+
+from magpie.auth.service import TokenService
+from magpie.server.app import app
+from magpie.server.deps import get_token_service
+
+
+class TestFlushEndpointAuth:
+    """Tests for flush endpoint authentication and authorization (#526).
+
+    Flush is the single most destructive operation in the system (removes a tag
+    from every artifact store-wide) and must validate a Bearer token directly via
+    require_admin_scope, matching GC and the token endpoints -- not merely trust
+    the X-Magpie-Scope header the way require_admin_scope_header does.
+    """
+
+    @pytest.fixture
+    def client(self, token_service: TokenService) -> TestClient:
+        """Test client with real Bearer-token auth (no auth dependency overrides).
+
+        Clears the autouse header-trust overrides so the endpoint's actual
+        dependency (require_admin_scope) is exercised end-to-end.
+        """
+        app.dependency_overrides.clear()
+
+        def override_token_service() -> TokenService:
+            return token_service
+
+        app.dependency_overrides[get_token_service] = override_token_service
+        yield TestClient(app, raise_server_exceptions=False)
+        app.dependency_overrides.clear()
+
+    def test_flush_rejects_header_only_admin_scope(self, client: TestClient) -> None:
+        """A forged/trusted X-Magpie-Scope: admin header alone must not authorize flush.
+
+        Regression test for #526: flush previously used require_admin_scope_header,
+        which authorized purely on this header. It must now require a valid Bearer
+        token like every other admin operation.
+        """
+        response = client.post(
+            "/api/v1/tags/some-tag/flush",
+            params={"confirm_walk_filesystem": True},
+            headers={"X-Magpie-Scope": "admin"},
+        )
+
+        assert response.status_code == 401
+
+    def test_flush_requires_authorization_header(self, client: TestClient) -> None:
+        """Flush without any Authorization header returns 401."""
+        response = client.post(
+            "/api/v1/tags/some-tag/flush",
+            params={"confirm_walk_filesystem": True},
+        )
+
+        assert response.status_code == 401
+
+    def test_flush_with_write_bearer_returns_403(
+        self, client: TestClient, write_token: str
+    ) -> None:
+        """Flush with a valid but non-admin Bearer token returns 403."""
+        response = client.post(
+            "/api/v1/tags/some-tag/flush",
+            params={"confirm_walk_filesystem": True},
+            headers={"Authorization": f"Bearer {write_token}"},
+        )
+
+        assert response.status_code == 403
+
+    def test_flush_with_valid_admin_bearer_succeeds(
+        self, client: TestClient, admin_token: str
+    ) -> None:
+        """Flush succeeds when a valid admin Bearer token is presented."""
+        mock_result = {
+            "tag_name": "some-tag",
+            "dry_run": False,
+            "count": 0,
+            "affected_artifacts": [],
+        }
+
+        with patch(
+            "magpie.server.routes.tags.run_ctl_command",
+            new=AsyncMock(return_value=mock_result),
+        ):
+            response = client.post(
+                "/api/v1/tags/some-tag/flush",
+                params={"confirm_walk_filesystem": True},
+                headers={"Authorization": f"Bearer {admin_token}"},
+            )
+
+        assert response.status_code == 200
 
 
 class TestDryRunPreview:


### PR DESCRIPTION
## Summary

The global `flush-tag` operation -- the single most destructive operation in the
system, removing a tag from every artifact store-wide -- was authorized by
`require_admin_scope_header` (trusting the `X-Magpie-Scope` header set by Caddy
`forward_auth`), while every other admin operation (GC, all token endpoints)
validates the Bearer token directly via `require_admin_scope`.

This PR switches `flush_tag` in `src/magpie/server/routes/tags.py` to
`require_admin_scope`, so it re-validates the Bearer token like the rest of the
admin surface, removing the most destructive operation from the header-trust
boundary entirely.

## Changes

- `src/magpie/server/routes/tags.py`: swap dependency from
  `require_admin_scope_header` to `require_admin_scope` (matches `routes/gc.py`
  and `routes/auth.py` token endpoints)
- `tests/integration/test_flush_endpoint.py`: new `TestFlushEndpointAuth` class
  covering:
  - a forged/trusted `X-Magpie-Scope: admin` header alone no longer authorizes
    flush (regression test for the bug)
  - missing `Authorization` header returns 401
  - a valid but non-admin Bearer token (write scope) returns 403
  - a valid admin Bearer token succeeds

## Test plan

- `just lint` -- passes
- `just fmt-check` -- passes
- `just test-ci` -- 1429 passed, 1 skipped (e2e excluded; docker compose is not
  available in this sandbox, consistent with the rest of this environment's
  constraints)

Closes #526

(AI-generated via Claude Code w/ Fable 5)