### PR TITLE
fix(security): strip inbound X-Magpie-* before forward_auth (closes #525)

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -158,17 +158,26 @@
 		@require_auth {
 			not client_ip {$MAGPIE_ALLOWED_CIDRS:255.255.255.255/32}
 		}
-		# For allowed IPs: strip client headers and inject synthetic ones (forward_auth skipped)
-		request_header @allowed_ip -X-Magpie-User
-		request_header @allowed_ip -X-Magpie-Scope
-		request_header @allowed_ip X-Magpie-User "cidr-bypass"
-		request_header @allowed_ip X-Magpie-Scope "read"
-		# For non-allowed IPs: run forward_auth to get real headers
-		forward_auth @require_auth magpie:8000 {
-			uri /api/v1/auth/validate
-			copy_headers X-Magpie-User X-Magpie-Scope
+		# route{} forces literal top-to-bottom execution (Caddy's default
+		# directive order would otherwise run forward_auth's copy_headers
+		# before request_header, undoing the strip below). See #525.
+		route {
+			# Strip inbound client-supplied identity headers before any auth
+			# path processes the request. Prevents a client from forging
+			# X-Magpie-User/-Scope regardless of Caddy version or
+			# auth-response shape.
+			request_header -X-Magpie-User
+			request_header -X-Magpie-Scope
+			# For allowed IPs: inject synthetic headers (forward_auth skipped)
+			request_header @allowed_ip X-Magpie-User "cidr-bypass"
+			request_header @allowed_ip X-Magpie-Scope "read"
+			# For non-allowed IPs: run forward_auth to get real headers
+			forward_auth @require_auth magpie:8000 {
+				uri /api/v1/auth/validate
+				copy_headers X-Magpie-User X-Magpie-Scope
+			}
+			reverse_proxy magpie:8000
 		}
-		reverse_proxy magpie:8000
 	}
 
 	# Protected artifact downloads - requires valid Bearer token OR allowed IP
@@ -179,12 +188,20 @@
 		@require_auth {
 			not client_ip {$MAGPIE_ALLOWED_CIDRS:255.255.255.255/32}
 		}
-		# For non-allowed IPs: run forward_auth to validate token
-		# Note: Caddy's file_server serves static files directly; no headers are
-		# forwarded to the backend, so we don't inject synthetic headers for allowed IPs
-		forward_auth @require_auth magpie:8000 {
-			uri /api/v1/auth/validate
-			copy_headers X-Magpie-User X-Magpie-Scope
+		# route{} forces literal top-to-bottom execution so the strip below
+		# always runs before forward_auth's copy_headers (see #525).
+		route {
+			# Strip inbound client-supplied identity headers before
+			# forward_auth validates the request.
+			request_header -X-Magpie-User
+			request_header -X-Magpie-Scope
+			# For non-allowed IPs: run forward_auth to validate token
+			# Note: Caddy's file_server serves static files directly; no headers are
+			# forwarded to the backend, so we don't inject synthetic headers for allowed IPs
+			forward_auth @require_auth magpie:8000 {
+				uri /api/v1/auth/validate
+				copy_headers X-Magpie-User X-Magpie-Scope
+			}
 		}
 		root * /data
 		# Security: Force download of artifact files to prevent XSS from user-uploaded HTML/JS
@@ -200,11 +217,17 @@
 
 	# Upload endpoint - requires write or admin scope
 	handle /api/v1/upload/* {
-		forward_auth magpie:8000 {
-			uri /api/v1/auth/validate
-			copy_headers X-Magpie-User X-Magpie-Scope
+		# route{} forces literal top-to-bottom execution so the strip below
+		# always runs before forward_auth's copy_headers (see #525).
+		route {
+			request_header -X-Magpie-User
+			request_header -X-Magpie-Scope
+			forward_auth magpie:8000 {
+				uri /api/v1/auth/validate
+				copy_headers X-Magpie-User X-Magpie-Scope
+			}
+			reverse_proxy magpie:8000
 		}
-		reverse_proxy magpie:8000
 	}
 
 	# Artifact metadata amendment - requires write or admin scope
@@ -215,11 +238,17 @@
 		path_regexp ^/api/v1/artifacts/.+
 	}
 	handle @artifacts_amend {
-		forward_auth magpie:8000 {
-			uri /api/v1/auth/validate
-			copy_headers X-Magpie-User X-Magpie-Scope
+		# route{} forces literal top-to-bottom execution so the strip below
+		# always runs before forward_auth's copy_headers (see #525).
+		route {
+			request_header -X-Magpie-User
+			request_header -X-Magpie-Scope
+			forward_auth magpie:8000 {
+				uri /api/v1/auth/validate
+				copy_headers X-Magpie-User X-Magpie-Scope
+			}
+			reverse_proxy magpie:8000
 		}
-		reverse_proxy magpie:8000
 	}
 
 	# Tag mutation endpoints - requires write or admin scope
@@ -232,47 +261,77 @@
 		path_regexp ^/api/v1/artifacts/.+/tags
 	}
 	handle @artifacts_tags {
-		forward_auth magpie:8000 {
-			uri /api/v1/auth/validate
-			copy_headers X-Magpie-User X-Magpie-Scope
+		# route{} forces literal top-to-bottom execution so the strip below
+		# always runs before forward_auth's copy_headers (see #525).
+		route {
+			request_header -X-Magpie-User
+			request_header -X-Magpie-Scope
+			forward_auth magpie:8000 {
+				uri /api/v1/auth/validate
+				copy_headers X-Magpie-User X-Magpie-Scope
+			}
+			reverse_proxy magpie:8000
 		}
-		reverse_proxy magpie:8000
 	}
 
 	# Flush tag endpoint - requires admin scope
 	handle /api/v1/tags/* {
-		forward_auth magpie:8000 {
-			uri /api/v1/auth/validate
-			copy_headers X-Magpie-User X-Magpie-Scope
+		# route{} forces literal top-to-bottom execution so the strip below
+		# always runs before forward_auth's copy_headers (see #525).
+		route {
+			request_header -X-Magpie-User
+			request_header -X-Magpie-Scope
+			forward_auth magpie:8000 {
+				uri /api/v1/auth/validate
+				copy_headers X-Magpie-User X-Magpie-Scope
+			}
+			reverse_proxy magpie:8000
 		}
-		reverse_proxy magpie:8000
 	}
 
 	# Token management endpoints - requires admin scope
 	handle /api/v1/tokens* {
-		forward_auth magpie:8000 {
-			uri /api/v1/auth/validate
-			copy_headers X-Magpie-User X-Magpie-Scope
+		# route{} forces literal top-to-bottom execution so the strip below
+		# always runs before forward_auth's copy_headers (see #525).
+		route {
+			request_header -X-Magpie-User
+			request_header -X-Magpie-Scope
+			forward_auth magpie:8000 {
+				uri /api/v1/auth/validate
+				copy_headers X-Magpie-User X-Magpie-Scope
+			}
+			reverse_proxy magpie:8000
 		}
-		reverse_proxy magpie:8000
 	}
 
 	# GC endpoint - requires admin scope
 	handle /api/v1/gc {
-		forward_auth magpie:8000 {
-			uri /api/v1/auth/validate
-			copy_headers X-Magpie-User X-Magpie-Scope
+		# route{} forces literal top-to-bottom execution so the strip below
+		# always runs before forward_auth's copy_headers (see #525).
+		route {
+			request_header -X-Magpie-User
+			request_header -X-Magpie-Scope
+			forward_auth magpie:8000 {
+				uri /api/v1/auth/validate
+				copy_headers X-Magpie-User X-Magpie-Scope
+			}
+			reverse_proxy magpie:8000
 		}
-		reverse_proxy magpie:8000
 	}
 
 	# Status endpoint - requires admin scope
 	handle /api/v1/status {
-		forward_auth magpie:8000 {
-			uri /api/v1/auth/validate
-			copy_headers X-Magpie-User X-Magpie-Scope
+		# route{} forces literal top-to-bottom execution so the strip below
+		# always runs before forward_auth's copy_headers (see #525).
+		route {
+			request_header -X-Magpie-User
+			request_header -X-Magpie-Scope
+			forward_auth magpie:8000 {
+				uri /api/v1/auth/validate
+				copy_headers X-Magpie-User X-Magpie-Scope
+			}
+			reverse_proxy magpie:8000
 		}
-		reverse_proxy magpie:8000
 	}
 
 	# =========================================================================
@@ -282,11 +341,17 @@
 	# is implemented in FastAPI route dependencies (require_admin_scope).
 	# Test endpoints also check MAGPIE_ENABLE_TEST_ENDPOINTS before running.
 	handle /api/v1/_test/* {
-		forward_auth magpie:8000 {
-			uri /api/v1/auth/validate
-			copy_headers X-Magpie-User X-Magpie-Scope
+		# route{} forces literal top-to-bottom execution so the strip below
+		# always runs before forward_auth's copy_headers (see #525).
+		route {
+			request_header -X-Magpie-User
+			request_header -X-Magpie-Scope
+			forward_auth magpie:8000 {
+				uri /api/v1/auth/validate
+				copy_headers X-Magpie-User X-Magpie-Scope
+			}
+			reverse_proxy magpie:8000
 		}
-		reverse_proxy magpie:8000
 	}
 
 	# =========================================================================

--- a/Caddyfile.prod
+++ b/Caddyfile.prod
@@ -272,17 +272,26 @@
 		@require_auth {
 			not client_ip {$MAGPIE_ALLOWED_CIDRS:255.255.255.255/32}
 		}
-		# For allowed IPs: strip client headers and inject synthetic ones (forward_auth skipped)
-		request_header @allowed_ip -X-Magpie-User
-		request_header @allowed_ip -X-Magpie-Scope
-		request_header @allowed_ip X-Magpie-User "cidr-bypass"
-		request_header @allowed_ip X-Magpie-Scope "read"
-		# For non-allowed IPs: run forward_auth to get real headers
-		forward_auth @require_auth magpie:8000 {
-			uri /api/v1/auth/validate
-			copy_headers X-Magpie-User X-Magpie-Scope
+		# route{} forces literal top-to-bottom execution (Caddy's default
+		# directive order would otherwise run forward_auth's copy_headers
+		# before request_header, undoing the strip below). See #525.
+		route {
+			# Strip inbound client-supplied identity headers before any auth
+			# path processes the request. Prevents a client from forging
+			# X-Magpie-User/-Scope regardless of Caddy version or
+			# auth-response shape.
+			request_header -X-Magpie-User
+			request_header -X-Magpie-Scope
+			# For allowed IPs: inject synthetic headers (forward_auth skipped)
+			request_header @allowed_ip X-Magpie-User "cidr-bypass"
+			request_header @allowed_ip X-Magpie-Scope "read"
+			# For non-allowed IPs: run forward_auth to get real headers
+			forward_auth @require_auth magpie:8000 {
+				uri /api/v1/auth/validate
+				copy_headers X-Magpie-User X-Magpie-Scope
+			}
+			reverse_proxy magpie:8000
 		}
-		reverse_proxy magpie:8000
 	}
 
 	# Protected artifact downloads - requires valid Bearer token OR allowed IP
@@ -318,12 +327,20 @@
 		@require_auth {
 			not client_ip {$MAGPIE_ALLOWED_CIDRS:255.255.255.255/32}
 		}
-		# For non-allowed IPs: run forward_auth to validate token
-		# Note: Caddy's file_server serves static files directly; no headers are
-		# forwarded to the backend, so we don't inject synthetic headers for allowed IPs
-		forward_auth @require_auth magpie:8000 {
-			uri /api/v1/auth/validate
-			copy_headers X-Magpie-User X-Magpie-Scope
+		# route{} forces literal top-to-bottom execution so the strip below
+		# always runs before forward_auth's copy_headers (see #525).
+		route {
+			# Strip inbound client-supplied identity headers before
+			# forward_auth validates the request.
+			request_header -X-Magpie-User
+			request_header -X-Magpie-Scope
+			# For non-allowed IPs: run forward_auth to validate token
+			# Note: Caddy's file_server serves static files directly; no headers are
+			# forwarded to the backend, so we don't inject synthetic headers for allowed IPs
+			forward_auth @require_auth magpie:8000 {
+				uri /api/v1/auth/validate
+				copy_headers X-Magpie-User X-Magpie-Scope
+			}
 		}
 		root * /data
 		# Security: Force download of artifact files to prevent XSS from user-uploaded HTML/JS
@@ -339,11 +356,17 @@
 
 	# Upload endpoint - requires write or admin scope
 	handle /api/v1/upload/* {
-		forward_auth magpie:8000 {
-			uri /api/v1/auth/validate
-			copy_headers X-Magpie-User X-Magpie-Scope
+		# route{} forces literal top-to-bottom execution so the strip below
+		# always runs before forward_auth's copy_headers (see #525).
+		route {
+			request_header -X-Magpie-User
+			request_header -X-Magpie-Scope
+			forward_auth magpie:8000 {
+				uri /api/v1/auth/validate
+				copy_headers X-Magpie-User X-Magpie-Scope
+			}
+			reverse_proxy magpie:8000
 		}
-		reverse_proxy magpie:8000
 	}
 
 	# Artifact metadata amendment - requires write or admin scope
@@ -354,11 +377,17 @@
 		path_regexp ^/api/v1/artifacts/.+
 	}
 	handle @artifacts_amend {
-		forward_auth magpie:8000 {
-			uri /api/v1/auth/validate
-			copy_headers X-Magpie-User X-Magpie-Scope
+		# route{} forces literal top-to-bottom execution so the strip below
+		# always runs before forward_auth's copy_headers (see #525).
+		route {
+			request_header -X-Magpie-User
+			request_header -X-Magpie-Scope
+			forward_auth magpie:8000 {
+				uri /api/v1/auth/validate
+				copy_headers X-Magpie-User X-Magpie-Scope
+			}
+			reverse_proxy magpie:8000
 		}
-		reverse_proxy magpie:8000
 	}
 
 	# Tag mutation endpoints - requires write or admin scope
@@ -371,11 +400,17 @@
 		path_regexp ^/api/v1/artifacts/.+/tags
 	}
 	handle @artifacts_tags {
-		forward_auth magpie:8000 {
-			uri /api/v1/auth/validate
-			copy_headers X-Magpie-User X-Magpie-Scope
+		# route{} forces literal top-to-bottom execution so the strip below
+		# always runs before forward_auth's copy_headers (see #525).
+		route {
+			request_header -X-Magpie-User
+			request_header -X-Magpie-Scope
+			forward_auth magpie:8000 {
+				uri /api/v1/auth/validate
+				copy_headers X-Magpie-User X-Magpie-Scope
+			}
+			reverse_proxy magpie:8000
 		}
-		reverse_proxy magpie:8000
 	}
 
 	# Flush tag endpoint - requires admin scope
@@ -391,38 +426,62 @@
 		path /api/v1/tags/*/flush
 	}
 	handle @tags_flush {
-		forward_auth magpie:8000 {
-			uri /api/v1/auth/validate
-			copy_headers X-Magpie-User X-Magpie-Scope
+		# route{} forces literal top-to-bottom execution so the strip below
+		# always runs before forward_auth's copy_headers (see #525).
+		route {
+			request_header -X-Magpie-User
+			request_header -X-Magpie-Scope
+			forward_auth magpie:8000 {
+				uri /api/v1/auth/validate
+				copy_headers X-Magpie-User X-Magpie-Scope
+			}
+			reverse_proxy magpie:8000
 		}
-		reverse_proxy magpie:8000
 	}
 
 	# Token management endpoints - requires admin scope
 	handle /api/v1/tokens* {
-		forward_auth magpie:8000 {
-			uri /api/v1/auth/validate
-			copy_headers X-Magpie-User X-Magpie-Scope
+		# route{} forces literal top-to-bottom execution so the strip below
+		# always runs before forward_auth's copy_headers (see #525).
+		route {
+			request_header -X-Magpie-User
+			request_header -X-Magpie-Scope
+			forward_auth magpie:8000 {
+				uri /api/v1/auth/validate
+				copy_headers X-Magpie-User X-Magpie-Scope
+			}
+			reverse_proxy magpie:8000
 		}
-		reverse_proxy magpie:8000
 	}
 
 	# GC endpoint - requires admin scope
 	handle /api/v1/gc {
-		forward_auth magpie:8000 {
-			uri /api/v1/auth/validate
-			copy_headers X-Magpie-User X-Magpie-Scope
+		# route{} forces literal top-to-bottom execution so the strip below
+		# always runs before forward_auth's copy_headers (see #525).
+		route {
+			request_header -X-Magpie-User
+			request_header -X-Magpie-Scope
+			forward_auth magpie:8000 {
+				uri /api/v1/auth/validate
+				copy_headers X-Magpie-User X-Magpie-Scope
+			}
+			reverse_proxy magpie:8000
 		}
-		reverse_proxy magpie:8000
 	}
 
 	# Status endpoint - requires admin scope
 	handle /api/v1/status {
-		forward_auth magpie:8000 {
-			uri /api/v1/auth/validate
-			copy_headers X-Magpie-User X-Magpie-Scope
+		# route{} forces literal top-to-bottom execution so the strip below
+		# always runs before forward_auth's copy_headers (see #525).
+		route {
+			request_header -X-Magpie-User
+			request_header -X-Magpie-Scope
+			forward_auth magpie:8000 {
+				uri /api/v1/auth/validate
+				copy_headers X-Magpie-User X-Magpie-Scope
+			}
+			reverse_proxy magpie:8000
 		}
-		reverse_proxy magpie:8000
 	}
 
 	# =========================================================================


### PR DESCRIPTION
## Summary

The Bearer `forward_auth` blocks did not strip inbound `X-Magpie-User` /
`X-Magpie-Scope` headers before validating. Under CVE-2026-30851 /
GHSA-7r4p-vjf4-gxv4, Caddy's `copy_headers` Set semantics are conditional on
the auth response actually containing the header: if a 2xx auth response ever
omits a header (a future edit, or an unpatched Caddy version), a
client-forged `X-Magpie-Scope: admin` would pass through untouched. The
CIDR-bypass branch already stripped-then-injected correctly (per the issue);
every other `forward_auth` block did not.

This PR adds `request_header -X-Magpie-User` and `request_header
-X-Magpie-Scope` immediately before every `forward_auth { copy_headers
X-Magpie-User X-Magpie-Scope }` block in both `Caddyfile` (dev) and
`Caddyfile.prod`, closing this class of gap regardless of Caddy version or
auth-response shape.

## Important correction to the naive approach

Naively adding the strip lines directly above the `forward_auth` block in the
Caddyfile text does **not** work. Caddy's Caddyfile adapter reorders
directives according to a global default order table, not their textual
position. I verified empirically (using a real `caddy:2-alpine` container and
a stub backend) that this table runs `forward_auth`'s `copy_headers` step
*before* a plain `request_header` directive placed above it in the text --
so the naive change silently discarded the real `X-Magpie-User`/`-Scope`
headers a successful auth response had just set, breaking normal
authentication entirely.

Each strip is instead wrapped in a `route { ... }` block together with the
`forward_auth` (and, where present, `reverse_proxy`) call it protects. `route
{}` forces literal top-to-bottom execution, which is the documented Caddy
idiom for exactly this situation.

## Verification (real Caddy, not just `caddy validate`)

Both files pass `caddy validate --adapter caddyfile`, but syntax validity
doesn't catch an ordering bug like the one above, so I also ran the actual
modified `Caddyfile` and `Caddyfile.prod` against a real `caddy:2-alpine`
container with a stub upstream, and confirmed:

- Legitimate auth still works: a valid Bearer token still results in the real
  `X-Magpie-User`/`X-Magpie-Scope` values reaching the backend.
- A forged `X-Magpie-Scope: admin` header from the client is always
  overridden -- never reaches the backend as sent.
- CVE-2026-30851 trigger condition: even when the stub auth backend's 200
  response *omits* `X-Magpie-Scope` entirely, the client's forged value still
  does not leak through (this is the actual regression the CVE describes).
- CIDR-allowlist branch (`@artifacts_read`): both the allowed-IP path
  (injects synthetic `cidr-bypass`/`read`, forged value overridden) and the
  non-allowed-IP path (goes through `forward_auth`, forged value overridden)
  behave correctly.
- `/artifacts/*` static file serving: an unauthenticated request is still
  correctly blocked with 401 before `file_server` runs (confirms `route {}`
  didn't change the auth-before-serve ordering relative to `root`/`file_server`,
  which sit outside the `route {}` block).

## Follow-up (out of scope here)

The deployed dual-caddy setup in `infra-deployment` needs the equivalent
header-strip applied separately. Tracked as a follow-up, not addressed in
this PR.

## Test plan

- `caddy validate --config Caddyfile --adapter caddyfile` -- valid
- `caddy validate --config Caddyfile.prod --adapter caddyfile` (with
  `MAGPIE_DOMAIN` set) -- valid
- Manual end-to-end verification against both files with a real
  `caddy:2-alpine` container + stub backend, covering all scenarios listed
  above
- `just lint` / `just fmt-check` -- pass (no Python changed by this PR)
- Could not run the repo's `tests/e2e/` pytest suite in this sandbox: it
  hardcodes port 8080 for its health check, which was already held by
  another concurrent worktree's `docker compose` stack in this environment.
  The manual verification above exercises the same code paths as
  `tests/e2e/test_routing.py::TestCaddyForwardAuth` and
  `tests/e2e/test_cidr_allowlist.py`.

Closes #525

(AI-generated via Claude Code w/ Fable 5)