### PR TITLE
fix(installer): validate inputs and stop sourcing .env as shell (closes #448)

### DIFF
--- a/scripts/magpie-deploy.sh
+++ b/scripts/magpie-deploy.sh
@@ -295,8 +295,20 @@ is_valid_ip_or_cidr() {
 # independently of how the value is later consumed. See issue #448.
 is_valid_acme_server_url() {
     local value="$1"
-    local pattern='^https://[A-Za-z0-9.-]+(:[0-9]{1,5})?(/[A-Za-z0-9._~%!$&()*+,;=:@/-]*)?$'
-    [[ "$value" =~ $pattern ]]
+    local pattern='^https://[A-Za-z0-9.-]+(:([0-9]{1,5}))?(/[A-Za-z0-9._~%!$&()*+,;=:@/-]*)?$'
+    [[ "$value" =~ $pattern ]] || return 1
+
+    # The charset regex alone allows a syntactically-shaped but out-of-range
+    # port (e.g. ":99999", which is 1-5 digits but > 65535) -- that would
+    # pass validation and then produce a Caddyfile Caddy rejects at
+    # install/update time. `10#...` forces base-10 (see the CIDR octet
+    # comment above for why: a leading zero would otherwise be read as
+    # octal by bash arithmetic).
+    local port="${BASH_REMATCH[2]}"
+    if [[ -n "$port" ]]; then
+        (( 10#$port >= 1 && 10#$port <= 65535 )) || return 1
+    fi
+    return 0
 }
 
 # Validates a whitespace-separated list of IPv4/IPv6 addresses or CIDRs.
@@ -520,6 +532,12 @@ read_env_file() {
     local line key value
 
     while IFS= read -r line || [[ -n "$line" ]]; do
+        # Strip a trailing CR so a CRLF-terminated (e.g. Windows-edited)
+        # .env doesn't leave a stray \r embedded in the parsed value (e.g.
+        # TRUSTED_PROXIES=...\r), which downstream validators would then
+        # reject as a control character.
+        line="${line%$'\r'}"
+
         [[ -z "$line" ]] && continue
         [[ "$line" =~ ^[[:space:]]*# ]] && continue
 
@@ -539,7 +557,10 @@ load_existing_config() {
         local -A env_vars=()
         read_env_file "${INSTALL_DIR}/etc/.env" env_vars
 
-        # Map env vars to script variables (only for MAGPIE_* prefixed vars)
+        # Map env vars to script variables. MAGPIE_* prefixed vars map to
+        # their unprefixed script variable name (DATA_DIR, HTTP_PORT,
+        # HTTPS_PORT, DOMAIN); the unprefixed persisted keys below
+        # (TLS_MODE, TRUSTED_PROXIES, BIND_IP, ACME_SERVER) map directly.
         DATA_DIR="${env_vars[MAGPIE_DATA_DIR]:-$DATA_DIR}"
         HTTP_PORT="${env_vars[MAGPIE_HTTP_PORT]:-$HTTP_PORT}"
         HTTPS_PORT="${env_vars[MAGPIE_HTTPS_PORT]:-$HTTPS_PORT}"

--- a/scripts/magpie-deploy.sh
+++ b/scripts/magpie-deploy.sh
@@ -300,14 +300,33 @@ is_valid_acme_server_url() {
 }
 
 # Validates a whitespace-separated list of IPv4/IPv6 addresses or CIDRs.
-# Word-splits on IFS (space, tab, newline), so an embedded newline is
-# checked per-token like any other separator: an injected non-IP token
-# (e.g. a Caddy directive) fails validation rather than being smuggled
-# through as part of one value.
+#
+# Rejects any control character (including a newline) in the raw value
+# up front, before splitting into tokens. A newline sitting *between* two
+# otherwise-valid tokens (e.g. "10.0.0.0/8\n192.168.1.1") would otherwise
+# pass per-token validation, but it corrupts the generated .env
+# (read_env_file() is line-based -- everything after the first newline in
+# a value becomes a separate, likely-dropped "line") and the Caddyfile's
+# `trusted_proxies static ${TRUSTED_PROXIES}` directive (split across
+# Caddyfile lines). See issue #448.
+#
+# Tokens are split with `read -ra` rather than `for token in $list`: the
+# latter performs pathname expansion (globbing) in addition to
+# word-splitting, so a value containing glob characters (e.g. "*") could
+# validate unpredictably depending on files in the current directory.
+# `read` never globs.
 is_valid_ip_or_cidr_list() {
     local list="$1"
+
+    if [[ "$list" =~ [[:cntrl:]] ]]; then
+        return 1
+    fi
+
+    local -a tokens
+    read -ra tokens <<< "$list"
+
     local token
-    for token in $list; do
+    for token in "${tokens[@]}"; do
         is_valid_ip_or_cidr "$token" || return 1
     done
     return 0

--- a/scripts/magpie-deploy.sh
+++ b/scripts/magpie-deploy.sh
@@ -301,8 +301,13 @@ is_valid_acme_server_url() {
 
 # Validates a whitespace-separated list of IPv4/IPv6 addresses or CIDRs.
 #
-# Rejects any control character (including a newline) in the raw value
-# up front, before splitting into tokens. A newline sitting *between* two
+# Rejects any control character EXCEPT horizontal tab in the raw value up
+# front, before splitting into tokens. Tab is excluded from the rejection
+# because it's a legitimate whitespace separator for this
+# "whitespace-separated" list (tokenization below already splits on it via
+# IFS) -- rejecting it would be a functional regression for tab-separated
+# input that previously validated. Newline/CR and other control
+# characters are still rejected: a newline sitting *between* two
 # otherwise-valid tokens (e.g. "10.0.0.0/8\n192.168.1.1") would otherwise
 # pass per-token validation, but it corrupts the generated .env
 # (read_env_file() is line-based -- everything after the first newline in
@@ -318,7 +323,8 @@ is_valid_acme_server_url() {
 is_valid_ip_or_cidr_list() {
     local list="$1"
 
-    if [[ "$list" =~ [[:cntrl:]] ]]; then
+    local without_tabs="${list//$'\t'/}"
+    if [[ "$without_tabs" =~ [[:cntrl:]] ]]; then
         return 1
     fi
 
@@ -623,9 +629,11 @@ MAGPIE_LOG_FORMAT=json
 MAGPIE_RETENTION_DAYS=90
 
 # TLS configuration (persisted for Caddyfile regeneration during updates)
-# See issues #340 and #344
+# See issues #340 and #344. MAGPIE_DOMAIN above is the single canonical
+# domain key -- load_existing_config() reads only that one, so there is no
+# separate DOMAIN= key here to avoid a stale/hand-edited duplicate being
+# silently ignored (issue #448).
 TLS_MODE=${TLS_MODE:-}
-DOMAIN=${DOMAIN:-}
 TRUSTED_PROXIES=${TRUSTED_PROXIES:-}
 
 # Network configuration (issue #446)

--- a/scripts/magpie-deploy.sh
+++ b/scripts/magpie-deploy.sh
@@ -243,12 +243,16 @@ is_valid_ipv4_cidr() {
     local value="$1"
     [[ "$value" =~ ^([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})(/([0-9]{1,2}))?$ ]] || return 1
 
+    # Force base-10 interpretation with `10#...`: bash arithmetic otherwise
+    # treats a leading-zero octet (e.g. "008") as octal, which either
+    # misjudges its value (e.g. "017" -> 15) or hard-errors ("008" has no
+    # digit 8/9 in octal).
     local octet
     for octet in "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}" "${BASH_REMATCH[3]}" "${BASH_REMATCH[4]}"; do
-        (( octet <= 255 )) || return 1
+        (( 10#$octet <= 255 )) || return 1
     done
     if [[ -n "${BASH_REMATCH[6]}" ]]; then
-        (( BASH_REMATCH[6] <= 32 )) || return 1
+        (( 10#${BASH_REMATCH[6]} <= 32 )) || return 1
     fi
     return 0
 }
@@ -264,7 +268,7 @@ is_valid_ipv6_cidr() {
     if [[ "$value" == */* ]]; then
         addr="${value%%/*}"
         prefix="${value#*/}"
-        [[ "$prefix" =~ ^[0-9]{1,3}$ ]] && (( prefix <= 128 )) || return 1
+        [[ "$prefix" =~ ^[0-9]{1,3}$ ]] && (( 10#$prefix <= 128 )) || return 1
     fi
 
     [[ "$addr" =~ ^[0-9A-Fa-f:]+$ ]] || return 1
@@ -276,6 +280,23 @@ is_valid_ipv6_cidr() {
 is_valid_ip_or_cidr() {
     local value="$1"
     is_valid_ipv4_cidr "$value" || is_valid_ipv6_cidr "$value"
+}
+
+# Matches an https:// URL using only an allowlisted RFC 3986-ish charset
+# for the authority and path. This is a strict ALLOWLIST (not a denylist of
+# specific bytes like whitespace/braces): it excludes every character not
+# explicitly permitted, including backslash. That matters because the
+# value is later interpolated into an awk program via ENVIRON (not `-v`),
+# but a denylist alone is not enough defense in depth -- `awk -v x=value`
+# decodes backslash escapes (`\n`, octal `\173`/`\175`/`\040`, etc.) in the
+# assigned value *before* the awk program runs, so a denylist that checks
+# only for literal whitespace/braces can be bypassed with escape sequences
+# that decode into them. Excluding backslash here closes that off
+# independently of how the value is later consumed. See issue #448.
+is_valid_acme_server_url() {
+    local value="$1"
+    local pattern='^https://[A-Za-z0-9.-]+(:[0-9]{1,5})?(/[A-Za-z0-9._~%!$&()*+,;=:@/-]*)?$'
+    [[ "$value" =~ $pattern ]]
 }
 
 # Validates a whitespace-separated list of IPv4/IPv6 addresses or CIDRs.
@@ -330,12 +351,8 @@ validate_network_config() {
         fi
     fi
 
-    if [[ -n "$ACME_SERVER" ]]; then
-        if [[ "$ACME_SERVER" != https://* ]]; then
-            errors+=("Invalid --acme-server: $ACME_SERVER (must start with https://)")
-        elif [[ "$ACME_SERVER" =~ [[:space:]{}] ]]; then
-            errors+=("Invalid --acme-server: $ACME_SERVER (must not contain whitespace, '{', or '}')")
-        fi
+    if [[ -n "$ACME_SERVER" ]] && ! is_valid_acme_server_url "$ACME_SERVER"; then
+        errors+=("Invalid --acme-server: $ACME_SERVER (must be an https:// URL using only RFC 3986 host/path characters; no whitespace, braces, or backslashes)")
     fi
 }
 
@@ -712,7 +729,19 @@ EOF
             if [[ -n "$ACME_SERVER" ]]; then
                 # Insert a tls block with the custom ACME server directly
                 # after the site address line.
-                awk -v site="${DOMAIN} {" -v acme="$ACME_SERVER" '
+                #
+                # ACME_SERVER is passed via ENVIRON, not `awk -v`: `-v`
+                # decodes backslash escapes (\n, octal \173/\175/\040, ...)
+                # in the assigned value before the awk program ever runs,
+                # which would let an escape-encoded payload with zero
+                # literal blocked bytes decode into real braces/newlines
+                # here -- even though it passed the ACME_SERVER allowlist.
+                # ENVIRON does not decode escapes. This is deliberately
+                # belt-and-suspenders with the strict allowlist in
+                # is_valid_acme_server_url(), which rejects backslashes
+                # outright. See issue #448.
+                ACME_SERVER="$ACME_SERVER" awk -v site="${DOMAIN} {" '
+                    BEGIN { acme = ENVIRON["ACME_SERVER"] }
                     {
                         print
                         if ($0 == site) {
@@ -1245,6 +1274,28 @@ cmd_update() {
     log "Updating magpie..."
 
     INSTALL_DIR="${INSTALL_DIR:-$DEFAULT_INSTALL_DIR}"
+
+    # Unlike DATA_DIR, INSTALL_DIR is not persisted to .env -- it comes
+    # straight from --install-dir on this invocation (or the default). It's
+    # later interpolated into `sed 's|...|${INSTALL_DIR}/...|g'` in
+    # patch_compose_for_caddyfile()/patch_compose_for_tls_certs(), so an
+    # unvalidated value containing '|' or other sed metacharacters could
+    # corrupt or hijack docker-compose.yml. cmd_install validates this via
+    # validate_config(); cmd_update needs its own check. See issue #448.
+    local errors=()
+    if [[ ! "$INSTALL_DIR" =~ ^/ ]]; then
+        errors+=("Install directory must be an absolute path: $INSTALL_DIR")
+    else
+        validate_path_value "$INSTALL_DIR" "Install directory"
+    fi
+    if [[ ${#errors[@]} -gt 0 ]]; then
+        log_error "Invalid --install-dir:"
+        for err in "${errors[@]}"; do
+            echo "  - $err" >&2
+        done
+        die "Fix the --install-dir value and try again."
+    fi
+
     verify_installation
     load_existing_config
 
@@ -1378,6 +1429,25 @@ cmd_uninstall() {
     load_existing_config
 
     if [[ "$PURGE" == "true" ]]; then
+        # DATA_DIR was just loaded from .env above; re-validate it before
+        # it's used in `rm -rf` -- a stale or hand-edited .env could
+        # otherwise point --purge at an arbitrary path. See issue #448.
+        local errors=()
+        if [[ -z "$DATA_DIR" ]]; then
+            errors+=("Data directory is empty; refusing to run --purge")
+        elif [[ ! "$DATA_DIR" =~ ^/ ]]; then
+            errors+=("Data directory must be an absolute path: $DATA_DIR")
+        else
+            validate_path_value "$DATA_DIR" "Data directory"
+        fi
+        if [[ ${#errors[@]} -gt 0 ]]; then
+            log_error "Refusing to purge -- data directory failed validation:"
+            for err in "${errors[@]}"; do
+                echo "  - $err" >&2
+            done
+            die "Fix ${INSTALL_DIR}/etc/.env or reinstall, then retry."
+        fi
+
         if ! confirm "This will permanently delete all artifacts and data. Continue?"; then
             log "Uninstall cancelled."
             exit 0

--- a/scripts/magpie-deploy.sh
+++ b/scripts/magpie-deploy.sh
@@ -221,6 +221,124 @@ check_prerequisites() {
 # Configuration validation
 # =============================================================================
 
+# Validation helpers (see issue #448) ----------------------------------------
+#
+# These are deliberately permissive-but-safe pattern checks rather than
+# fully RFC-compliant validators: the goal is to reject anything that could
+# be interpreted as shell, sed, or Caddyfile syntax (metacharacters,
+# newlines, braces), not to certify that a value is a *routable* hostname
+# or IP address.
+
+# Matches a syntactically valid DNS hostname: labels of alphanumerics and
+# hyphens (not starting/ending with a hyphen), separated by dots. Excludes
+# every character that would let a value act as regex, sed script, or shell
+# metacharacters ('/', '\', '$', backtick, ';', '&', newline, etc.).
+is_valid_domain() {
+    local domain="$1"
+    [[ "$domain" =~ ^[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*$ ]]
+}
+
+# Matches a single IPv4 address, optionally with a /NN CIDR prefix.
+is_valid_ipv4_cidr() {
+    local value="$1"
+    [[ "$value" =~ ^([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})(/([0-9]{1,2}))?$ ]] || return 1
+
+    local octet
+    for octet in "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}" "${BASH_REMATCH[3]}" "${BASH_REMATCH[4]}"; do
+        (( octet <= 255 )) || return 1
+    done
+    if [[ -n "${BASH_REMATCH[6]}" ]]; then
+        (( BASH_REMATCH[6] <= 32 )) || return 1
+    fi
+    return 0
+}
+
+# Matches a single IPv6 address, optionally with a /NNN CIDR prefix. This is
+# a charset/shape check (hex digits and colons only), not a full RFC 4291
+# validator -- it exists to reject injection characters.
+is_valid_ipv6_cidr() {
+    local value="$1"
+    local addr="$value"
+    local prefix=""
+
+    if [[ "$value" == */* ]]; then
+        addr="${value%%/*}"
+        prefix="${value#*/}"
+        [[ "$prefix" =~ ^[0-9]{1,3}$ ]] && (( prefix <= 128 )) || return 1
+    fi
+
+    [[ "$addr" =~ ^[0-9A-Fa-f:]+$ ]] || return 1
+    [[ "$addr" == *:* ]] || return 1
+    return 0
+}
+
+# Matches a single IP address (v4 or v6), optionally with a CIDR prefix.
+is_valid_ip_or_cidr() {
+    local value="$1"
+    is_valid_ipv4_cidr "$value" || is_valid_ipv6_cidr "$value"
+}
+
+# Validates a whitespace-separated list of IPv4/IPv6 addresses or CIDRs.
+# Word-splits on IFS (space, tab, newline), so an embedded newline is
+# checked per-token like any other separator: an injected non-IP token
+# (e.g. a Caddy directive) fails validation rather than being smuggled
+# through as part of one value.
+is_valid_ip_or_cidr_list() {
+    local list="$1"
+    local token
+    for token in $list; do
+        is_valid_ip_or_cidr "$token" || return 1
+    done
+    return 0
+}
+
+# Rejects path values that contain '..' path-traversal segments or any
+# character outside a safe allowlist. Paths in this script are written
+# unquoted into generated shell/systemd/docker-compose artifacts, so this
+# is stricter than "not empty" / "absolute" alone. Appends to the caller's
+# 'errors' array (relies on bash's dynamic scoping of locals). See issue #448.
+validate_path_value() {
+    local path="$1"
+    local label="$2"
+
+    if [[ "$path" =~ (^|/)\.\.(/|$) ]]; then
+        errors+=("$label must not contain '..' path segments: $path")
+    fi
+
+    if ! [[ "$path" =~ ^[A-Za-z0-9._/-]+$ ]]; then
+        errors+=("$label contains invalid characters (only letters, digits, '.', '_', '-', '/' are allowed): $path")
+    fi
+}
+
+# Validates DOMAIN, TRUSTED_PROXIES, BIND_IP, and ACME_SERVER format.
+# Called both during install (via validate_config) and update (to
+# re-validate values loaded from an existing .env before they're used to
+# regenerate the Caddyfile). Appends to the caller's 'errors' array (relies
+# on bash's dynamic scoping of locals). See issue #448.
+validate_network_config() {
+    if [[ -n "$DOMAIN" ]] && ! is_valid_domain "$DOMAIN"; then
+        errors+=("Invalid domain: $DOMAIN (must be a valid hostname, e.g. magpie.example.com)")
+    fi
+
+    if [[ -n "$TRUSTED_PROXIES" ]] && ! is_valid_ip_or_cidr_list "$TRUSTED_PROXIES"; then
+        errors+=("Invalid --trusted-proxies: $TRUSTED_PROXIES (must be a whitespace-separated list of IPv4/IPv6 addresses or CIDRs)")
+    fi
+
+    if [[ -n "$BIND_IP" ]]; then
+        if [[ "$BIND_IP" == */* ]] || ! is_valid_ip_or_cidr "$BIND_IP"; then
+            errors+=("Invalid --bind-ip: $BIND_IP (must be a single IPv4 or IPv6 address, no CIDR prefix)")
+        fi
+    fi
+
+    if [[ -n "$ACME_SERVER" ]]; then
+        if [[ "$ACME_SERVER" != https://* ]]; then
+            errors+=("Invalid --acme-server: $ACME_SERVER (must start with https://)")
+        elif [[ "$ACME_SERVER" =~ [[:space:]{}] ]]; then
+            errors+=("Invalid --acme-server: $ACME_SERVER (must not contain whitespace, '{', or '}')")
+        fi
+    fi
+}
+
 validate_config() {
     local errors=()
 
@@ -264,11 +382,18 @@ validate_config() {
         errors+=("Invalid HTTPS port: $HTTPS_PORT")
     fi
 
+    # Network value validation (DOMAIN, TRUSTED_PROXIES, BIND_IP, ACME_SERVER)
+    # These values later flow into the generated .env and Caddyfile, so they
+    # must be validated here, before any file is generated. See issue #448.
+    validate_network_config
+
     # Directory validation
     if [[ -z "$INSTALL_DIR" ]]; then
         errors+=("Install directory cannot be empty")
     elif [[ ! "$INSTALL_DIR" =~ ^/ ]]; then
         errors+=("Install directory must be an absolute path: $INSTALL_DIR")
+    else
+        validate_path_value "$INSTALL_DIR" "Install directory"
     fi
 
     # Data directory validation
@@ -276,6 +401,8 @@ validate_config() {
         errors+=("Data directory cannot be empty")
     elif [[ ! "$DATA_DIR" =~ ^/ ]]; then
         errors+=("Data directory must be an absolute path: $DATA_DIR")
+    else
+        validate_path_value "$DATA_DIR" "Data directory"
     fi
 
     # Warn about /home with ProtectHome=true
@@ -338,17 +465,49 @@ verify_installation() {
     fi
 }
 
+# Reads a strict KEY=value .env file into the caller's associative array
+# without performing any shell expansion, command substitution, sourcing,
+# or evaluation of the file's contents. Comment lines (leading '#') and
+# blank lines are skipped; lines that do not match a bare KEY=value shape
+# are silently ignored -- this also means a value containing an embedded
+# newline cannot smuggle in a second "line" that looks like a directive, it
+# just becomes inert trailing text or a rejected non-KV line. See issue #448.
+read_env_file() {
+    local file="$1"
+    local -n out_array="$2"
+    local line key value
+
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        [[ -z "$line" ]] && continue
+        [[ "$line" =~ ^[[:space:]]*# ]] && continue
+
+        if [[ "$line" =~ ^([A-Za-z_][A-Za-z0-9_]*)=(.*)$ ]]; then
+            key="${BASH_REMATCH[1]}"
+            value="${BASH_REMATCH[2]}"
+            # shellcheck disable=SC2034  # out_array is a nameref to the caller's array; shellcheck can't see its use there
+            out_array["$key"]="$value"
+        fi
+    done < "$file"
+}
+
 load_existing_config() {
     if [[ -f "${INSTALL_DIR}/etc/.env" ]]; then
-        # shellcheck source=/dev/null
-        source "${INSTALL_DIR}/etc/.env"
+        # Parsed with read_env_file (no shell expansion/execution of the
+        # file's contents) rather than sourced as a shell script. See #448.
+        local -A env_vars=()
+        read_env_file "${INSTALL_DIR}/etc/.env" env_vars
 
         # Map env vars to script variables (only for MAGPIE_* prefixed vars)
-        DATA_DIR="${MAGPIE_DATA_DIR:-$DATA_DIR}"
-        HTTP_PORT="${MAGPIE_HTTP_PORT:-$HTTP_PORT}"
-        HTTPS_PORT="${MAGPIE_HTTPS_PORT:-$HTTPS_PORT}"
-        DOMAIN="${MAGPIE_DOMAIN:-$DOMAIN}"
-        # TLS_MODE, TRUSTED_PROXIES, BIND_IP, and ACME_SERVER are loaded directly (no prefix mapping needed)
+        DATA_DIR="${env_vars[MAGPIE_DATA_DIR]:-$DATA_DIR}"
+        HTTP_PORT="${env_vars[MAGPIE_HTTP_PORT]:-$HTTP_PORT}"
+        HTTPS_PORT="${env_vars[MAGPIE_HTTPS_PORT]:-$HTTPS_PORT}"
+        DOMAIN="${env_vars[MAGPIE_DOMAIN]:-$DOMAIN}"
+        # TLS_MODE, TRUSTED_PROXIES, BIND_IP, and ACME_SERVER are stored
+        # without a MAGPIE_ prefix (see generate_env_file); map directly.
+        TLS_MODE="${env_vars[TLS_MODE]:-$TLS_MODE}"
+        TRUSTED_PROXIES="${env_vars[TRUSTED_PROXIES]:-$TRUSTED_PROXIES}"
+        BIND_IP="${env_vars[BIND_IP]:-$BIND_IP}"
+        ACME_SERVER="${env_vars[ACME_SERVER]:-$ACME_SERVER}"
     fi
 }
 
@@ -537,27 +696,53 @@ EOF
 
         auto)
             # Automatic TLS (Let's Encrypt or custom ACME server)
-            # - Replace {$MAGPIE_DOMAIN} with actual domain
-            # - Add custom ACME server if configured
-            cp "$source_caddyfile" "$dest_caddyfile"
-            sed -i "s/{\\\$MAGPIE_DOMAIN}/${DOMAIN}/g" "$dest_caddyfile"
+            # - Replace {$MAGPIE_DOMAIN} with the actual domain
+            # - Add a custom ACME server if configured
+            #
+            # DOMAIN and ACME_SERVER are substituted with bash's own literal
+            # string replacement and matched with awk -v (not sed), and are
+            # validated (validate_config/validate_network_config) before
+            # this ever runs, so neither value is interpreted as a regex or
+            # sed script. See issue #448.
+            local content
+            content="$(cat "$source_caddyfile")"
+            content="${content//\{\$MAGPIE_DOMAIN\}/$DOMAIN}"
+            printf '%s\n' "$content" > "$dest_caddyfile"
 
-            # Add custom ACME server if configured
             if [[ -n "$ACME_SERVER" ]]; then
-                # Insert custom ACME server after the site address line
-                # The tls block should be added inside the site block
-                sed -i "/${DOMAIN} {/a\\	tls {\n\t\tca ${ACME_SERVER}\n\t}" "$dest_caddyfile"
+                # Insert a tls block with the custom ACME server directly
+                # after the site address line.
+                awk -v site="${DOMAIN} {" -v acme="$ACME_SERVER" '
+                    {
+                        print
+                        if ($0 == site) {
+                            print "\ttls {"
+                            print "\t\tca " acme
+                            print "\t}"
+                        }
+                    }
+                ' "$dest_caddyfile" > "${dest_caddyfile}.tmp"
+                mv "${dest_caddyfile}.tmp" "$dest_caddyfile"
             fi
 
             # Add generation header
-            sed -i "1i# Generated by magpie-deploy.sh v${MAGPIE_VERSION} (TLS mode: auto)" "$dest_caddyfile"
+            {
+                echo "# Generated by magpie-deploy.sh v${MAGPIE_VERSION} (TLS mode: auto)"
+                cat "$dest_caddyfile"
+            } > "${dest_caddyfile}.tmp"
+            mv "${dest_caddyfile}.tmp" "$dest_caddyfile"
             ;;
 
         manual)
             # Manual TLS with user-provided certificates
             # - Copy certs to install dir so they're managed with the installation
-            # - Replace {$MAGPIE_DOMAIN} with actual domain
+            # - Replace {$MAGPIE_DOMAIN} with the actual domain
             # - Add tls directive with container paths
+            #
+            # DOMAIN is substituted with bash's own literal string
+            # replacement and matched with awk -v (not sed), and is
+            # validated (validate_config/validate_network_config) before
+            # this ever runs. See issue #448.
 
             # Copy certificates to installation directory
             local tls_dir="${INSTALL_DIR}/etc/tls"
@@ -568,14 +753,28 @@ EOF
             chmod 644 "${tls_dir}/cert.pem"
             chmod 600 "${tls_dir}/key.pem"
 
-            cp "$source_caddyfile" "$dest_caddyfile"
-            sed -i "s/{\\\$MAGPIE_DOMAIN}/${DOMAIN}/g" "$dest_caddyfile"
+            local content
+            content="$(cat "$source_caddyfile")"
+            content="${content//\{\$MAGPIE_DOMAIN\}/$DOMAIN}"
+            printf '%s\n' "$content" > "$dest_caddyfile"
 
             # Add tls directive with container paths (certs mounted at /etc/caddy/tls/)
-            sed -i "/${DOMAIN} {/a\\	tls /etc/caddy/tls/cert.pem /etc/caddy/tls/key.pem" "$dest_caddyfile"
+            awk -v site="${DOMAIN} {" '
+                {
+                    print
+                    if ($0 == site) {
+                        print "\ttls /etc/caddy/tls/cert.pem /etc/caddy/tls/key.pem"
+                    }
+                }
+            ' "$dest_caddyfile" > "${dest_caddyfile}.tmp"
+            mv "${dest_caddyfile}.tmp" "$dest_caddyfile"
 
             # Add generation header
-            sed -i "1i# Generated by magpie-deploy.sh v${MAGPIE_VERSION} (TLS mode: manual)" "$dest_caddyfile"
+            {
+                echo "# Generated by magpie-deploy.sh v${MAGPIE_VERSION} (TLS mode: manual)"
+                cat "$dest_caddyfile"
+            } > "${dest_caddyfile}.tmp"
+            mv "${dest_caddyfile}.tmp" "$dest_caddyfile"
             ;;
     esac
 
@@ -1097,19 +1296,31 @@ cmd_update() {
     if [[ ! -f "${INSTALL_DIR}/repo/Caddyfile.prod" ]]; then
         log_warn "Caddyfile.prod not found in repo, skipping Caddyfile update"
     else
-        # Load existing environment (includes TLS_MODE, DOMAIN, TRUSTED_PROXIES from .env)
-        # These values are persisted during install by generate_env_file().
-        # See issues #340 and #344 for background.
-        if [[ -f "${INSTALL_DIR}/etc/.env" ]]; then
-            set -a
-            # shellcheck disable=SC1091
-            source "${INSTALL_DIR}/etc/.env"
-            set +a
-        fi
+        # TLS_MODE, DOMAIN, TRUSTED_PROXIES, BIND_IP, and ACME_SERVER were
+        # already loaded from .env by load_existing_config() above, using a
+        # parser that performs no shell expansion or execution of the
+        # file's contents -- no need to source the file again here.
+        # See issues #340, #344, and #448 for background.
 
         # Apply defaults for vars that may be missing from old .env files (migration from pre-#345 installs)
         TLS_MODE="${TLS_MODE:-$DEFAULT_TLS_MODE}"
         TRUSTED_PROXIES="${TRUSTED_PROXIES:-$DEFAULT_TRUSTED_PROXIES}"
+
+        # Re-validate the values loaded from .env before they're used to
+        # regenerate the Caddyfile -- guards against a hand-edited or
+        # pre-#448 .env file containing a value that would no longer pass
+        # validation. Does not call the full validate_config(), since
+        # TLS_CERT/TLS_KEY (manual-mode certificate paths) are per-install
+        # CLI args, not persisted to .env, and would spuriously fail here.
+        local errors=()
+        validate_network_config
+        if [[ ${#errors[@]} -gt 0 ]]; then
+            log_error "Existing configuration in .env failed validation; refusing to regenerate Caddyfile:"
+            for err in "${errors[@]}"; do
+                echo "  - $err" >&2
+            done
+            die "Fix or remove the invalid value(s) in ${INSTALL_DIR}/etc/.env, or reinstall."
+        fi
 
         # Regenerate the Caddyfile using the configured (or defaulted) TLS settings
         if declare -F generate_caddyfile >/dev/null 2>&1; then
@@ -1250,11 +1461,19 @@ cmd_logs() {
 
     cd "$INSTALL_DIR"
 
-    local follow_flag=""
-    [[ "$FOLLOW" == "true" ]] && follow_flag="-f"
+    # Validate --lines before it reaches docker compose. See issue #448.
+    if ! [[ "$LINES" =~ ^[0-9]+$ ]]; then
+        die "Invalid --lines value: $LINES (must be a non-negative integer)"
+    fi
 
-    # shellcheck disable=SC2086
-    docker compose --env-file "${INSTALL_DIR}/etc/.env" logs $follow_flag --tail="$LINES" "$@"
+    # Build the docker-compose argument list as a quoted array rather than
+    # interpolating into an unquoted command line. See issue #448.
+    local compose_args=(--env-file "${INSTALL_DIR}/etc/.env" logs)
+    [[ "$FOLLOW" == "true" ]] && compose_args+=(-f)
+    compose_args+=(--tail="$LINES")
+    compose_args+=("$@")
+
+    docker compose "${compose_args[@]}"
 }
 
 # =============================================================================

--- a/scripts/test_installer_issue448.sh
+++ b/scripts/test_installer_issue448.sh
@@ -13,6 +13,16 @@
 #    when read by read_env_file/load_existing_config (no more `source`).
 # 5. Path inputs (--install-dir/--data-dir) reject '..' and shell metachars.
 # 6. `logs` rejects a non-numeric --lines value.
+# 7. An escape-encoded --acme-server payload (\n, octal \173/\175/\040 --
+#    i.e. no literal blocked bytes) is rejected by the allowlist validator,
+#    and even if validation were bypassed, generate_caddyfile no longer
+#    decodes it into a real directive (ENVIRON, not `awk -v`).
+# 8. `uninstall --purge` refuses to `rm -rf` a DATA_DIR loaded from a
+#    hostile .env.
+# 9. `update` rejects an --install-dir containing sed metacharacters
+#    (e.g. '|') before it reaches the docker-compose sed patching.
+# 10. IPv4/IPv6 CIDR validation does not misjudge or error on leading-zero
+#     octets/prefixes (bash arithmetic octal gotcha).
 
 set -uo pipefail
 
@@ -310,6 +320,165 @@ test_logs_lines_validation() {
     log "  ✓ cmd_logs no longer uses unquoted \$follow_flag expansion"
 }
 
+# Test 11: an escape-encoded --acme-server payload (\n, octal \173/\175/\040
+# -- i.e. no *literal* whitespace/brace/backslash-decoded bytes at
+# validation time) must be rejected by the allowlist validator, not just a
+# denylist of literal bytes. This is the payload class that bypassed the
+# original denylist-based validation and reached awk's escape-decoding `-v`
+# assignment.
+test_acme_server_rejects_escape_encoded_injection() {
+    log "Test 11: is_valid_acme_server_url rejects an escape-encoded injection payload"
+
+    local hostile_acme
+    hostile_acme=$(printf 'https://ca.example.com\\n\\175\\nadmin_endpoint\\0400.0.0.0:2999\\040\\173\\n\\tenforce_origin\\n\\175\\ntest\\040\\173')
+
+    if is_valid_acme_server_url "$hostile_acme"; then
+        fail "is_valid_acme_server_url accepted an escape-encoded injection payload: $hostile_acme"
+    fi
+    log "  ✓ escape-encoded payload rejected by the allowlist validator"
+
+    if ! is_valid_acme_server_url "https://ca.example.com/acme/acme/directory"; then
+        fail "is_valid_acme_server_url rejected a legitimate ACME server URL"
+    fi
+    log "  ✓ legitimate https:// ACME server URL accepted"
+
+    if (
+        TLS_MODE=auto DOMAIN="magpie.example.com" TLS_CERT="" TLS_KEY="" \
+        HTTP_PORT=8080 HTTPS_PORT=8443 \
+        INSTALL_DIR="${TEST_DIR}/install_acme_escape" DATA_DIR="${TEST_DIR}/install_acme_escape/data" \
+        TRUSTED_PROXIES="" BIND_IP="" ACME_SERVER="$hostile_acme" \
+        validate_config
+    ) >/dev/null 2>&1; then
+        fail "validate_config accepted an escape-encoded --acme-server payload"
+    fi
+    log "  ✓ validate_config rejects the escape-encoded payload end to end"
+}
+
+# Test 12: even if ACME_SERVER validation were bypassed, generate_caddyfile
+# must not decode escape sequences in it into real Caddyfile syntax. This
+# is the defense-in-depth layer: ACME_SERVER is passed to awk via ENVIRON
+# (which does not decode \n / octal escapes), not `awk -v` (which does).
+test_generate_caddyfile_no_escape_decoding() {
+    log "Test 12: generate_caddyfile does not decode escape sequences in ACME_SERVER"
+
+    local hostile_acme
+    hostile_acme=$(printf 'https://ca.example.com\\n\\175\\nadmin_endpoint\\0400.0.0.0:2999\\040\\173\\n\\tenforce_origin\\n\\175\\ntest\\040\\173')
+
+    local install_dir="${TEST_DIR}/gc_escape_install"
+    mkdir -p "${install_dir}/repo" "${install_dir}/etc"
+    cp "${SCRIPT_DIR}/../Caddyfile.prod" "${install_dir}/repo/Caddyfile.prod" 2>/dev/null \
+        || cat > "${install_dir}/repo/Caddyfile.prod" << 'EOF'
+{
+	admin off
+}
+
+{$MAGPIE_DOMAIN} {
+	reverse_proxy magpie:8000
+}
+EOF
+
+    (
+        INSTALL_DIR="$install_dir" MAGPIE_VERSION="test" TLS_MODE="auto" \
+        DOMAIN="magpie.example.com" ACME_SERVER="$hostile_acme" \
+        generate_caddyfile
+    ) >/dev/null 2>&1 || true
+
+    local caddyfile="${install_dir}/etc/Caddyfile"
+    [[ -f "$caddyfile" ]] || fail "generate_caddyfile did not produce a Caddyfile"
+
+    # A real injected directive would appear as its own line (awk decoding
+    # \n into an actual newline, and \175/\173 into standalone braces). If
+    # the escapes were left inert, everything stays on the single `ca` line.
+    if grep -qxE '[[:space:]]*admin_endpoint.*' "$caddyfile"; then
+        fail "admin_endpoint was injected as its own Caddyfile directive -- escape sequences were decoded"
+    fi
+    log "  ✓ no standalone admin_endpoint directive was injected"
+
+    local ca_lines
+    ca_lines=$(grep -c '^\s*ca ' "$caddyfile" || true)
+    if [[ "$ca_lines" -ne 1 ]]; then
+        fail "expected exactly one 'ca' directive line, found $ca_lines"
+    fi
+    log "  ✓ hostile ACME_SERVER value stayed inert on a single 'ca' line (no escape decoding)"
+}
+
+# Test 13: `uninstall --purge` must refuse to `rm -rf` a DATA_DIR that was
+# loaded from a hostile/stale .env, not just trust whatever load_existing_config
+# populated it with.
+test_uninstall_purge_revalidates_data_dir() {
+    log "Test 13: cmd_uninstall --purge refuses a hostile DATA_DIR loaded from .env"
+
+    local install_dir="${TEST_DIR}/uninstall_install"
+    mkdir -p "${install_dir}/etc"
+    echo "MAGPIE_DATA_DIR=/opt/magpie/data; touch ${MARKER}_purge" > "${install_dir}/etc/.env"
+
+    local out
+    if out=$(
+        (
+            INSTALL_DIR="$install_dir" PURGE="true" YES="true" NONINTERACTIVE="true" \
+            cmd_uninstall
+        ) 2>&1
+    ); then
+        fail "cmd_uninstall --purge accepted a hostile DATA_DIR from .env"
+    fi
+
+    if ! echo "$out" | grep -q "failed validation"; then
+        fail "cmd_uninstall --purge did not report a validation failure for the hostile DATA_DIR: $out"
+    fi
+    log "  ✓ cmd_uninstall --purge refused a hostile DATA_DIR before rm -rf"
+
+    [[ -e "${MARKER}_purge" ]] && fail "hostile DATA_DIR content was executed"
+    log "  ✓ no command executed via the hostile DATA_DIR value"
+}
+
+# Test 14: `update` must reject an --install-dir containing sed
+# metacharacters (e.g. '|') before it reaches
+# patch_compose_for_caddyfile()/patch_compose_for_tls_certs(), which
+# interpolate INSTALL_DIR into a `sed 's|...|...|g'` replacement.
+test_update_rejects_hostile_install_dir() {
+    log "Test 14: cmd_update rejects an --install-dir containing sed metacharacters"
+
+    local out
+    if out=$(
+        (
+            INSTALL_DIR="/opt/magpie|s/foo/bar/;x" cmd_update
+        ) 2>&1
+    ); then
+        fail "cmd_update accepted an --install-dir containing '|'"
+    fi
+
+    if ! echo "$out" | grep -qE "Invalid --install-dir|invalid characters"; then
+        fail "cmd_update did not report an install-dir validation failure: $out"
+    fi
+    log "  ✓ cmd_update rejected a pipe-containing --install-dir before any patching"
+}
+
+# Test 15: leading-zero IPv4 octets / CIDR prefixes must not be misjudged
+# (bash arithmetic treats a leading zero as octal) or throw a stderr error.
+test_cidr_leading_zero_octets() {
+    log "Test 15: IPv4/IPv6 CIDR validation handles leading-zero octets/prefixes correctly"
+
+    local err_output
+    err_output=$(is_valid_ipv4_cidr "10.0.008.1" 2>&1 1>/dev/null)
+    if [[ -n "$err_output" ]]; then
+        fail "is_valid_ipv4_cidr printed a stderr error for a leading-zero octet: $err_output"
+    fi
+    if ! is_valid_ipv4_cidr "10.0.008.1"; then
+        fail "is_valid_ipv4_cidr rejected a valid leading-zero octet (008 == 8, <= 255)"
+    fi
+    log "  ✓ leading-zero octet '008' handled without error, correctly accepted"
+
+    if ! is_valid_ipv4_cidr "10.0.017.1"; then
+        fail "is_valid_ipv4_cidr rejected 10.0.017.1 (017 == 17 in base 10, <= 255)"
+    fi
+    log "  ✓ leading-zero octet '017' evaluated as base-10 17, not octal 15"
+
+    if is_valid_ipv4_cidr "10.0.0.1/256"; then
+        fail "is_valid_ipv4_cidr accepted an out-of-range CIDR prefix"
+    fi
+    log "  ✓ out-of-range CIDR prefix still rejected"
+}
+
 # Run all tests
 log "Running tests for issue #448"
 log ""
@@ -324,6 +493,11 @@ test_env_file_not_sourced
 test_load_existing_config_no_execution
 test_path_validation
 test_logs_lines_validation
+test_acme_server_rejects_escape_encoded_injection
+test_generate_caddyfile_no_escape_decoding
+test_uninstall_purge_revalidates_data_dir
+test_update_rejects_hostile_install_dir
+test_cidr_leading_zero_octets
 
 log ""
 log "All tests passed!"

--- a/scripts/test_installer_issue448.sh
+++ b/scripts/test_installer_issue448.sh
@@ -26,6 +26,13 @@
 # 11. A newline sitting between two otherwise-valid --trusted-proxies
 #     tokens is rejected up front, not left to per-token validation (which
 #     would pass it, since each half is individually a valid IP/CIDR).
+# 12. A tab-separated --trusted-proxies list is still accepted (tab is a
+#     legitimate whitespace separator, not rejected as a control char).
+# 13. generate_env_file() writes a single canonical MAGPIE_DOMAIN key (no
+#     duplicate bare DOMAIN= that load_existing_config() never reads).
+# 14. The "no source .env" test assertion actually detects a reintroduced
+#     source line (verified against the anchoring bug that made it
+#     vacuously pass regardless of whether .env was sourced).
 
 set -uo pipefail
 
@@ -278,8 +285,16 @@ test_load_existing_config_no_execution() {
     fi
     log "  ✓ load_existing_config parses .env without executing it"
 
-    grep -q "^source " "$DEPLOY_SCRIPT" && grep -qE 'source ".*etc/\.env"' "$DEPLOY_SCRIPT" \
-        && fail "magpie-deploy.sh still sources the generated .env file somewhere"
+    # Anchored on start-of-line with no leading whitespace allowed, this
+    # check would never match (magpie-deploy.sh's only literal `source`
+    # invocation, `source /etc/os-release` in check_os(), is indented) --
+    # making the assertion below vacuously true regardless of whether the
+    # .env is sourced. Allow leading whitespace and the `.` dot-command
+    # synonym, and require "etc/.env" on the same line so it stays
+    # specific to the file this test cares about.
+    if grep -qE '(^|[[:space:]])(source|\.)[[:space:]]+.*etc/\.env' "$DEPLOY_SCRIPT"; then
+        fail "magpie-deploy.sh still sources the generated .env file somewhere"
+    fi
     log "  ✓ magpie-deploy.sh no longer sources the generated .env file"
 }
 
@@ -549,6 +564,123 @@ test_trusted_proxies_rejects_newline_between_valid_tokens() {
         "now prevented entirely by rejecting the newline up front"
 }
 
+# Test 17: a horizontal tab is a legitimate whitespace separator for
+# --trusted-proxies (tokenization already splits on it via IFS) and must
+# not be rejected by the control-character guard -- only line breaks
+# (which corrupt the .env/Caddyfile round trip) should be.
+test_trusted_proxies_allows_tab_separator() {
+    log "Test 17: is_valid_ip_or_cidr_list accepts a tab-separated list"
+
+    local tab_list
+    tab_list=$(printf '10.0.0.0/8\t192.168.1.1')
+    if ! is_valid_ip_or_cidr_list "$tab_list"; then
+        fail "is_valid_ip_or_cidr_list rejected a legitimate tab-separated CIDR list (functional regression)"
+    fi
+    log "  ✓ tab-separated list accepted"
+
+    local nl_list
+    nl_list=$(printf '10.0.0.0/8\n192.168.1.1')
+    if is_valid_ip_or_cidr_list "$nl_list"; then
+        fail "is_valid_ip_or_cidr_list accepted a newline-separated list (regression of the #448 fix)"
+    fi
+    log "  ✓ newline-separated list is still rejected"
+}
+
+# Test 18: generate_env_file() must write a single canonical domain key
+# (MAGPIE_DOMAIN); load_existing_config() only ever reads that one. A
+# duplicate bare DOMAIN= key would be silently ignored if an operator
+# edited it, which is confusing -- assert it isn't written, and that the
+# domain still round-trips correctly through the single key.
+test_domain_single_canonical_key() {
+    log "Test 18: generate_env_file/load_existing_config use a single canonical DOMAIN key"
+
+    local install_dir="${TEST_DIR}/domain_key_install"
+    mkdir -p "${install_dir}/etc"
+
+    (
+        INSTALL_DIR="$install_dir" DATA_DIR="${install_dir}/data" \
+        HTTP_PORT=8080 HTTPS_PORT=8443 DOMAIN="magpie.example.com" \
+        TLS_MODE="auto" TRUSTED_PROXIES="" BIND_IP="" ACME_SERVER="" \
+        MAGPIE_VERSION="test" \
+        generate_env_file
+    ) >/dev/null 2>&1
+
+    local env_file="${install_dir}/etc/.env"
+    [[ -f "$env_file" ]] || fail "generate_env_file did not produce a .env file"
+
+    if grep -qE '^DOMAIN=' "$env_file"; then
+        fail "generate_env_file wrote a duplicate bare DOMAIN= key -- edits to it would be silently ignored by load_existing_config"
+    fi
+    log "  ✓ no duplicate bare DOMAIN= key written"
+
+    if ! grep -q '^MAGPIE_DOMAIN=magpie.example.com$' "$env_file"; then
+        fail "generate_env_file did not write the canonical MAGPIE_DOMAIN= key"
+    fi
+    log "  ✓ canonical MAGPIE_DOMAIN= key written"
+
+    # NOTE: variables must be set as standalone assignments here, not
+    # prefixed to the load_existing_config call (`VAR=val load_existing_config`)
+    # -- a prefix assignment is scoped only to that one command and reverts
+    # once it returns, so a later `echo "$DOMAIN"` in the same subshell
+    # would read the pre-call value, not what the function set.
+    local out
+    out=$(
+        (
+            # shellcheck disable=SC2034  # all consumed by load_existing_config(), sourced from magpie-deploy.sh
+            INSTALL_DIR="$install_dir"
+            # shellcheck disable=SC2034
+            DATA_DIR=""
+            # shellcheck disable=SC2034
+            HTTP_PORT=""
+            # shellcheck disable=SC2034
+            HTTPS_PORT=""
+            DOMAIN=""
+            # shellcheck disable=SC2034
+            TLS_MODE=""
+            TRUSTED_PROXIES=""
+            # shellcheck disable=SC2034
+            BIND_IP=""
+            # shellcheck disable=SC2034
+            ACME_SERVER=""
+            load_existing_config
+            echo "DOMAIN=$DOMAIN"
+        )
+    )
+    if [[ "$out" != "DOMAIN=magpie.example.com" ]]; then
+        fail "DOMAIN did not round-trip through load_existing_config: $out"
+    fi
+    log "  ✓ DOMAIN round-trips correctly through the single canonical key"
+}
+
+# Test 19: the "no source .env" assertion (Test 8, above) must actually
+# detect a reintroduced `source`/`.` of the .env file, not just an
+# anchored-at-column-0 pattern that never matches because
+# magpie-deploy.sh's only literal `source` invocation
+# (`source /etc/os-release` in check_os()) is indented. Verify the
+# assertion's regex against a temporary copy with a source line
+# reintroduced, so this specific test can't quietly go vacuous again.
+test_source_env_detection_is_not_vacuous() {
+    log "Test 19: the .env-not-sourced assertion actually detects a reintroduced source line"
+
+    local pattern='(^|[[:space:]])(source|\.)[[:space:]]+.*etc/\.env'
+
+    if grep -qE "$pattern" "$DEPLOY_SCRIPT"; then
+        fail "magpie-deploy.sh currently sources the generated .env file -- investigate before trusting this test"
+    fi
+    log "  ✓ current magpie-deploy.sh does not match the source-detection pattern (expected)"
+
+    local reintroduced="${TEST_DIR}/magpie-deploy-with-source-reintroduced.sh"
+    {
+        cat "$DEPLOY_SCRIPT"
+        echo '    source "${INSTALL_DIR}/etc/.env"  # test-only: simulates a reintroduced vulnerability'
+    } > "$reintroduced"
+
+    if ! grep -qE "$pattern" "$reintroduced"; then
+        fail "the source-detection pattern failed to catch a reintroduced (indented) source of etc/.env -- this assertion would be vacuous again"
+    fi
+    log "  ✓ pattern correctly detects an indented, reintroduced source of etc/.env"
+}
+
 # Run all tests
 log "Running tests for issue #448"
 log ""
@@ -569,6 +701,9 @@ test_uninstall_purge_revalidates_data_dir
 test_update_rejects_hostile_install_dir
 test_cidr_leading_zero_octets
 test_trusted_proxies_rejects_newline_between_valid_tokens
+test_trusted_proxies_allows_tab_separator
+test_domain_single_canonical_key
+test_source_env_detection_is_not_vacuous
 
 log ""
 log "All tests passed!"

--- a/scripts/test_installer_issue448.sh
+++ b/scripts/test_installer_issue448.sh
@@ -23,6 +23,9 @@
 #    (e.g. '|') before it reaches the docker-compose sed patching.
 # 10. IPv4/IPv6 CIDR validation does not misjudge or error on leading-zero
 #     octets/prefixes (bash arithmetic octal gotcha).
+# 11. A newline sitting between two otherwise-valid --trusted-proxies
+#     tokens is rejected up front, not left to per-token validation (which
+#     would pass it, since each half is individually a valid IP/CIDR).
 
 set -uo pipefail
 
@@ -43,6 +46,17 @@ trap cleanup EXIT
 # below with test-local versions.
 # shellcheck source=/dev/null
 source <(sed '/^main "\$@"$/d' "$DEPLOY_SCRIPT")
+
+# Sourcing magpie-deploy.sh above also executes its own top-level
+# `set -euo pipefail`, which would leave `errexit` enabled here. That's
+# unwanted in this test script: several tests intentionally exercise a
+# function's EXPECTED-FAILURE path, and while those calls are wrapped in
+# explicit subshells or `if` conditions (both errexit-safe), a stray
+# unprotected failing command anywhere else could otherwise abort the
+# whole run silently instead of reporting a clear FAIL. Re-assert only the
+# options this test script itself wants.
+set +e
+set -uo pipefail
 
 log() {
     echo "[test] $*"
@@ -395,7 +409,9 @@ EOF
     log "  ✓ no standalone admin_endpoint directive was injected"
 
     local ca_lines
-    ca_lines=$(grep -c '^\s*ca ' "$caddyfile" || true)
+    # [[:space:]] rather than \s -- \s is not a portable whitespace escape
+    # in POSIX basic/extended grep regex (GNU grep treats a literal 's').
+    ca_lines=$(grep -cE '^[[:space:]]*ca ' "$caddyfile" || true)
     if [[ "$ca_lines" -ne 1 ]]; then
         fail "expected exactly one 'ca' directive line, found $ca_lines"
     fi
@@ -479,6 +495,60 @@ test_cidr_leading_zero_octets() {
     log "  ✓ out-of-range CIDR prefix still rejected"
 }
 
+# Test 16: a newline sitting *between* two otherwise-valid IP/CIDR tokens
+# must be rejected. Splitting on IFS whitespace (which includes newline)
+# means each half of "10.0.0.0/8\n192.168.1.1" is individually a valid
+# token, so a purely per-token validator lets the newline through even
+# though every token "looks like" a CIDR (Copilot review finding). Also
+# confirms tokenization no longer globs (`read -ra`, not `for t in $list`).
+test_trusted_proxies_rejects_newline_between_valid_tokens() {
+    log "Test 16: is_valid_ip_or_cidr_list rejects a newline between two valid tokens"
+
+    local hostile
+    hostile=$(printf '10.0.0.0/8\n192.168.1.1')
+    if is_valid_ip_or_cidr_list "$hostile"; then
+        fail "is_valid_ip_or_cidr_list accepted a newline between two otherwise-valid IP/CIDR tokens: $hostile"
+    fi
+    log "  ✓ newline-between-valid-tokens payload rejected"
+
+    if (
+        TLS_MODE=off DOMAIN="" TLS_CERT="" TLS_KEY="" \
+        HTTP_PORT=8080 HTTPS_PORT=8443 \
+        INSTALL_DIR="${TEST_DIR}/install_tp_newline" DATA_DIR="${TEST_DIR}/install_tp_newline/data" \
+        TRUSTED_PROXIES="$hostile" BIND_IP="" ACME_SERVER="" \
+        validate_config
+    ) >/dev/null 2>&1; then
+        fail "validate_config accepted a newline-between-valid-tokens --trusted-proxies value"
+    fi
+    log "  ✓ validate_config rejects it end to end"
+
+    # Exploitability check: even without validation, demonstrate why this
+    # matters -- a newline in TRUSTED_PROXIES corrupts the .env round trip
+    # (read_env_file() is line-based, so everything after the first
+    # embedded newline in a value becomes a separate, dropped "line").
+    local env_test_dir="${TEST_DIR}/tp_newline_env"
+    mkdir -p "${env_test_dir}/etc"
+    (
+        INSTALL_DIR="$env_test_dir" DATA_DIR="${env_test_dir}/data" \
+        HTTP_PORT=8080 HTTPS_PORT=8443 DOMAIN="" TLS_MODE="off" \
+        TRUSTED_PROXIES="$hostile" BIND_IP="" ACME_SERVER="" MAGPIE_VERSION="test" \
+        generate_env_file
+    ) >/dev/null 2>&1
+
+    local parsed_tp
+    parsed_tp=$(
+        declare -A parsed=()
+        read_env_file "${env_test_dir}/etc/.env" parsed
+        echo "${parsed[TRUSTED_PROXIES]:-}"
+    )
+    if [[ "$parsed_tp" == *$'\n'* ]] || [[ "$parsed_tp" == *"192.168.1.1"* ]]; then
+        fail "unexpected: newline survived the .env round trip intact: $parsed_tp"
+    fi
+    log "  ✓ (pre-validation-fix scenario) demonstrated: a newline in TRUSTED_PROXIES" \
+        "silently truncates the value on .env round trip -- config-integrity bug, not RCE," \
+        "now prevented entirely by rejecting the newline up front"
+}
+
 # Run all tests
 log "Running tests for issue #448"
 log ""
@@ -498,6 +568,7 @@ test_generate_caddyfile_no_escape_decoding
 test_uninstall_purge_revalidates_data_dir
 test_update_rejects_hostile_install_dir
 test_cidr_leading_zero_octets
+test_trusted_proxies_rejects_newline_between_valid_tokens
 
 log ""
 log "All tests passed!"

--- a/scripts/test_installer_issue448.sh
+++ b/scripts/test_installer_issue448.sh
@@ -1,0 +1,329 @@
+#!/bin/bash
+# Test script for issue #448: input sanitization / RCE hardening
+#
+# This script exercises the *real* functions from magpie-deploy.sh (sourced,
+# not reimplemented) to verify that:
+# 1. A hostile --domain is rejected by validate_config/is_valid_domain, and
+#    even if it reached generate_caddyfile, no command is executed (sed's
+#    'e' command is no longer used to interpolate DOMAIN).
+# 2. A hostile --trusted-proxies value (embedded newline + Caddy directive)
+#    is rejected by validate_config/is_valid_ip_or_cidr_list.
+# 3. A hostile --bind-ip and --acme-server are rejected.
+# 4. A hostile .env value ($(...) / backtick / newline) does not execute
+#    when read by read_env_file/load_existing_config (no more `source`).
+# 5. Path inputs (--install-dir/--data-dir) reject '..' and shell metachars.
+# 6. `logs` rejects a non-numeric --lines value.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEPLOY_SCRIPT="${SCRIPT_DIR}/magpie-deploy.sh"
+TEST_DIR=$(mktemp -d)
+MARKER="${TEST_DIR}/pwned"
+
+cleanup() {
+    rm -rf "$TEST_DIR"
+    rm -f "$MARKER"
+}
+trap cleanup EXIT
+
+# Source only the function definitions from magpie-deploy.sh -- drop the
+# trailing `main "$@"` invocation so sourcing doesn't run the CLI. This also
+# pulls in the script's own log()/log_error()/die(), which we override
+# below with test-local versions.
+# shellcheck source=/dev/null
+source <(sed '/^main "\$@"$/d' "$DEPLOY_SCRIPT")
+
+log() {
+    echo "[test] $*"
+}
+
+fail() {
+    echo "[test] FAIL: $*" >&2
+    exit 1
+}
+
+# Test 1: is_valid_domain rejects a sed 'e'-command injection payload
+test_domain_rejects_injection() {
+    log "Test 1: is_valid_domain rejects hostile --domain values"
+
+    local hostile="x/g;e touch ${MARKER}"
+    if is_valid_domain "$hostile"; then
+        fail "is_valid_domain accepted a hostile domain: $hostile"
+    fi
+    log "  ✓ hostile domain rejected: $hostile"
+
+    if ! is_valid_domain "magpie.example.com"; then
+        fail "is_valid_domain rejected a legitimate domain: magpie.example.com"
+    fi
+    log "  ✓ legitimate domain accepted: magpie.example.com"
+}
+
+# Test 2: validate_config rejects a hostile --domain before any file is generated
+test_validate_config_rejects_hostile_domain() {
+    log "Test 2: validate_config rejects hostile DOMAIN"
+
+    local hostile="x/g;e touch ${MARKER}"
+    if (
+        TLS_MODE=auto DOMAIN="$hostile" TLS_CERT="" TLS_KEY="" \
+        HTTP_PORT=8080 HTTPS_PORT=8443 \
+        INSTALL_DIR="${TEST_DIR}/install" DATA_DIR="${TEST_DIR}/install/data" \
+        TRUSTED_PROXIES="" BIND_IP="" ACME_SERVER="" \
+        validate_config
+    ) >/dev/null 2>&1; then
+        fail "validate_config accepted a hostile domain: $hostile"
+    fi
+    log "  ✓ validate_config rejected hostile domain"
+    [[ -e "$MARKER" ]] && fail "hostile domain executed a command during validation"
+    log "  ✓ no command executed during validation"
+}
+
+# Test 3: generate_caddyfile no longer uses sed to interpolate DOMAIN, so
+# even a hostile value that reached it (bypassing validate_config) cannot
+# execute a command via sed's 'e' command.
+test_generate_caddyfile_no_command_execution() {
+    log "Test 3: generate_caddyfile does not execute commands via DOMAIN"
+
+    local install_dir="${TEST_DIR}/gc_install"
+    mkdir -p "${install_dir}/repo" "${install_dir}/etc"
+    cp "${SCRIPT_DIR}/../Caddyfile.prod" "${install_dir}/repo/Caddyfile.prod" 2>/dev/null \
+        || cat > "${install_dir}/repo/Caddyfile.prod" << 'EOF'
+{
+	admin off
+}
+
+{$MAGPIE_DOMAIN} {
+	reverse_proxy magpie:8000
+}
+EOF
+
+    local hostile="x/g;e touch ${MARKER}"
+    (
+        INSTALL_DIR="$install_dir" MAGPIE_VERSION="test" TLS_MODE="auto" \
+        DOMAIN="$hostile" ACME_SERVER="" \
+        generate_caddyfile
+    ) >/dev/null 2>&1 || true
+
+    if [[ -e "$MARKER" ]]; then
+        fail "generate_caddyfile executed a command via a hostile DOMAIN value"
+    fi
+    log "  ✓ no command executed by generate_caddyfile"
+
+    if [[ -f "${install_dir}/etc/Caddyfile" ]] && grep -qF "$hostile {" "${install_dir}/etc/Caddyfile"; then
+        log "  ✓ hostile domain written as inert literal text (no injection)"
+    fi
+}
+
+# Test 4: is_valid_ip_or_cidr_list rejects a newline-smuggled Caddy directive
+test_trusted_proxies_rejects_injection() {
+    log "Test 4: is_valid_ip_or_cidr_list rejects hostile --trusted-proxies"
+
+    local hostile
+    hostile=$'10.0.0.0/8\n}\nadmin_endpoint 0.0.0.0:2999 {\n\tenforce_origin\n}\n{'
+    if is_valid_ip_or_cidr_list "$hostile"; then
+        fail "is_valid_ip_or_cidr_list accepted a directive-injection payload"
+    fi
+    log "  ✓ hostile trusted-proxies value rejected"
+
+    if ! is_valid_ip_or_cidr_list "127.0.0.0/8 10.0.0.0/8 172.16.0.0/12 192.168.0.0/16"; then
+        fail "is_valid_ip_or_cidr_list rejected the default RFC1918 proxy list"
+    fi
+    log "  ✓ legitimate whitespace-separated CIDR list accepted"
+}
+
+# Test 5: validate_config rejects hostile --trusted-proxies end to end
+test_validate_config_rejects_hostile_trusted_proxies() {
+    log "Test 5: validate_config rejects hostile TRUSTED_PROXIES"
+
+    local hostile
+    hostile=$'10.0.0.0/8\n}\nadmin_endpoint 0.0.0.0:2999 {'
+    if (
+        TLS_MODE=off DOMAIN="" TLS_CERT="" TLS_KEY="" \
+        HTTP_PORT=8080 HTTPS_PORT=8443 \
+        INSTALL_DIR="${TEST_DIR}/install2" DATA_DIR="${TEST_DIR}/install2/data" \
+        TRUSTED_PROXIES="$hostile" BIND_IP="" ACME_SERVER="" \
+        validate_config
+    ) >/dev/null 2>&1; then
+        fail "validate_config accepted hostile trusted-proxies"
+    fi
+    log "  ✓ validate_config rejected hostile trusted-proxies"
+}
+
+# Test 6: --bind-ip and --acme-server format validation
+test_bind_ip_and_acme_server_validation() {
+    log "Test 6: BIND_IP and ACME_SERVER validation"
+
+    if is_valid_ip_or_cidr "10.3.3.107/24"; then
+        : # CIDR is valid as a CIDR
+    fi
+    if [[ "10.3.3.107/24" == */* ]]; then
+        log "  ✓ CIDR-with-prefix correctly identified for --bind-ip rejection"
+    fi
+
+    if (
+        TLS_MODE=off DOMAIN="" TLS_CERT="" TLS_KEY="" \
+        HTTP_PORT=8080 HTTPS_PORT=8443 \
+        INSTALL_DIR="${TEST_DIR}/install3" DATA_DIR="${TEST_DIR}/install3/data" \
+        TRUSTED_PROXIES="" BIND_IP="10.3.3.107/24" ACME_SERVER="" \
+        validate_config
+    ) >/dev/null 2>&1; then
+        fail "validate_config accepted a --bind-ip value with a CIDR prefix"
+    fi
+    log "  ✓ --bind-ip with CIDR prefix rejected"
+
+    local hostile_acme=$'https://ca.example.com\n{\n\trespond 200\n}'
+    if (
+        TLS_MODE=auto DOMAIN="magpie.example.com" TLS_CERT="" TLS_KEY="" \
+        HTTP_PORT=8080 HTTPS_PORT=8443 \
+        INSTALL_DIR="${TEST_DIR}/install4" DATA_DIR="${TEST_DIR}/install4/data" \
+        TRUSTED_PROXIES="" BIND_IP="" ACME_SERVER="$hostile_acme" \
+        validate_config
+    ) >/dev/null 2>&1; then
+        fail "validate_config accepted a hostile --acme-server value"
+    fi
+    log "  ✓ hostile --acme-server (embedded directive) rejected"
+
+    if (
+        TLS_MODE=auto DOMAIN="magpie.example.com" TLS_CERT="" TLS_KEY="" \
+        HTTP_PORT=8080 HTTPS_PORT=8443 \
+        INSTALL_DIR="${TEST_DIR}/install5" DATA_DIR="${TEST_DIR}/install5/data" \
+        TRUSTED_PROXIES="" BIND_IP="" ACME_SERVER="http://ca.example.com/acme/directory" \
+        validate_config
+    ) >/dev/null 2>&1; then
+        fail "validate_config accepted a non-https --acme-server value"
+    fi
+    log "  ✓ non-https --acme-server rejected"
+}
+
+# Test 7: read_env_file does not execute $(...)/backtick/newline payloads (H1)
+test_env_file_not_sourced() {
+    log "Test 7: read_env_file parses .env without shell execution"
+
+    local hostile_env="${TEST_DIR}/hostile.env"
+    {
+        echo "MAGPIE_DATA_DIR=/opt/magpie/data"
+        echo "MAGPIE_DOMAIN=magpie.example.com\$(touch ${MARKER})"
+        printf 'TRUSTED_PROXIES=10.0.0.0/8\n%s\n' "touch ${MARKER}_smuggled_line"
+        echo 'BACKTICK_VAL=`touch '"${MARKER}"'_backtick`'
+    } > "$hostile_env"
+
+    declare -A parsed=()
+    read_env_file "$hostile_env" parsed
+
+    if [[ -e "$MARKER" || -e "${MARKER}_smuggled_line" || -e "${MARKER}_backtick" ]]; then
+        fail "read_env_file executed a command embedded in a .env value"
+    fi
+    log "  ✓ no command executed while parsing a hostile .env file"
+
+    if [[ "${parsed[MAGPIE_DATA_DIR]:-}" != "/opt/magpie/data" ]]; then
+        fail "read_env_file failed to parse a well-formed line"
+    fi
+    log "  ✓ well-formed KEY=value lines still parse correctly"
+
+    if [[ "${parsed[MAGPIE_DOMAIN]:-}" != *'$(touch'* ]]; then
+        fail "read_env_file did not preserve the value literally"
+    fi
+    log "  ✓ hostile value preserved as inert literal text (not expanded)"
+}
+
+# Test 8: load_existing_config uses read_env_file (no `source`) end to end
+test_load_existing_config_no_execution() {
+    log "Test 8: load_existing_config does not execute .env contents"
+
+    local install_dir="${TEST_DIR}/lec_install"
+    mkdir -p "${install_dir}/etc"
+    {
+        echo "MAGPIE_DATA_DIR=/opt/magpie/data"
+        echo "MAGPIE_HTTP_PORT=8080"
+        echo "MAGPIE_HTTPS_PORT=8443"
+        echo "MAGPIE_DOMAIN=magpie.example.com"
+        echo "TLS_MODE=auto"
+        echo "TRUSTED_PROXIES=10.0.0.0/8"
+        echo "BIND_IP=\$(touch ${MARKER}_lec)"
+        echo "ACME_SERVER="
+    } > "${install_dir}/etc/.env"
+
+    (
+        INSTALL_DIR="$install_dir" DATA_DIR="" HTTP_PORT="" HTTPS_PORT="" DOMAIN="" \
+        TLS_MODE="" TRUSTED_PROXIES="" BIND_IP="" ACME_SERVER="" \
+        load_existing_config
+    )
+
+    if [[ -e "${MARKER}_lec" ]]; then
+        fail "load_existing_config executed a command embedded in .env"
+    fi
+    log "  ✓ load_existing_config parses .env without executing it"
+
+    grep -q "^source " "$DEPLOY_SCRIPT" && grep -qE 'source ".*etc/\.env"' "$DEPLOY_SCRIPT" \
+        && fail "magpie-deploy.sh still sources the generated .env file somewhere"
+    log "  ✓ magpie-deploy.sh no longer sources the generated .env file"
+}
+
+# Test 9: path inputs reject '..' segments and shell metacharacters
+test_path_validation() {
+    log "Test 9: install/data directory validation rejects '..' and metacharacters"
+
+    if (
+        TLS_MODE=off DOMAIN="" TLS_CERT="" TLS_KEY="" \
+        HTTP_PORT=8080 HTTPS_PORT=8443 \
+        INSTALL_DIR="/opt/magpie/../../etc" DATA_DIR="/opt/magpie/data" \
+        TRUSTED_PROXIES="" BIND_IP="" ACME_SERVER="" \
+        validate_config
+    ) >/dev/null 2>&1; then
+        fail "validate_config accepted an install-dir containing '..'"
+    fi
+    log "  ✓ '..' path segment rejected"
+
+    if (
+        TLS_MODE=off DOMAIN="" TLS_CERT="" TLS_KEY="" \
+        HTTP_PORT=8080 HTTPS_PORT=8443 \
+        INSTALL_DIR="/opt/magpie" DATA_DIR='/opt/magpie/data; rm -rf /' \
+        TRUSTED_PROXIES="" BIND_IP="" ACME_SERVER="" \
+        validate_config
+    ) >/dev/null 2>&1; then
+        fail "validate_config accepted a data-dir containing shell metacharacters"
+    fi
+    log "  ✓ shell metacharacters in data-dir rejected"
+}
+
+# Test 10: `logs` rejects a non-numeric --lines value and uses a quoted array
+test_logs_lines_validation() {
+    log "Test 10: cmd_logs rejects non-numeric --lines"
+
+    local install_dir="${TEST_DIR}/logs_install"
+    mkdir -p "${install_dir}/etc"
+    echo "MAGPIE_DATA_DIR=/opt/magpie/data" > "${install_dir}/etc/.env"
+
+    if (
+        INSTALL_DIR="$install_dir" LINES="5; touch ${MARKER}_lines" FOLLOW="false" \
+        cmd_logs
+    ) >/dev/null 2>&1; then
+        fail "cmd_logs accepted a non-numeric --lines value"
+    fi
+    log "  ✓ non-numeric --lines rejected"
+    [[ -e "${MARKER}_lines" ]] && fail "non-numeric --lines value was executed"
+    log "  ✓ no command executed via --lines"
+
+    if grep -qE 'docker compose --env-file "\$\{INSTALL_DIR\}/etc/\.env" logs \$follow_flag' "$DEPLOY_SCRIPT"; then
+        fail "cmd_logs still builds its docker-compose invocation via unquoted expansion"
+    fi
+    log "  ✓ cmd_logs no longer uses unquoted \$follow_flag expansion"
+}
+
+# Run all tests
+log "Running tests for issue #448"
+log ""
+
+test_domain_rejects_injection
+test_validate_config_rejects_hostile_domain
+test_generate_caddyfile_no_command_execution
+test_trusted_proxies_rejects_injection
+test_validate_config_rejects_hostile_trusted_proxies
+test_bind_ip_and_acme_server_validation
+test_env_file_not_sourced
+test_load_existing_config_no_execution
+test_path_validation
+test_logs_lines_validation
+
+log ""
+log "All tests passed!"

--- a/scripts/test_installer_issue448.sh
+++ b/scripts/test_installer_issue448.sh
@@ -33,6 +33,10 @@
 # 14. The "no source .env" test assertion actually detects a reintroduced
 #     source line (verified against the anchoring bug that made it
 #     vacuously pass regardless of whether .env was sourced).
+# 15. is_valid_acme_server_url() rejects an out-of-range port (e.g.
+#     :99999, which is 1-5 digits but > 65535).
+# 16. read_env_file() strips a trailing CR so a CRLF-terminated (e.g.
+#     Windows-edited) .env doesn't leave a stray \r embedded in values.
 
 set -uo pipefail
 
@@ -681,6 +685,72 @@ test_source_env_detection_is_not_vacuous() {
     log "  ✓ pattern correctly detects an indented, reintroduced source of etc/.env"
 }
 
+# Test 20: is_valid_acme_server_url() must reject an out-of-range port. The
+# charset regex alone allows 1-5 digits (e.g. ":99999"), which is
+# syntactically port-shaped but exceeds the valid 1-65535 range and would
+# produce a Caddyfile Caddy rejects.
+test_acme_server_rejects_out_of_range_port() {
+    log "Test 20: is_valid_acme_server_url rejects an out-of-range port"
+
+    if is_valid_acme_server_url "https://ca.example.com:99999/directory"; then
+        fail "is_valid_acme_server_url accepted an out-of-range port (:99999)"
+    fi
+    log "  ✓ port 99999 rejected"
+
+    if is_valid_acme_server_url "https://ca.example.com:65536/directory"; then
+        fail "is_valid_acme_server_url accepted a port one above the valid range (:65536)"
+    fi
+    log "  ✓ port 65536 (one above max) rejected"
+
+    if is_valid_acme_server_url "https://ca.example.com:0/directory"; then
+        fail "is_valid_acme_server_url accepted port 0"
+    fi
+    log "  ✓ port 0 rejected"
+
+    if ! is_valid_acme_server_url "https://ca.example.com:65535/directory"; then
+        fail "is_valid_acme_server_url rejected the maximum valid port (65535)"
+    fi
+    if ! is_valid_acme_server_url "https://ca.example.com:443/directory"; then
+        fail "is_valid_acme_server_url rejected a normal port (443)"
+    fi
+    if ! is_valid_acme_server_url "https://ca.example.com/directory"; then
+        fail "is_valid_acme_server_url rejected a URL with no port at all"
+    fi
+    log "  ✓ valid ports (443, 65535) and no-port URLs still accepted"
+}
+
+# Test 21: read_env_file() must strip a trailing CR so a CRLF-terminated
+# (e.g. Windows-edited) .env doesn't leave a stray \r embedded in parsed
+# values, which downstream validators would then reject as a control
+# character even though the value looks correct.
+test_read_env_file_strips_crlf() {
+    log "Test 21: read_env_file strips trailing CR from CRLF-terminated lines"
+
+    local crlf_env="${TEST_DIR}/crlf.env"
+    printf 'MAGPIE_DATA_DIR=/opt/magpie/data\r\nTRUSTED_PROXIES=10.0.0.0/8\r\nMAGPIE_DOMAIN=magpie.example.com\r\n' > "$crlf_env"
+
+    declare -A parsed=()
+    read_env_file "$crlf_env" parsed
+
+    if [[ "${parsed[TRUSTED_PROXIES]}" == *$'\r'* ]]; then
+        fail "read_env_file left a trailing CR in TRUSTED_PROXIES: $(printf '%q' "${parsed[TRUSTED_PROXIES]}")"
+    fi
+    if [[ "${parsed[TRUSTED_PROXIES]}" != "10.0.0.0/8" ]]; then
+        fail "read_env_file did not parse the CRLF-terminated value correctly: $(printf '%q' "${parsed[TRUSTED_PROXIES]}")"
+    fi
+    log "  ✓ CRLF-terminated value parsed without a stray trailing CR"
+
+    if ! is_valid_ip_or_cidr_list "${parsed[TRUSTED_PROXIES]}"; then
+        fail "the CR-stripped TRUSTED_PROXIES value unexpectedly still fails validation"
+    fi
+    log "  ✓ CR-stripped value passes downstream validation (previously would have failed on the stray control char)"
+
+    if [[ "${parsed[MAGPIE_DOMAIN]}" != "magpie.example.com" ]]; then
+        fail "read_env_file did not parse the last CRLF-terminated value correctly: $(printf '%q' "${parsed[MAGPIE_DOMAIN]}")"
+    fi
+    log "  ✓ last line of a CRLF file also parsed correctly (no CR left even without a trailing LF-only read)"
+}
+
 # Run all tests
 log "Running tests for issue #448"
 log ""
@@ -704,6 +774,8 @@ test_trusted_proxies_rejects_newline_between_valid_tokens
 test_trusted_proxies_allows_tab_separator
 test_domain_single_canonical_key
 test_source_env_detection_is_not_vacuous
+test_acme_server_rejects_out_of_range_port
+test_read_env_file_strips_crlf
 
 log ""
 log "All tests passed!"


### PR DESCRIPTION
## Summary

Closes #448. The installer (`scripts/magpie-deploy.sh`) previously flowed
operator-supplied `--domain`, `--trusted-proxies`, `--bind-ip`, `--acme-server`,
and path values into the generated `.env`, the generated Caddyfile, and
docker compose without format validation or safe interpolation, enabling
root-level command execution via a hostile `.env` value (sourced on every
`update`/`status`/`uninstall`) or a hostile `--domain` interpolated through
`sed`'s `e` command during Caddyfile generation.

- `validate_config()` now format-validates `DOMAIN` (hostname regex),
  `TRUSTED_PROXIES`/`BIND_IP` (IPv4/IPv6/CIDR), and `ACME_SERVER`
  (`https://` URL, no whitespace/`{`/`}`) before any file is generated
  (via new `validate_network_config()`), and rejects `..` path segments
  and shell metacharacters in `--install-dir`/`--data-dir` (via new
  `validate_path_value()`).
- `load_existing_config()` no longer `source`s the generated `.env` as
  shell. A new `read_env_file()` parses strict `KEY=value` lines with no
  expansion, command substitution, or execution. The redundant
  `set -a; source ...; set +a` re-source in `cmd_update()` is removed
  (the values are already loaded by `load_existing_config()`); the update
  path now re-validates the loaded network config with
  `validate_network_config()` before regenerating the Caddyfile (full
  `validate_config()` isn't used here since `TLS_CERT`/`TLS_KEY` aren't
  persisted to `.env` and would spuriously fail).
- `generate_caddyfile()`'s `auto`/`manual` branches no longer pass
  `DOMAIN`/`ACME_SERVER` through `sed`. `DOMAIN` is substituted with
  bash's own literal string replacement (`${content//pattern/replacement}`,
  not a regex engine), and the ACME `tls {}` block / manual `tls` directive
  are inserted with `awk -v` exact-line matching instead of `sed`'s
  address-regex + `a\` script text.
- `cmd_logs()` validates `--lines` as `^[0-9]+$` and builds the
  `docker compose` invocation as a quoted array instead of an unquoted
  `$follow_flag` expansion.
- Added `scripts/test_installer_issue448.sh`, which sources the *real*
  functions from `magpie-deploy.sh` (not reimplementations) and exercises
  them with hostile `--domain` (sed `e`-command payload), `--trusted-proxies`
  (newline-smuggled Caddy directive), `--bind-ip`, `--acme-server`, a hostile
  `.env` (`$(...)`/backtick/newline), hostile paths, and a non-numeric
  `--lines`, asserting rejection and/or no command execution (a marker file
  is checked for absence after each hostile input).

## Test plan

- [x] `scripts/test_installer_issue448.sh` -- new regression test, passes
- [x] `scripts/test_installer_issue446.sh` -- passes (no regression)
- [x] `scripts/test_installer_issue506.sh` -- passes (no regression)
- [x] `scripts/test_caddyfile_extraction.sh` -- pre-existing Test 4 failure
      reproduces identically on `origin/default` (unrelated to this change,
      not touched here)
- [x] `shellcheck scripts/magpie-deploy.sh` -- no new findings (one
      unavoidable `SC2034` false positive on a bash nameref target,
      suppressed with a comment); remaining `SC2016` info-level hits are
      pre-existing and untouched by this PR
- [x] `just lint`, `just fmt-check`, `just test-unit` -- all pass (978
      unit tests; no Python source touched)
- [x] Manually exercised the full `validate_config` -> `generate_env_file`
      -> `generate_caddyfile` -> `load_existing_config` round trip for both
      `auto` (with a custom ACME server) and `manual` TLS modes with
      realistic values, confirming output and round-tripped values match

## AI disclosure

Implemented via Claude Code (Claude Fable 5). See commit trailer.