### PR TITLE
test: prevent structlog global-state leak between tests (closes #540)

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -28,7 +28,9 @@ jobs:
         run: uv sync --all-groups
 
       - name: Run unit and integration tests
-        run: uv run pytest tests/unit/ tests/integration/ -v --tb=short --junitxml=test-results.xml
+        run: >-
+          uv run pytest -m "not e2e" --cov=src/magpie --cov-report=term --cov-report=xml
+          -v --tb=short --junitxml=test-results.xml
 
       - name: Upload test results
         if: always()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,14 +2,51 @@
 
 from __future__ import annotations
 
+import logging
 import shutil
 import tempfile
 from pathlib import Path
 from typing import Generator
 
 import pytest
+import structlog
 
 from magpie.config import MagpieSettings
+
+
+@pytest.fixture(autouse=True)
+def _isolate_logging_state() -> Generator[None, None, None]:
+    """Snapshot and restore global structlog/stdlib logging config around every test.
+
+    structlog.configure() and the stdlib root logger are process-global, so any test
+    that reconfigures them (directly, or via a fixture that calls
+    structlog.reset_defaults()) can leak that state into every test that runs
+    afterward in the same process. reset_defaults() in particular resets structlog to
+    its own *library* defaults -- ConsoleRenderer + PrintLoggerFactory, which writes
+    to stdout -- not to the app's production defaults (JSON to stderr, configured
+    once at import time by magpie.server.app). Nothing re-applies those production
+    defaults afterward, so once a test leaves structlog on library defaults, later
+    tests that log through the app's loggers get console-formatted output mixed into
+    stdout.
+
+    This fixture is declared here (not in a test module) and is autouse, so pytest
+    sets it up before, and tears it down after, any per-module logging fixtures --
+    guaranteeing the snapshot taken here is what's restored, regardless of what
+    happens inside the test or its other fixtures.
+    """
+    structlog_config = structlog.get_config()
+    root_logger = logging.getLogger()
+    root_level = root_logger.level
+    root_handlers = root_logger.handlers[:]
+
+    yield
+
+    structlog.configure(**structlog_config)
+    root_logger.setLevel(root_level)
+    for handler in root_logger.handlers[:]:
+        root_logger.removeHandler(handler)
+    for handler in root_handlers:
+        root_logger.addHandler(handler)
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

Fixes the post-merge `full-test-suite` job failing on `default` while every PR's CI stays green -- a test-isolation bug, not a runtime regression (SouthwestCCDC/magpie#540).

**Root cause:** `structlog.reset_defaults()` (used by autouse fixtures in `tests/unit/test_logging_config.py` and `tests/unit/test_observability.py`) resets structlog to its own *library* defaults -- `ConsoleRenderer` + `PrintLoggerFactory`, which writes to **stdout** -- not the app's production defaults (JSON to **stderr**, configured once at import time by `magpie/server/app.py`). Nothing re-applies the production config afterward, so once either of those files runs, every later test in the same process that logs through the app's structlog loggers gets console-formatted log lines mixed into stdout. That's what broke 7 CLI integration tests that parse `CliRunner` output as JSON -- they only failed when `tests/unit` ran before `tests/integration` in the same process (post-merge's invocation order), not when run alone or via PR CI's default alphabetical collection (`tests/integration` before `tests/unit`).

**Fix:**
- Added an autouse, function-scoped fixture in `tests/conftest.py` that snapshots `structlog.get_config()` plus the stdlib root logger's level/handlers before each test and restores them after. Because it's declared in the top-level conftest, pytest tears it down *after* any per-module logging fixtures (standard fixture LIFO teardown ordering), so this restoration always wins regardless of what an individual test or its own fixtures do to global logging state -- making the fix robust even if new tests reconfigure structlog in the future.
- Aligned `.github/workflows/post-merge.yml`'s pytest invocation with `just test-ci` (`-m "not e2e"` + coverage flags over the full `tests/` tree) so the post-merge and PR-CI signals use the same collection scope/order going forward.

## Test plan

- [x] `uv run pytest tests/unit tests/integration -q` -- 1359 passed (previously 7 failed)
- [x] Same command with `tests/integration tests/unit` order -- 1359 passed
- [x] `just test-ci` -- 1425 passed, 1 skipped, 122 deselected (unchanged pass count from before the fix)
- [x] `just lint` / `just fmt-check` -- clean
- [x] `just test-unit` -- 978 passed

(AI-generated via Claude Code w/ Fable 5)