### PR TITLE
fix(entrypoint)+test: chown error message and token-rotation failure-injection (closes #535, #410)

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -41,8 +41,14 @@ chmod 644 /run/magpie-user
 # with artifacts.
 STORAGE_DIR="${MAGPIE_STORAGE_PATH:-/data/artifacts}"
 if [ ! -d "$STORAGE_DIR" ]; then
-    mkdir -p "$STORAGE_DIR"
-    chown "$RUN_UID:$RUN_GID" "$STORAGE_DIR"
+    if ! mkdir -p "$STORAGE_DIR"; then
+        echo "Error: Failed to create storage directory $STORAGE_DIR" >&2
+        exit 1
+    fi
+    if ! chown "$RUN_UID:$RUN_GID" "$STORAGE_DIR"; then
+        echo "Error: Failed to chown storage directory $STORAGE_DIR to $RUN_UID:$RUN_GID (the container may lack permission to change ownership on this mount, e.g. some bind mounts or non-root filesystems)" >&2
+        exit 1
+    fi
 fi
 
 # Auto-initialize database if it doesn't exist

--- a/tests/unit/test_token_service.py
+++ b/tests/unit/test_token_service.py
@@ -307,6 +307,35 @@ class TestRotateToken:
         # Verify original token still works (wasn't permanently deleted)
         assert token_service.validate_token(original_token) is not None
 
+    def test_rotate_token_rolls_back_on_save_failure(
+        self, token_service: TokenService, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """rotate_token should leave the original token intact if save fails mid-rotation.
+
+        This is a failure-injection test for the atomicity fix: it forces save_token()
+        to raise *after* delete_token() has already run within rotate_token()'s own
+        transaction, then verifies the original token was never actually lost. Unlike
+        test_rotate_token_is_atomic (which exercises raw sqlite3 rollback semantics
+        directly), this drives the failure through rotate_token() itself.
+        """
+        original_token = token_service.create_token("failure-injection", TokenScope.WRITE)
+
+        # Sanity check: original token works before rotation is attempted.
+        assert token_service.validate_token(original_token) is not None
+
+        def _failing_save_token(*args: object, **kwargs: object) -> None:
+            raise RuntimeError("simulated failure during save_token")
+
+        # save_token is imported into the service module's namespace, so patch it there.
+        monkeypatch.setattr("magpie.auth.service.save_token", _failing_save_token)
+
+        with pytest.raises(RuntimeError, match="simulated failure during save_token"):
+            token_service.rotate_token("failure-injection")
+
+        # The delete (which ran before the injected failure) must have been rolled back
+        # by the transaction, so the original token should still exist and still work.
+        assert token_service.validate_token(original_token) is not None
+
     def test_rotate_token_preserves_scope_immutably(self, token_service: TokenService) -> None:
         """rotate_token should always preserve the original token scope.
 


### PR DESCRIPTION
## Summary

Two small v0.1.4 items:

1. **#535** - The first-boot storage-dir `chown` in `entrypoint.sh` (added in #512) ran under `set -e` with no error message. If it failed (e.g. a bind mount the container genuinely can't chown), the container exited with a bare non-zero status and no hint why. Added explicit, actionable error messages around both the `mkdir` and `chown` steps, matching the style already used by the adjacent flock/lock-file section in the same script.

2. **#410** - Added `test_rotate_token_rolls_back_on_save_failure` to `tests/unit/test_token_service.py`, a failure-injection test for `TokenService.rotate_token()`. It mocks `save_token()` to raise *after* `delete_token()` has already run inside `rotate_token()`'s own transaction, then asserts the original token still exists and still authenticates. This complements the existing `test_rotate_token_is_atomic` (which tests raw sqlite3 rollback semantics directly) by driving the failure through `rotate_token()` itself, per the #406 review feedback that motivated the issue.

Did not touch the admin-token-logging behavior in `ctl/commands/init.py` (out of scope, separate design discussion per #387).

## Test plan

- [x] `just lint` - clean
- [x] `just fmt-check` - clean
- [x] `just test-ci` (excludes e2e) - 1426 passed, 1 skipped
- [x] `just security` (bandit) - no issues
- [x] `shellcheck entrypoint.sh` - clean
- [x] New unit test passes and fails without the fix (verified rotate_token() actually rolls back)
- [ ] Full e2e suite not run in this session due to a local Docker port conflict (8080 already allocated by a concurrent worktree) - unrelated to this change; entrypoint.sh changes are only additional error handling on already-existing failure paths.

(AI-generated via Claude Code w/ Fable 5)