### PR TITLE
test(e2e): comprehensive auth-surface security matrix (closes #308)

### DIFF
--- a/src/magpie/ctl/commands/flush_tag.py
+++ b/src/magpie/ctl/commands/flush_tag.py
@@ -61,6 +61,24 @@ def flush_tag(
         action = "Would flush" if dry_run else "Flushing"
         click.echo(f"{action} tag '{tag_name}' globally...", err=True)
 
+    if json_output:
+        # Suppress all structlog output when outputting JSON to keep stdout clean.
+        # Without this, StorageService.flush_tag()'s info-level log events land on
+        # stdout alongside the JSON payload, breaking the server's
+        # run_ctl_command() json.loads() parse of the subprocess output. See gc.py
+        # for the same pattern (this command never got the equivalent fix).
+        from typing import NoReturn
+
+        import structlog
+
+        def drop_all_logs(logger: object, method_name: str, event_dict: dict) -> NoReturn:
+            raise structlog.DropEvent
+
+        structlog.configure(
+            processors=[drop_all_logs],
+            cache_logger_on_first_use=False,
+        )
+
     # Use StorageService for the actual flush operation
     storage_service = StorageService(settings)
     try:

--- a/src/magpie/ctl/commands/flush_tag.py
+++ b/src/magpie/ctl/commands/flush_tag.py
@@ -61,6 +61,8 @@ def flush_tag(
         action = "Would flush" if dry_run else "Flushing"
         click.echo(f"{action} tag '{tag_name}' globally...", err=True)
 
+    storage_service = StorageService(settings)
+
     if json_output:
         # Suppress all structlog output when outputting JSON to keep stdout clean.
         # Without this, StorageService.flush_tag()'s info-level log events land on
@@ -79,28 +81,36 @@ def flush_tag(
             cache_logger_on_first_use=False,
         )
 
-    # Use StorageService for the actual flush operation
-    storage_service = StorageService(settings)
-    try:
-        result = storage_service.flush_tag(tag_name, dry_run=dry_run)
-    except ValidationError as e:
-        if json_output:
+        try:
+            result = storage_service.flush_tag(tag_name, dry_run=dry_run)
+            output = {
+                "tag_name": result.tag_name,
+                "dry_run": dry_run,
+                "count": result.count,
+                "affected_artifacts": result.affected_artifacts,
+            }
+            click.echo(json.dumps(output))
+        except Exception as e:
+            # Intentionally broad exception handler for subprocess integration:
+            # when called with --json-output by the server's flush-tag endpoint, we
+            # must always output valid JSON so the server can parse the error.
+            # Without this, an exception from anywhere in the (destructive) removal
+            # phase -- not just tag-name validation -- would cause Click to print an
+            # unstructured traceback the server can't parse, and could leave a
+            # partial flush with no JSON signal back to the caller. Mirrors gc.py's
+            # handling of the same subprocess-integration constraint (#209).
             error_data = {"error": str(e)}
             click.echo(json.dumps(error_data))
             raise SystemExit(1)
-        raise click.ClickException(str(e))
-
-    if json_output:
-        output = {
-            "tag_name": result.tag_name,
-            "dry_run": dry_run,
-            "count": result.count,
-            "affected_artifacts": result.affected_artifacts,
-        }
-        click.echo(json.dumps(output))
         return
 
-    # Human-readable output
+    # Human-readable / interactive path: keep validation errors as a clean
+    # ClickException rather than a raw traceback.
+    try:
+        result = storage_service.flush_tag(tag_name, dry_run=dry_run)
+    except ValidationError as e:
+        raise click.ClickException(str(e))
+
     if dry_run:
         click.echo(f"Would remove tag '{tag_name}' from {result.count} artifact(s)")
     else:

--- a/src/magpie/storage/service.py
+++ b/src/magpie/storage/service.py
@@ -11,7 +11,11 @@ from typing import TYPE_CHECKING, BinaryIO
 import structlog
 
 from magpie.storage.blob import store_blob, store_blob_from_temp
-from magpie.storage.exceptions import ArtifactNotFoundError, InvalidArtifactPathError
+from magpie.storage.exceptions import (
+    ArtifactNotFoundError,
+    InvalidArtifactPathError,
+    ManifestCorruptError,
+)
 from magpie.storage.hash import short_hash
 from magpie.storage.manifest import read_manifest, remove_tag, update_tag
 from magpie.storage.metadata import (
@@ -486,8 +490,20 @@ class StorageService:
             # Compute artifact path relative to storage_path
             artifact_path = str(artifact_dir.relative_to(self.config.storage_path))
 
-            # Read manifest to check if tag exists
-            manifest = read_manifest(artifact_dir)
+            # Read manifest to check if tag exists. Mirrors gc.py's handling: skip
+            # artifacts with corrupt manifests or I/O errors and continue the walk,
+            # rather than letting one bad artifact fail this global operation for
+            # every other artifact in the tree.
+            try:
+                manifest = read_manifest(artifact_dir)
+            except (ManifestCorruptError, OSError) as e:
+                logger.warning(
+                    "flush_tag_skipping_corrupt_manifest",
+                    artifact_path=artifact_path,
+                    error=str(e),
+                    error_type=type(e).__name__,
+                )
+                continue
 
             if tag_name in manifest.tags:
                 affected_artifacts.append(artifact_path)

--- a/tests/e2e/test_cidr_allowlist.py
+++ b/tests/e2e/test_cidr_allowlist.py
@@ -624,6 +624,97 @@ class TestCIDRAllowListTokenInteraction:
 
 @pytest.mark.e2e
 @pytest.mark.slow
+class TestCIDRAllowListForgedHeaders:
+    """Regression guard for #525 on the CIDR-bypass path.
+
+    Even from an IP inside MAGPIE_ALLOWED_CIDRS, a client-forged
+    X-Magpie-User/X-Magpie-Scope header must never be trusted. The
+    @artifacts_read route{} block strips inbound identity headers before
+    deciding whether to inject the synthetic cidr-bypass/read identity or
+    run forward_auth; every other protected route strips them the same way
+    regardless of source IP, since write/admin operations are never
+    CIDR-exempt.
+    """
+
+    def test_forged_admin_scope_on_allowed_read_stays_read_only(
+        self,
+        cidr_http_client: httpx.Client,
+        cidr_authenticated_client: httpx.Client,
+        test_artifact_content: bytes,
+    ) -> None:
+        """A forged X-Magpie-Scope: admin header on the CIDR-bypass read path
+        must not cause any different (elevated) behavior than the synthetic
+        read identity Caddy actually injects."""
+        upload_response = cidr_authenticated_client.post(
+            "/api/v1/upload/cidr-test/forged-header-read",
+            files={"file": ("artifact", test_artifact_content, "application/octet-stream")},
+        )
+        assert upload_response.status_code in (200, 201)
+
+        response = cidr_http_client.get(
+            "/api/v1/artifacts?recursive=true",
+            headers={"X-Magpie-Scope": "admin", "X-Magpie-User": "attacker"},
+        )
+        # This route only ever requires read scope, so the request succeeds
+        # regardless -- the point is that the forged "admin" scope is inert:
+        # it neither breaks the read (which the synthetic read identity
+        # grants anyway) nor is it trusted for anything more privileged.
+        assert response.status_code == 200
+
+    def test_forged_headers_cannot_bypass_write_auth_from_allowed_ip(
+        self,
+        cidr_http_client: httpx.Client,
+        test_artifact_content: bytes,
+    ) -> None:
+        """SECURITY CRITICAL: forged identity headers from an allowed IP must
+        not grant write access. Write ops always require a real Bearer
+        token, even from allowed IPs, and the strip in the upload route{}
+        block removes forged headers before forward_auth runs."""
+        response = cidr_http_client.post(
+            "/api/v1/upload/cidr-test/forged-header-write",
+            files={"file": ("artifact", test_artifact_content, "application/octet-stream")},
+            headers={"X-Magpie-Scope": "admin", "X-Magpie-User": "attacker"},
+        )
+        assert response.status_code == 401, (
+            f"SECURITY FAILURE: forged X-Magpie-Scope header from an allowed IP "
+            f"granted write access. Expected 401, got {response.status_code}"
+        )
+
+    def test_forged_headers_cannot_bypass_admin_auth_from_allowed_ip(
+        self,
+        cidr_http_client: httpx.Client,
+    ) -> None:
+        """SECURITY CRITICAL: forged admin header from an allowed IP must not
+        grant access to admin-only endpoints, which are never CIDR-exempt."""
+        response = cidr_http_client.get(
+            "/api/v1/status",
+            headers={"X-Magpie-Scope": "admin", "X-Magpie-User": "attacker"},
+        )
+        assert response.status_code == 401, (
+            f"SECURITY FAILURE: forged X-Magpie-Scope header from an allowed IP "
+            f"granted admin access. Expected 401, got {response.status_code}"
+        )
+
+    def test_forged_headers_cannot_bypass_flush_auth_from_allowed_ip(
+        self,
+        cidr_http_client: httpx.Client,
+    ) -> None:
+        """SECURITY CRITICAL: forged admin header from an allowed IP must not
+        grant access to the flush-tag endpoint, which requires a validated
+        admin Bearer token (#526) regardless of source IP."""
+        response = cidr_http_client.post(
+            "/api/v1/tags/cidr-forged-header-flush-probe/flush",
+            params={"confirm_walk_filesystem": True},
+            headers={"X-Magpie-Scope": "admin", "X-Magpie-User": "attacker"},
+        )
+        assert response.status_code == 401, (
+            f"SECURITY FAILURE: forged X-Magpie-Scope header from an allowed IP "
+            f"granted flush-tag access. Expected 401, got {response.status_code}"
+        )
+
+
+@pytest.mark.e2e
+@pytest.mark.slow
 class TestCIDRAllowListOutsideIPDenied:
     """Tests verifying IPs OUTSIDE the CIDR allow-list get 401 on read attempts.
 

--- a/tests/e2e/test_security_matrix.py
+++ b/tests/e2e/test_security_matrix.py
@@ -191,6 +191,7 @@ class TestForgedIdentityHeaders:
             },
         )
         assert upload_response.status_code == 200, upload_response.text
+        uploaded_hash = upload_response.json()["hash"]
 
         info_response = http_client.get(
             "/api/v1/artifacts/security-matrix/identity-spoof-probe",
@@ -198,13 +199,21 @@ class TestForgedIdentityHeaders:
         )
         assert info_response.status_code == 200
         versions = info_response.json()["versions"]
-        assert len(versions) >= 1
-        assert versions[0]["uploaded_by"] == "test-writer", (
+        # list_artifacts() enumerates metadata files via Path.iterdir(), which has
+        # no guaranteed order, so match the version we just uploaded by hash rather
+        # than indexing [0].
+        matching = [v for v in versions if v["hash"] == uploaded_hash]
+        assert len(matching) == 1, (
+            f"Expected exactly one version matching uploaded hash {uploaded_hash!r}, "
+            f"found {len(matching)} in {versions!r}"
+        )
+        uploaded_version = matching[0]
+        assert uploaded_version["uploaded_by"] == "test-writer", (
             f"SECURITY FAILURE: forged X-Magpie-User header overrode the real token "
             f"identity. Expected 'test-writer' (the write_token fixture's real name), "
-            f"got {versions[0]['uploaded_by']!r}."
+            f"got {uploaded_version['uploaded_by']!r}."
         )
-        assert versions[0]["uploaded_by"] != "attacker"
+        assert uploaded_version["uploaded_by"] != "attacker"
 
 
 @pytest.mark.e2e

--- a/tests/e2e/test_security_matrix.py
+++ b/tests/e2e/test_security_matrix.py
@@ -1,0 +1,418 @@
+"""Comprehensive security matrix E2E tests for the magpie auth surface (#308).
+
+This suite is the systematic regression guard for two recent auth-hardening
+fixes and documents the full endpoint/token authorization matrix as living
+specification:
+
+- #525: Caddy previously trusted client-supplied X-Magpie-User/X-Magpie-Scope
+  headers in some code paths, letting a client forge its own identity/scope.
+  The fix wraps every protected `handle` block in a `route {}` that strips
+  both headers before forward_auth (or the CIDR-bypass synthetic injection)
+  runs. TestForgedIdentityHeaders exercises every one of those route{}
+  blocks directly.
+- #526: The flush-tag endpoint used to trust the X-Magpie-Scope header for
+  its admin check. The fix requires a validated admin Bearer token instead.
+  TestFlushTagBearerGating exercises the three-way gate (no bearer -> 401,
+  write bearer -> 403, admin bearer -> 200).
+
+TestScopeEnforcementMatrix documents the endpoint-type/token-scope matrix
+from #308's acceptance criteria as an executable specification, and
+TestUnauthenticatedBeforeHandler guards against the #302 information
+disclosure pattern (path existence leaking via 404 before auth runs).
+
+Run via `just e2e` (uses the standard docker-compose.yml stack, no CIDR
+allow-list). CIDR-specific forged-header coverage lives alongside the rest
+of the CIDR suite in test_cidr_allowlist.py, since it requires the two-network
+test-runner setup from docker-compose.cidr-test.yml.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+# Headers an attacker might send to try to forge identity/scope. These must
+# never reach the FastAPI backend on any protected route -- Caddy strips them
+# before forward_auth (or the CIDR-bypass synthetic injection) runs.
+FORGED_HEADERS = {"X-Magpie-User": "attacker", "X-Magpie-Scope": "admin"}
+
+# One entry per route{} block in the Caddyfile's protected-route section.
+# Templates are formatted against the `matrix_artifact` fixture's dict.
+FORGED_HEADER_ROUTES: list[tuple[str, str, str]] = [
+    ("upload", "POST", "/api/v1/upload/{path}/forged-upload-probe"),
+    ("artifact_list_paths", "GET", "/api/v1/artifacts"),
+    ("artifact_list_versions", "GET", "/api/v1/artifacts/{path}"),
+    ("artifact_info", "GET", "/api/v1/artifacts/{path}/{hash_ref}/info"),
+    ("artifact_amend", "PATCH", "/api/v1/artifacts/{path}/{hash_ref}"),
+    ("tag_create", "POST", "/api/v1/artifacts/{path}/{hash_ref}/tags"),
+    ("tag_delete", "DELETE", "/api/v1/artifacts/{path}/tags/{tag_name}"),
+    ("flush_tag", "POST", "/api/v1/tags/{tag_name}/flush?confirm_walk_filesystem=true"),
+    ("tokens_list", "GET", "/api/v1/tokens"),
+    ("tokens_create", "POST", "/api/v1/tokens"),
+    ("tokens_delete", "DELETE", "/api/v1/tokens/nonexistent-forged-probe"),
+    ("tokens_rotate", "POST", "/api/v1/tokens/nonexistent-forged-probe/rotate"),
+    ("gc", "POST", "/api/v1/gc"),
+    ("status", "GET", "/api/v1/status"),
+    ("static_download", "GET", "/artifacts/{path}/{hash_ref}/artifact"),
+]
+
+
+@pytest.mark.e2e
+@pytest.mark.slow
+class TestForgedIdentityHeaders:
+    """Regression guard for #525 across every protected route{} block.
+
+    A client sending X-Magpie-User/X-Magpie-Scope directly (without a valid
+    Bearer token) must never be treated as authenticated or authorized. This
+    is the key regression guard for the route{}-wrapped strip that replaced
+    19 copy-pasted forward_auth blocks.
+    """
+
+    @pytest.fixture(scope="class")
+    @classmethod
+    def matrix_artifact(cls, base_url: str, admin_token: str) -> dict[str, str]:
+        """Upload and tag one artifact for use by every route in the table.
+
+        Deliberately independent of the shared function-scoped conftest
+        fixtures (authenticated_client, test_artifact_content) so this can
+        be class-scoped and set up once for the whole parametrized sweep.
+        """
+        with httpx.Client(base_url=base_url, timeout=30.0) as client:
+            upload_response = client.post(
+                "/api/v1/upload/security-matrix/forged-target",
+                files={
+                    "file": ("artifact", b"forged-header-matrix-probe", "application/octet-stream")
+                },
+                headers={"Authorization": f"Bearer {admin_token}"},
+            )
+            assert upload_response.status_code == 200, upload_response.text
+            hash_ref = upload_response.json()["hash_ref"]
+
+            tag_response = client.post(
+                f"/api/v1/artifacts/security-matrix/forged-target/{hash_ref}/tags",
+                json={"tag_name": "matrix-tag"},
+                headers={"Authorization": f"Bearer {admin_token}"},
+            )
+            assert tag_response.status_code in (200, 201), tag_response.text
+
+        return {
+            "path": "security-matrix/forged-target",
+            "hash_ref": hash_ref,
+            "tag_name": "matrix-tag",
+        }
+
+    @pytest.mark.parametrize(
+        "route_name,method,template",
+        FORGED_HEADER_ROUTES,
+        ids=[r[0] for r in FORGED_HEADER_ROUTES],
+    )
+    def test_forged_headers_alone_are_rejected(
+        self,
+        http_client: httpx.Client,
+        matrix_artifact: dict[str, str],
+        route_name: str,
+        method: str,
+        template: str,
+    ) -> None:
+        """Verify forged X-Magpie-* headers without a Bearer token get 401.
+
+        SECURITY CRITICAL: if this fails for any route, a client can forge
+        its own identity and scope on that endpoint without ever presenting
+        a valid token.
+        """
+        path = template.format(**matrix_artifact)
+        response = http_client.request(method, path, headers=FORGED_HEADERS)
+        assert response.status_code == 401, (
+            f"SECURITY FAILURE: route '{route_name}' ({method} {path}) accepted forged "
+            f"X-Magpie-User/X-Magpie-Scope headers without a Bearer token. "
+            f"Expected 401, got {response.status_code}. Response: {response.text}"
+        )
+
+    def test_forged_admin_scope_with_read_token_does_not_grant_admin(
+        self,
+        http_client: httpx.Client,
+        read_token: str,
+    ) -> None:
+        """A forged X-Magpie-Scope: admin header alongside a real read token
+        must not elevate the request past what the read token actually grants."""
+        response = http_client.get(
+            "/api/v1/status",
+            headers={
+                "Authorization": f"Bearer {read_token}",
+                "X-Magpie-Scope": "admin",
+                "X-Magpie-User": "attacker",
+            },
+        )
+        assert response.status_code == 403, (
+            f"SECURITY FAILURE: forged X-Magpie-Scope: admin header elevated a read "
+            f"token to admin access. Expected 403, got {response.status_code}"
+        )
+
+    def test_forged_admin_scope_with_write_token_cannot_flush(
+        self,
+        http_client: httpx.Client,
+        write_token: str,
+    ) -> None:
+        """A forged X-Magpie-Scope: admin header alongside a real write token
+        must not grant access to the admin-only flush-tag endpoint."""
+        response = http_client.post(
+            "/api/v1/tags/forged-scope-flush-probe/flush",
+            params={"confirm_walk_filesystem": True},
+            headers={
+                "Authorization": f"Bearer {write_token}",
+                "X-Magpie-Scope": "admin",
+                "X-Magpie-User": "attacker",
+            },
+        )
+        assert response.status_code == 403, (
+            f"SECURITY FAILURE: forged X-Magpie-Scope: admin header let a write "
+            f"token flush tags. Expected 403, got {response.status_code}"
+        )
+
+    def test_forged_user_header_does_not_override_real_identity(
+        self,
+        http_client: httpx.Client,
+        write_token: str,
+    ) -> None:
+        """Functional check: uploaded_by must reflect the token's real name,
+        never a client-forged X-Magpie-User value.
+
+        The upload route reads X-Magpie-User to attribute the upload. Before
+        #525, a client could forge this header directly since it was only
+        stripped on some routes. This proves the strip is effective, not
+        just that it returns the right status code.
+        """
+        upload_response = http_client.post(
+            "/api/v1/upload/security-matrix/identity-spoof-probe",
+            files={"file": ("artifact", b"identity spoof probe", "application/octet-stream")},
+            headers={
+                "Authorization": f"Bearer {write_token}",
+                "X-Magpie-User": "attacker",
+            },
+        )
+        assert upload_response.status_code == 200, upload_response.text
+
+        info_response = http_client.get(
+            "/api/v1/artifacts/security-matrix/identity-spoof-probe",
+            headers={"Authorization": f"Bearer {write_token}"},
+        )
+        assert info_response.status_code == 200
+        versions = info_response.json()["versions"]
+        assert len(versions) >= 1
+        assert versions[0]["uploaded_by"] == "test-writer", (
+            f"SECURITY FAILURE: forged X-Magpie-User header overrode the real token "
+            f"identity. Expected 'test-writer' (the write_token fixture's real name), "
+            f"got {versions[0]['uploaded_by']!r}."
+        )
+        assert versions[0]["uploaded_by"] != "attacker"
+
+
+@pytest.mark.e2e
+@pytest.mark.slow
+class TestFlushTagBearerGating:
+    """Regression guard for #526: flush-tag requires a validated admin Bearer
+    token. The X-Magpie-Scope header (even if genuinely set by Caddy) is no
+    longer sufficient on its own.
+    """
+
+    def test_no_bearer_token_rejected(self, http_client: httpx.Client) -> None:
+        """No Authorization header at all -> 401."""
+        response = http_client.post(
+            "/api/v1/tags/bearer-gate-no-token-probe/flush",
+            params={"confirm_walk_filesystem": True},
+        )
+        assert response.status_code == 401
+
+    def test_forged_admin_scope_header_without_bearer_rejected(
+        self, http_client: httpx.Client
+    ) -> None:
+        """Forged X-Magpie-Scope: admin header with no Bearer token -> 401,
+        not 200. This is the direct #526 regression case: the header alone
+        must never be sufficient."""
+        response = http_client.post(
+            "/api/v1/tags/bearer-gate-forged-header-probe/flush",
+            params={"confirm_walk_filesystem": True},
+            headers={"X-Magpie-Scope": "admin", "X-Magpie-User": "attacker"},
+        )
+        assert response.status_code == 401, (
+            f"SECURITY FAILURE: forged X-Magpie-Scope: admin header without a Bearer "
+            f"token was accepted by flush-tag. Expected 401, got {response.status_code}"
+        )
+
+    def test_write_bearer_token_rejected(self, http_client: httpx.Client, write_token: str) -> None:
+        """A valid write-scope Bearer token is insufficient -> 403."""
+        response = http_client.post(
+            "/api/v1/tags/bearer-gate-write-token-probe/flush",
+            params={"confirm_walk_filesystem": True},
+            headers={"Authorization": f"Bearer {write_token}"},
+        )
+        assert response.status_code == 403
+
+    def test_admin_bearer_token_succeeds(self, http_client: httpx.Client, admin_token: str) -> None:
+        """A valid admin-scope Bearer token succeeds -> 200.
+
+        Uses a tag name that doesn't exist anywhere, so this is a safe
+        no-op flush (count=0) rather than mutating real test data.
+        """
+        response = http_client.post(
+            "/api/v1/tags/bearer-gate-admin-token-probe/flush",
+            params={"confirm_walk_filesystem": True},
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert data["tag_name"] == "bearer-gate-admin-token-probe"
+        assert data["count"] == 0
+
+
+@pytest.mark.e2e
+@pytest.mark.slow
+class TestScopeEnforcementMatrix:
+    """Executable specification for the #308 endpoint/token authorization matrix.
+
+    | Endpoint Type | No Token | Read | Write | Admin |
+    |---------------|----------|------|-------|-------|
+    | Public        | 200      | 200  | 200   | 200   |
+    | Read          | 401      | 200  | 200   | 200   |
+    | Write         | 401      | 403  | 200   | 200   |
+    | Admin         | 401      | 403  | 403   | 200   |
+
+    One representative, idempotent endpoint stands in for each row so the
+    matrix can run repeatedly against the same fixture data without ordering
+    side effects: GET /health (public), GET /api/v1/artifacts (read),
+    PATCH .../{ref} to amend metadata (write), GET /api/v1/status (admin).
+    """
+
+    @pytest.fixture(scope="class")
+    @classmethod
+    def matrix_artifact(cls, base_url: str, admin_token: str) -> dict[str, str]:
+        with httpx.Client(base_url=base_url, timeout=30.0) as client:
+            upload_response = client.post(
+                "/api/v1/upload/security-matrix/scope-target",
+                files={"file": ("artifact", b"scope-matrix-probe", "application/octet-stream")},
+                headers={"Authorization": f"Bearer {admin_token}"},
+            )
+            assert upload_response.status_code == 200, upload_response.text
+            hash_ref = upload_response.json()["hash_ref"]
+        return {"path": "security-matrix/scope-target", "hash_ref": hash_ref}
+
+    @staticmethod
+    def _headers(request: pytest.FixtureRequest, token_fixture: str | None) -> dict[str, str]:
+        if token_fixture is None:
+            return {}
+        token = request.getfixturevalue(token_fixture)
+        return {"Authorization": f"Bearer {token}"}
+
+    @pytest.mark.parametrize(
+        "token_fixture,expected_status",
+        [(None, 200), ("read_token", 200), ("write_token", 200), ("admin_token", 200)],
+        ids=["no_token", "read_token", "write_token", "admin_token"],
+    )
+    def test_public_endpoint_matrix(
+        self,
+        http_client: httpx.Client,
+        request: pytest.FixtureRequest,
+        token_fixture: str | None,
+        expected_status: int,
+    ) -> None:
+        """GET /health: accessible regardless of token presence or scope."""
+        headers = self._headers(request, token_fixture)
+        response = http_client.get("/health", headers=headers)
+        assert response.status_code == expected_status
+
+    @pytest.mark.parametrize(
+        "token_fixture,expected_status",
+        [(None, 401), ("read_token", 200), ("write_token", 200), ("admin_token", 200)],
+        ids=["no_token", "read_token", "write_token", "admin_token"],
+    )
+    def test_read_endpoint_matrix(
+        self,
+        http_client: httpx.Client,
+        request: pytest.FixtureRequest,
+        token_fixture: str | None,
+        expected_status: int,
+    ) -> None:
+        """GET /api/v1/artifacts: requires at least read scope."""
+        headers = self._headers(request, token_fixture)
+        response = http_client.get("/api/v1/artifacts", headers=headers)
+        assert response.status_code == expected_status
+
+    @pytest.mark.parametrize(
+        "token_fixture,expected_status",
+        [(None, 401), ("read_token", 403), ("write_token", 200), ("admin_token", 200)],
+        ids=["no_token", "read_token", "write_token", "admin_token"],
+    )
+    def test_write_endpoint_matrix(
+        self,
+        http_client: httpx.Client,
+        request: pytest.FixtureRequest,
+        matrix_artifact: dict[str, str],
+        token_fixture: str | None,
+        expected_status: int,
+    ) -> None:
+        """PATCH .../{ref} (metadata amend): requires write or admin scope.
+
+        Idempotent: re-amending the same artifact's source_uri is safe to
+        repeat across parametrized cases in any order.
+        """
+        headers = self._headers(request, token_fixture)
+        path = f"/api/v1/artifacts/{matrix_artifact['path']}/{matrix_artifact['hash_ref']}"
+        response = http_client.patch(
+            path,
+            json={"source_uri": f"probe://{token_fixture or 'anonymous'}"},
+            headers=headers,
+        )
+        assert response.status_code == expected_status
+
+    @pytest.mark.parametrize(
+        "token_fixture,expected_status",
+        [(None, 401), ("read_token", 403), ("write_token", 403), ("admin_token", 200)],
+        ids=["no_token", "read_token", "write_token", "admin_token"],
+    )
+    def test_admin_endpoint_matrix(
+        self,
+        http_client: httpx.Client,
+        request: pytest.FixtureRequest,
+        token_fixture: str | None,
+        expected_status: int,
+    ) -> None:
+        """GET /api/v1/status: requires admin scope."""
+        headers = self._headers(request, token_fixture)
+        response = http_client.get("/api/v1/status", headers=headers)
+        assert response.status_code == expected_status
+
+
+@pytest.mark.e2e
+@pytest.mark.slow
+class TestUnauthenticatedBeforeHandler:
+    """Guards against the #302 information-disclosure pattern: path
+    existence must never be observable (via 404 vs 401) before auth runs.
+    """
+
+    def test_nonexistent_artifact_list_returns_401_not_404(self, http_client: httpx.Client) -> None:
+        response = http_client.get("/api/v1/artifacts/does/not/exist/anywhere")
+        assert response.status_code == 401, (
+            "Unauthenticated requests for a nonexistent artifact path must fail auth "
+            "(401) before path resolution can leak existence via 404."
+        )
+
+    def test_nonexistent_artifact_info_returns_401_not_404(self, http_client: httpx.Client) -> None:
+        response = http_client.get("/api/v1/artifacts/does/not/exist/@deadbeef/info")
+        assert response.status_code == 401
+
+    def test_nonexistent_static_artifact_returns_401_not_404(
+        self, http_client: httpx.Client
+    ) -> None:
+        response = http_client.get("/artifacts/does/not/exist/@deadbeef/artifact")
+        assert response.status_code == 401
+
+    def test_nonexistent_admin_route_child_returns_401_not_404(
+        self, http_client: httpx.Client
+    ) -> None:
+        """Even a bogus tag name under the admin-gated flush path must 401
+        before any filesystem walk or 404 could occur."""
+        response = http_client.post(
+            "/api/v1/tags/this-tag-does-not-exist-anywhere/flush",
+            params={"confirm_walk_filesystem": True},
+        )
+        assert response.status_code == 401

--- a/tests/integration/test_ctl.py
+++ b/tests/integration/test_ctl.py
@@ -1101,6 +1101,76 @@ class TestFlushTag:
         manifest_after = read_manifest(artifact_dir)
         assert "preserve" in manifest_after.tags
 
+    def test_flush_tag_corrupt_manifest_handling(self, ctl_runner: tuple[CliRunner, Path]) -> None:
+        """Flush-tag handles corrupt .magpie manifest files gracefully.
+
+        Mirrors TestGC.test_gc_corrupt_manifest_handling: a single unreadable
+        manifest anywhere in storage must not crash the whole global walk, and
+        readable artifacts with the target tag must still be flushed.
+        """
+        runner, tmp_path = ctl_runner
+        runner.invoke(ctl_cli, ["init"])
+
+        # Create a valid, readable artifact with the tag we're about to flush.
+        from magpie.storage.manifest import Manifest, read_manifest, write_manifest
+
+        good_dir = tmp_path / "good-artifact"
+        good_dir.mkdir()
+        (good_dir / "blobs").mkdir()
+        (good_dir / "blobs" / "abc12345").write_bytes(b"good content")
+        write_manifest(good_dir, Manifest(tags={"release": "@abc12345"}))
+
+        # Create an artifact directory with a corrupt manifest alongside it.
+        corrupt_dir = tmp_path / "corrupt-artifact"
+        corrupt_dir.mkdir()
+        (corrupt_dir / ".magpie").write_text("{ this is not valid JSON }", encoding="utf-8")
+
+        # Flush-tag should skip the corrupt manifest and continue, still
+        # flushing the tag from the good artifact.
+        result = runner.invoke(ctl_cli, ["flush-tag", "release"])
+
+        assert result.exit_code == 0, (
+            f"flush-tag should skip corrupt manifest gracefully, got exit "
+            f"{result.exit_code}: {result.output}"
+        )
+        assert "Removed tag 'release' from 1 artifact(s)" in result.output, (
+            "flush-tag should still flush the readable artifact despite the "
+            "corrupt one elsewhere in storage"
+        )
+        assert "good-artifact" in result.output
+
+        # Verify the tag was actually removed from the good artifact.
+        updated_manifest = read_manifest(good_dir)
+        assert "release" not in updated_manifest.tags
+
+    def test_flush_tag_json_output_skips_corrupt_manifest(
+        self, ctl_runner: tuple[CliRunner, Path]
+    ) -> None:
+        """--json-output mode also skips corrupt manifests and still emits
+        clean, parseable JSON (the server subprocess integration path)."""
+        runner, tmp_path = ctl_runner
+        runner.invoke(ctl_cli, ["init"])
+
+        from magpie.storage.manifest import Manifest, write_manifest
+
+        good_dir = tmp_path / "good-artifact"
+        good_dir.mkdir()
+        (good_dir / "blobs").mkdir()
+        (good_dir / "blobs" / "def12345").write_bytes(b"good content")
+        write_manifest(good_dir, Manifest(tags={"release": "@def12345"}))
+
+        corrupt_dir = tmp_path / "corrupt-artifact"
+        corrupt_dir.mkdir()
+        (corrupt_dir / ".magpie").write_text("{ this is not valid JSON }", encoding="utf-8")
+
+        result = runner.invoke(ctl_cli, ["flush-tag", "release", "--json-output"])
+
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["tag_name"] == "release"
+        assert data["count"] == 1
+        assert "good-artifact" in data["affected_artifacts"]
+
 
 class TestSync:
     """Integration tests for magpie-ctl sync commands.

--- a/tests/unit/test_flush_tag.py
+++ b/tests/unit/test_flush_tag.py
@@ -302,3 +302,58 @@ class TestFlushTagValidation:
         """flush_tag should raise ValidationError for tag with special chars."""
         with pytest.raises(ValidationError):
             storage_service.flush_tag("v1@beta!")
+
+
+class TestFlushTagCorruptManifestHandling:
+    """Tests that flush_tag skips corrupt manifests rather than crashing the
+    entire global walk. Mirrors run_gc()'s handling of the same failure mode
+    (magpie/storage/gc.py), which flush_tag previously lacked.
+    """
+
+    def test_flush_tag_skips_corrupt_manifest_and_continues(
+        self, storage_service: StorageService, test_config: MagpieSettings
+    ) -> None:
+        """A corrupt manifest anywhere in storage must not prevent flush_tag
+        from still flushing the tag off readable artifacts."""
+        # A normal, readable artifact with the target tag.
+        _, ref = store_test_artifact(storage_service, "good/artifact", b"good content")
+        storage_service.create_tag("good/artifact", ref, "release")
+
+        # A separate artifact directory with a corrupt .magpie manifest.
+        corrupt_dir = artifact_dir_path(test_config.storage_path, "corrupt/artifact")
+        corrupt_dir.mkdir(parents=True)
+        (corrupt_dir / ".magpie").write_text("{ not valid json }", encoding="utf-8")
+
+        # Should not raise, and should still flush the good artifact.
+        result = storage_service.flush_tag("release")
+
+        assert result.tag_name == "release"
+        assert result.count == 1
+        assert "good/artifact" in result.affected_artifacts
+        assert "corrupt/artifact" not in result.affected_artifacts
+
+        # Verify the tag was actually removed from the good artifact.
+        good_dir = artifact_dir_path(test_config.storage_path, "good/artifact")
+        manifest = read_manifest(good_dir)
+        assert "release" not in manifest.tags
+
+    def test_flush_tag_dry_run_also_skips_corrupt_manifest(
+        self, storage_service: StorageService, test_config: MagpieSettings
+    ) -> None:
+        """dry_run mode must also tolerate a corrupt manifest during the walk."""
+        _, ref = store_test_artifact(storage_service, "good/artifact", b"good content")
+        storage_service.create_tag("good/artifact", ref, "preview-tag")
+
+        corrupt_dir = artifact_dir_path(test_config.storage_path, "corrupt/artifact")
+        corrupt_dir.mkdir(parents=True)
+        (corrupt_dir / ".magpie").write_text("{ not valid json }", encoding="utf-8")
+
+        result = storage_service.flush_tag("preview-tag", dry_run=True)
+
+        assert result.count == 1
+        assert "good/artifact" in result.affected_artifacts
+
+        # dry_run: tag must still be present afterward.
+        good_dir = artifact_dir_path(test_config.storage_path, "good/artifact")
+        manifest = read_manifest(good_dir)
+        assert "preview-tag" in manifest.tags


### PR DESCRIPTION
## Summary

Adds a systematic E2E security matrix test for magpie's auth surface, per #308. Validates the auth-hardening fixes now on `default`:

- **#525** (Caddy strips inbound `X-Magpie-User`/`X-Magpie-Scope` before `forward_auth` on every protected route{} block)
- **#526** (`flush-tag` requires a validated admin Bearer token, not just the scope header)

### New tests (`tests/e2e/test_security_matrix.py`)

- `TestForgedIdentityHeaders` -- forged `X-Magpie-User`/`X-Magpie-Scope` headers alone (no Bearer token) are rejected with 401 across all 15 protected routes (upload, artifact list/versions/info, amend, tag create/delete, flush, tokens list/create/delete/rotate, gc, status, static download) -- one assertion per `route{}` block from the #525 fix. Also checks that a forged admin-scope header can't elevate a real read/write token past what it actually grants, and that a forged `X-Magpie-User` can't override the real uploader identity (verified via the `uploaded_by` field in the upload response, not just a status code).
- `TestFlushTagBearerGating` -- the #526 three-way gate: no bearer -> 401, forged `X-Magpie-Scope: admin` header alone -> 401, write bearer -> 403, admin bearer -> 200.
- `TestScopeEnforcementMatrix` -- executable specification of the public/read/write/admin x no-token/read/write/admin matrix from #308's acceptance criteria, using one representative idempotent endpoint per row (`/health`, `GET /api/v1/artifacts`, `PATCH .../{ref}`, `GET /api/v1/status`).
- `TestUnauthenticatedBeforeHandler` -- nonexistent paths return 401 (not 404) before path resolution, guarding against the #302 information-disclosure pattern.

### New tests (`tests/e2e/test_cidr_allowlist.py`)

- `TestCIDRAllowListForgedHeaders` -- forged identity headers from an IP inside `MAGPIE_ALLOWED_CIDRS` can't escalate the read-only CIDR bypass into write/admin/flush access, and don't cause any different behavior on the bypass-eligible read path.

### Bugs found and fixed along the way

Building this matrix against the real Caddy+FastAPI stack (not mocks) surfaced two pre-existing bugs, independent of #525/#526, that were blocking the "admin Bearer succeeds" flush-tag path from ever actually working:

1. `magpie-ctl flush-tag --json-output` never got the stdout structlog-suppression fix that `gc.py` already has. Its `tag_flushed` info log landed on stdout right next to the JSON payload, so the server's `json.loads()` of the subprocess output always threw, and every real (successful) admin flush-tag call returned 500.
2. `StorageService.flush_tag()`'s manifest walk had no corrupt-manifest handling (unlike `gc`'s equivalent walk, which already skips-and-warns). Any single unreadable `.magpie` manifest anywhere in storage crashed the *entire* global flush operation for every tag, not just the affected artifact.

Both are fixed by mirroring the exact pattern already used in `gc.py`/`storage/gc.py`.

## Test plan

- [x] `uv run pytest tests/unit/ tests/integration/ -v` -- 1374 passed, 1 skipped
- [x] `uv run bandit -r src/` -- clean
- [x] `uv run ruff check` / `ruff format --check` -- clean
- [x] `uv run pytest tests/e2e/ -v` (full suite, standard `docker-compose.yml`, alternate ports locally to avoid colliding with an unrelated running stack on this host) -- 136 passed, 32 skipped (CIDR tests, which require the two-network harness below)
- [x] Reproduced and fixed a real test-order-dependent flush-tag failure: `test_release_validation.py::test_gc_dry_run_skips_corrupt_manifest` leaves a corrupt manifest in the shared e2e storage, which the old `flush_tag` code crashed on when walking the full tree. Confirmed fixed by re-running `test_release_validation.py` immediately before `test_security_matrix.py` (the same file order pytest uses when collecting `tests/e2e/`, and the same order CI's `just e2e` will hit).
- [x] `./scripts/run-cidr-tests.sh`-equivalent manual run (two-network `docker-compose.cidr-test.yml` harness, alternate ports) -- inside: 24 passed, 2 skipped; outside: 7 passed. All 4 new `TestCIDRAllowListForgedHeaders` tests pass.
- [ ] CI (GitHub Actions `E2E Tests` workflow) -- not yet observed on this PR; local runs above used alternate ports/project names since port 8080 was held by an unrelated running stack on this host.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>