### PR TITLE
feat(security): pluggable admin-token delivery sink (closes #387)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,6 +66,39 @@
 # MAGPIE_MAX_UPLOAD_SIZE=
 
 # =============================================================================
+# Admin Bootstrap Token Delivery
+# =============================================================================
+
+# How the first-boot admin token is delivered. Production has NO default --
+# an explicit choice is required (fail-closed). The dev docker-compose.yml
+# defaults this to "file" for frictionless local bootstrap.
+#
+# One of:
+#   file    - write a 0600 file at MAGPIE_ADMIN_TOKEN_SINK_FILE_PATH
+#   exec    - pipe the token via stdin to MAGPIE_ADMIN_TOKEN_SINK_EXEC_COMMAND
+#             (never argv or env); a non-zero exit is a delivery failure
+#   discard - retain no bootstrap token; mint one later via an interactive
+#             session: magpie-ctl token create --name ops-admin --scope admin
+#   stdout  - opt-in only; the old (insecure) behavior -- the token is
+#             captured by container logs. Never the default.
+#
+# A delivery failure for "file" or "exec" aborts init; the server does not
+# start. See docs/installation.md "Admin Token Delivery" for details,
+# including the Vault-via-exec example.
+# MAGPIE_ADMIN_TOKEN_SINK=discard
+
+# Path for sink=file. Default: a sibling of MAGPIE_DATABASE_PATH (typically
+# /data/admin-token).
+# MAGPIE_ADMIN_TOKEN_SINK_FILE_PATH=/data/admin-token
+
+# Shell-style command line for sink=exec (parsed with shlex, never run
+# through a shell). Example: writing into Vault with `vault kv put`:
+# MAGPIE_ADMIN_TOKEN_SINK_EXEC_COMMAND=vault kv put -mount=secret bootstrap/magpie/admin-token token=-
+
+# Timeout in seconds for the sink=exec command. Default: 30.
+# MAGPIE_ADMIN_TOKEN_SINK_EXEC_TIMEOUT_SECONDS=30
+
+# =============================================================================
 # Logging
 # =============================================================================
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -95,6 +95,18 @@ services:
       # IMPORTANT: Keep debug mode disabled in production. Enabling it exposes
       # detailed error messages and stack traces that could leak sensitive info.
       - MAGPIE_DEBUG=false
+      # Admin bootstrap token delivery -- REQUIRED, no default (fail-closed by
+      # design; see docs/installation.md "Admin Token Delivery"). Choose one of:
+      #   file    - write a 0600 file at MAGPIE_ADMIN_TOKEN_SINK_FILE_PATH
+      #   exec    - pipe the token via stdin to MAGPIE_ADMIN_TOKEN_SINK_EXEC_COMMAND
+      #             (e.g. a `vault kv put ...` invocation)
+      #   discard - retain no bootstrap token; mint one later via
+      #             `docker compose ... exec magpie magpie-ctl token create --scope admin`
+      #   stdout  - opt-in only; insecure, prints the token to container logs
+      - MAGPIE_ADMIN_TOKEN_SINK=${MAGPIE_ADMIN_TOKEN_SINK:?MAGPIE_ADMIN_TOKEN_SINK must be set (file, exec, discard, or stdout) -- see docs/installation.md}
+      - MAGPIE_ADMIN_TOKEN_SINK_FILE_PATH=${MAGPIE_ADMIN_TOKEN_SINK_FILE_PATH:-/data/admin-token}
+      - MAGPIE_ADMIN_TOKEN_SINK_EXEC_COMMAND=${MAGPIE_ADMIN_TOKEN_SINK_EXEC_COMMAND:-}
+      - MAGPIE_ADMIN_TOKEN_SINK_EXEC_TIMEOUT_SECONDS=${MAGPIE_ADMIN_TOKEN_SINK_EXEC_TIMEOUT_SECONDS:-30}
       # S3/AWS configuration for magpie-ctl sync command (optional)
       # Set these variables in your .env file to enable S3 backup functionality
       - MAGPIE_S3_BUCKET=${MAGPIE_S3_BUCKET:-}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,13 @@ services:
       - MAGPIE_STORAGE_PATH=/data/artifacts
       - MAGPIE_DATABASE_PATH=${MAGPIE_DATABASE_PATH:-/data/magpie.db}
       - MAGPIE_DEBUG=${MAGPIE_DEBUG:-false}
+      # Admin bootstrap token delivery (see docs/installation.md). Dev default
+      # is sink=file, written into the same bind-mounted /data directory so
+      # it's readable on the host at ${MAGPIE_DATA_DIR:-./data}/admin-token.
+      - MAGPIE_ADMIN_TOKEN_SINK=${MAGPIE_ADMIN_TOKEN_SINK:-file}
+      - MAGPIE_ADMIN_TOKEN_SINK_FILE_PATH=${MAGPIE_ADMIN_TOKEN_SINK_FILE_PATH:-/data/admin-token}
+      - MAGPIE_ADMIN_TOKEN_SINK_EXEC_COMMAND=${MAGPIE_ADMIN_TOKEN_SINK_EXEC_COMMAND:-}
+      - MAGPIE_ADMIN_TOKEN_SINK_EXEC_TIMEOUT_SECONDS=${MAGPIE_ADMIN_TOKEN_SINK_EXEC_TIMEOUT_SECONDS:-30}
       - MAGPIE_S3_BUCKET=${MAGPIE_S3_BUCKET:-}
       - MAGPIE_S3_PREFIX=${MAGPIE_S3_PREFIX:-}
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-}

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -46,8 +46,9 @@ Choose one:
 
 - **`exec`** -- pipes the token to an operator-configured command via
   **stdin only** (never argv or env, so it can't leak via `ps` or
-  `/proc/<pid>/environ`). A non-zero exit is a delivery failure and aborts
-  init. This is the general "push into my secret store" mechanism -- e.g.
+  `/proc/<pid>/environ`). A non-zero exit is a delivery failure -- see
+  below for what that aborts, depending on which command triggered it.
+  This is the general "push into my secret store" mechanism -- e.g.
   writing straight into Vault:
   ```bash
   export MAGPIE_ADMIN_TOKEN_SINK=exec
@@ -76,12 +77,19 @@ Choose one:
   docker compose -f docker-compose.prod.yml logs magpie | grep "ADMIN TOKEN"
   ```
 
-Token generation happens **only** on first boot; a delivery failure for
-`file` or `exec` aborts init and the server does not start (a
-generated-but-undelivered token is a liability, not a degraded feature).
-Rotating the admin token (`magpie-ctl init --reset-admin-token` or
-`magpie-ctl token rotate admin`) delivers the new token through the same
-configured sink.
+Token generation happens **only** on first boot. In every case (first-boot
+init, `--reset-admin-token`, and `token rotate admin`) delivery is attempted
+**before** any database change -- a generated-but-undelivered token is a
+liability, not a degraded feature, so nothing is ever persisted or revoked
+until the sink confirms success:
+
+- **First boot:** a `file`/`exec` delivery failure means no admin token
+  exists in the database, and the server does not start (entrypoint.sh
+  removes the incomplete database and retries automatically on next start).
+- **`--reset-admin-token` / `token rotate admin`** (run via `docker exec`
+  against an already-running server): a delivery failure leaves the
+  **existing** admin token completely untouched -- nothing is lost. Fix the
+  sink and simply re-run the command.
 
 A native `vault` sink (writing directly to a Vault path, optionally with
 response-wrapping) is planned for a future release; `exec` already covers

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -20,44 +20,95 @@ docker compose -f docker-compose.prod.yml up -d
 
 Requires: domain name for TLS (auto-provisioned via Let's Encrypt).
 
+## Admin Token Delivery
+
+On first boot (no existing database), magpie generates a break-glass admin
+token and delivers it via the sink configured by `MAGPIE_ADMIN_TOKEN_SINK`.
+It is **never** printed to stdout (and therefore never captured by
+`docker logs` or a log shipper) unless `sink=stdout` is explicitly chosen.
+
+`docker-compose.prod.yml` requires this variable to be set explicitly --
+there is no default in production, by design (fail-closed). The dev
+`docker-compose.yml` defaults to `sink=file` for frictionless local
+bootstrap. See [.env.example](../.env.example) for the full list of
+`MAGPIE_ADMIN_TOKEN_SINK*` variables.
+
+Choose one:
+
+- **`file`** -- writes a root-only (0600) file at
+  `MAGPIE_ADMIN_TOKEN_SINK_FILE_PATH` (default: a sibling of
+  `MAGPIE_DATABASE_PATH`, typically `/data/admin-token`):
+  ```bash
+  export MAGPIE_ADMIN_TOKEN_SINK=file
+  docker compose -f docker-compose.prod.yml up -d
+  sudo cat "${MAGPIE_DATA_DIR:-./data}/admin-token"
+  ```
+
+- **`exec`** -- pipes the token to an operator-configured command via
+  **stdin only** (never argv or env, so it can't leak via `ps` or
+  `/proc/<pid>/environ`). A non-zero exit is a delivery failure and aborts
+  init. This is the general "push into my secret store" mechanism -- e.g.
+  writing straight into Vault:
+  ```bash
+  export MAGPIE_ADMIN_TOKEN_SINK=exec
+  export MAGPIE_ADMIN_TOKEN_SINK_EXEC_COMMAND='vault kv put -mount=secret bootstrap/magpie/admin-token token=-'
+  docker compose -f docker-compose.prod.yml up -d
+  ```
+
+- **`discard`** -- generates and immediately drops the bootstrap token;
+  nothing is delivered anywhere. Use this for an "install now, mint a token
+  when I'm ready" flow. Obtain a usable admin-scope token later via an
+  interactive `docker exec` session (which prints to your terminal, not the
+  container log stream, so it's safe):
+  ```bash
+  export MAGPIE_ADMIN_TOKEN_SINK=discard
+  docker compose -f docker-compose.prod.yml up -d
+  docker compose -f docker-compose.prod.yml exec magpie \
+    magpie-ctl token create --name ops-admin --scope admin
+  ```
+
+- **`stdout`** -- opt-in only, prints a warning plus the token to stdout
+  (the pre-#387 behavior). Never the default; only use this for local/dev
+  convenience, not production:
+  ```bash
+  export MAGPIE_ADMIN_TOKEN_SINK=stdout
+  docker compose -f docker-compose.prod.yml up -d
+  docker compose -f docker-compose.prod.yml logs magpie | grep "ADMIN TOKEN"
+  ```
+
+Token generation happens **only** on first boot; a delivery failure for
+`file` or `exec` aborts init and the server does not start (a
+generated-but-undelivered token is a liability, not a degraded feature).
+Rotating the admin token (`magpie-ctl init --reset-admin-token` or
+`magpie-ctl token rotate admin`) delivers the new token through the same
+configured sink.
+
+A native `vault` sink (writing directly to a Vault path, optionally with
+response-wrapping) is planned for a future release; `exec` already covers
+Vault via `vault kv put` in the meantime.
+
 ## First Steps
 
-1. Get admin token:
-```bash
-docker compose -f docker-compose.prod.yml logs magpie | grep "ADMIN TOKEN"
-```
+Once the admin token has been delivered (see above), use it to bootstrap
+everyday access:
 
-The admin token (format: `mgp_ADMIN_...`) is generated once on first initialization and written to the container logs (you can re-run the `logs` command to see it until logs are rotated). Save it securely - it's primarily used to bootstrap and perform admin actions (like creating additional tokens), not for everyday CLI usage.
-
-**Security Note:** The initial admin token appears in container logs. As a best practice, create a new admin token and revoke the initial one after deployment:
-
-```bash
-# Create new admin token
-docker compose -f docker-compose.prod.yml exec magpie magpie-ctl token create --name ops-admin --scope admin
-
-# Revoke the initial break-glass token (default name: "admin")
-docker compose -f docker-compose.prod.yml exec magpie magpie-ctl token revoke admin
-```
-
-See [Issue #387](https://github.com/SouthwestCCDC/magpie/issues/387) for tracking improvements to token initialization.
-
-2. Create CI tokens:
+1. Create CI tokens:
 ```bash
 docker compose -f docker-compose.prod.yml exec magpie magpie-ctl token create --name ci-deployer --scope write
 ```
 
-3. Install client:
+2. Install client:
 ```bash
 uv pip install git+https://github.com/SouthwestCCDC/magpie
 ```
 
-4. Configure client:
+3. Configure client:
 ```bash
 export MAGPIE_SERVER=https://magpie.example.com
 export MAGPIE_TOKEN=mgp_your_token_here
 ```
 
-5. Test:
+4. Test:
 ```bash
 curl https://magpie.example.com/health
 echo "test" > test.txt
@@ -73,6 +124,7 @@ Key environment variables (see [.env.example](../.env.example) for all):
 - `MAGPIE_STORAGE_PATH` - Artifact storage (default: `/data/artifacts`)
 - `MAGPIE_RETENTION_DAYS` - GC retention period (default: 90)
 - `MAGPIE_DEBUG` - Verbose logging (default: false; never in production)
+- `MAGPIE_ADMIN_TOKEN_SINK` - Admin bootstrap token delivery: `file`/`exec`/`discard`/`stdout` (required in production, no default; see [Admin Token Delivery](#admin-token-delivery) above)
 
 Next: [Production Checklist](production-checklist.md) → [User Guide](user-guide.md) → [Backup & Restore](backup-restore.md)
 

--- a/docs/production-checklist.md
+++ b/docs/production-checklist.md
@@ -7,19 +7,30 @@ Before deploying to production:
 - [ ] Firewall allows ports 80 and 443
 - [ ] Persistent storage provisioned for `MAGPIE_DATA_DIR`
 - [ ] Backup destination configured (see [backup-restore.md](backup-restore.md))
+- [ ] `MAGPIE_ADMIN_TOKEN_SINK` chosen (`file`/`exec`/`discard`/`stdout`) --
+      `docker-compose.prod.yml` refuses to start without it (fail-closed, no
+      default). See [installation.md](installation.md#admin-token-delivery).
 
 ## Security Setup
 - [ ] `MAGPIE_DEBUG=false`
-- [ ] Admin token stored securely (from startup logs)
+- [ ] `MAGPIE_ADMIN_TOKEN_SINK` set to a non-`stdout` value (`file`, `exec`,
+      or `discard`) -- `stdout` is opt-in only and reintroduces the
+      container-log leak this checklist previously required guarding against
+- [ ] Admin token delivered and stored securely via the configured sink (or
+      intentionally discarded, with a mint-later plan)
 - [ ] HTTPS enabled (automatic via Let's Encrypt)
 
 ## Deploy
 ```bash
 export MAGPIE_DOMAIN=magpie.example.com
 export MAGPIE_DATA_DIR=/path/to/persistent/storage
+export MAGPIE_ADMIN_TOKEN_SINK=file   # or exec / discard / stdout
 docker compose -f docker-compose.prod.yml up -d
-docker compose -f docker-compose.prod.yml logs magpie | grep "ADMIN TOKEN"
 ```
+
+Retrieve the admin token per the chosen sink -- see
+[installation.md](installation.md#admin-token-delivery) for the `file`,
+`exec`, and `discard` (mint-later) flows.
 
 ## Validation
 - [ ] Health check: `curl https://$MAGPIE_DOMAIN/health`
@@ -37,6 +48,13 @@ docker compose -f docker-compose.prod.yml logs magpie | grep "ADMIN TOKEN"
 **Recover admin token if lost:**
 ```bash
 docker compose -f docker-compose.prod.yml exec magpie magpie-ctl init --reset-admin-token
+```
+The new token is delivered through the same configured `MAGPIE_ADMIN_TOKEN_SINK`
+(not printed to stdout unless `sink=stdout`). If using `sink=discard`, mint a
+fresh admin-scope token directly instead:
+```bash
+docker compose -f docker-compose.prod.yml exec magpie \
+  magpie-ctl token create --name ops-admin --scope admin
 ```
 
 ---

--- a/docs/production-checklist.md
+++ b/docs/production-checklist.md
@@ -50,8 +50,10 @@ Retrieve the admin token per the chosen sink -- see
 docker compose -f docker-compose.prod.yml exec magpie magpie-ctl init --reset-admin-token
 ```
 The new token is delivered through the same configured `MAGPIE_ADMIN_TOKEN_SINK`
-(not printed to stdout unless `sink=stdout`). If using `sink=discard`, mint a
-fresh admin-scope token directly instead:
+(not printed to stdout unless `sink=stdout`) -- delivery is attempted before
+any database change, so if it fails (e.g. a broken exec command), the prior
+admin token is left completely valid and unchanged; fix the sink and re-run.
+If using `sink=discard`, mint a fresh admin-scope token directly instead:
 ```bash
 docker compose -f docker-compose.prod.yml exec magpie \
   magpie-ctl token create --name ops-admin --scope admin

--- a/scripts/magpie-deploy.sh
+++ b/scripts/magpie-deploy.sh
@@ -1204,7 +1204,14 @@ run_init() {
     while (( attempt <= max_retries )); do
         log "Attempting database initialization (attempt $attempt/$max_retries)..."
 
-        if output=$(docker compose --env-file "${INSTALL_DIR}/etc/.env" exec -T magpie magpie-ctl init 2>&1); then
+        # MAGPIE_ADMIN_TOKEN_SINK=stdout is overridden for just this exec so
+        # the token can be scraped below and shown to the operator running
+        # this installer, regardless of the deployed docker-compose.yml's
+        # own default -- this is an operator-initiated `docker compose exec`
+        # printing to this interactive install session, not the automatic
+        # first-boot init that runs as the container's PID 1 (which is the
+        # actual leak vector #387 addresses; see docs/installation.md).
+        if output=$(docker compose --env-file "${INSTALL_DIR}/etc/.env" exec -T -e MAGPIE_ADMIN_TOKEN_SINK=stdout magpie magpie-ctl init 2>&1); then
             init_success=true
             break
         fi
@@ -1249,7 +1256,15 @@ run_init() {
         echo "=============================================="
         echo ""
     else
-        log "Database initialized (admin token already exists)"
+        # No token in this exec's output -- almost always because the
+        # container's own first-boot init (entrypoint.sh, running before
+        # this script's health check returns) already generated and
+        # delivered it via MAGPIE_ADMIN_TOKEN_SINK (default: file, at
+        # ${DATA_DIR}/admin-token) before this exec ever ran.
+        log "Database already initialized; admin token was delivered on first boot."
+        log "Default sink is 'file': sudo cat ${DATA_DIR}/admin-token"
+        log "To mint an additional admin-scope token instead:"
+        log "  docker compose --env-file ${INSTALL_DIR}/etc/.env exec magpie magpie-ctl token create --name ops-admin --scope admin"
     fi
 }
 

--- a/scripts/run-cidr-tests.sh
+++ b/scripts/run-cidr-tests.sh
@@ -72,7 +72,11 @@ fi
 # Initialize magpie and get admin token
 echo "Initializing magpie and getting admin token..."
 # Capture output and return code separately to avoid mixing stdout/stderr
-INIT_OUTPUT=$(docker compose exec -T magpie magpie-ctl init --reset-admin-token 2>&1)
+# MAGPIE_ADMIN_TOKEN_SINK=stdout is overridden for just this exec so the
+# token can be scraped below, regardless of docker-compose.yml's own
+# (file-sink) default -- this is the script reading its own token, not a
+# production delivery path.
+INIT_OUTPUT=$(docker compose exec -T -e MAGPIE_ADMIN_TOKEN_SINK=stdout magpie magpie-ctl init --reset-admin-token 2>&1)
 INIT_EXIT_CODE=$?
 
 if [ $INIT_EXIT_CODE -ne 0 ]; then

--- a/src/magpie/auth/service.py
+++ b/src/magpie/auth/service.py
@@ -125,7 +125,7 @@ class TokenService:
 
         if plaintext_token is None:
             # Generate secure random token
-            plaintext_token = self._generate_plaintext_token(scope)
+            plaintext_token = self.generate_plaintext_token(scope)
         else:
             # Validate provided token has correct prefix
             if scope == TokenScope.ADMIN:
@@ -245,7 +245,9 @@ class TokenService:
         finally:
             conn.close()
 
-    def rotate_token(self, name: str) -> tuple[str, TokenScope] | None:
+    def rotate_token(
+        self, name: str, plaintext_token: str | None = None
+    ) -> tuple[str, TokenScope] | None:
         """Rotate a token by revoking and creating a new one with the same scope.
 
         This is an atomic operation that:
@@ -261,6 +263,12 @@ class TokenService:
 
         Args:
             name: Name of the token to rotate.
+            plaintext_token: Optional pre-generated plaintext to persist instead of
+                generating a new random one. Used by callers (e.g. the admin token's
+                sink-delivery flow) that must generate and successfully *deliver* a
+                token before it's ever written to the database -- see
+                generate_plaintext_token() and magpie.auth.token_sink. Not validated
+                for prefix/format here; callers are responsible for that.
 
         Returns:
             Tuple of (plaintext_token, scope) if rotation succeeded, None if token not found.
@@ -285,7 +293,9 @@ class TokenService:
 
                 # Create and persist new token with same name and scope (without committing)
                 try:
-                    new_plaintext = self._create_and_save_token(conn, name, scope)
+                    new_plaintext = self._create_and_save_token(
+                        conn, name, scope, plaintext_token=plaintext_token
+                    )
                 except sqlite3.IntegrityError as e:
                     # Extremely unlikely hash collision during rotation
                     raise TokenError(
@@ -297,21 +307,59 @@ class TokenService:
         finally:
             conn.close()
 
+    def replace_token(self, name: str, scope: TokenScope, plaintext_token: str) -> None:
+        """Atomically persist an already-generated (and already-delivered) plaintext.
+
+        Deletes any existing token with this name and creates a new one with the
+        given plaintext, in a single transaction -- unlike rotate_token(), this
+        succeeds even if no token with this name currently exists (used by the
+        admin token's --reset-admin-token flow, which may be reviving a token
+        that was never created or was previously revoked).
+
+        Callers must only call this AFTER plaintext_token has already been
+        successfully delivered (e.g. via magpie.auth.token_sink) -- this method
+        never generates a value itself, so there is no risk of persisting a
+        token that wasn't (or couldn't be) delivered.
+
+        Args:
+            name: Token name.
+            scope: Token scope.
+            plaintext_token: Already-generated, already-delivered plaintext to persist.
+
+        Raises:
+            TokenError: If a hash collision occurs during creation (extremely unlikely).
+        """
+        conn = get_connection(self.db_path)
+        try:
+            with conn:
+                delete_token(conn, name, commit=False)
+                try:
+                    self._create_and_save_token(conn, name, scope, plaintext_token=plaintext_token)
+                except sqlite3.IntegrityError as e:
+                    raise TokenError(
+                        f"Failed to replace token '{name}' due to hash collision. Please try again."
+                    ) from e
+        finally:
+            conn.close()
+
     def _create_and_save_token(
         self,
         conn: sqlite3.Connection,
         name: str,
         scope: TokenScope,
+        plaintext_token: str | None = None,
     ) -> str:
         """Create a new token with the given name and scope using an existing connection.
 
-        This helper is used by rotate_token to ensure that token deletion and creation
-        happen within a single database transaction.
+        This helper is used by rotate_token() and replace_token() to ensure that
+        token deletion and creation happen within a single database transaction.
 
         Args:
             conn: Existing database connection.
             name: Token name.
             scope: Token scope.
+            plaintext_token: Optional pre-generated plaintext to persist instead of
+                generating a new random one.
 
         Returns:
             Plaintext token string.
@@ -319,8 +367,10 @@ class TokenService:
         # Validate token name defensively (defense in depth)
         validate_token_name(name)
 
-        # Generate a new secure plaintext token
-        plaintext = self._generate_plaintext_token(scope)
+        # Use the caller-supplied plaintext if given, otherwise generate one
+        plaintext = (
+            plaintext_token if plaintext_token is not None else self.generate_plaintext_token(scope)
+        )
 
         # Hash the token for storage
         token_hash = self._hash_token(plaintext)
@@ -353,8 +403,12 @@ class TokenService:
         """
         return _SCOPE_LEVELS[token_scope] >= _SCOPE_LEVELS[required_scope]
 
-    def _generate_plaintext_token(self, scope: TokenScope) -> str:
-        """Generate a new plaintext token with appropriate prefix.
+    def generate_plaintext_token(self, scope: TokenScope) -> str:
+        """Generate a new plaintext token with appropriate prefix, without persisting it.
+
+        Public so callers can generate-then-deliver-then-persist (e.g. the admin
+        token's sink-delivery flow in magpie.ctl.commands.init/token, which must
+        confirm delivery succeeded before writing anything to the database).
 
         Args:
             scope: Token scope (determines prefix).

--- a/src/magpie/auth/token_sink.py
+++ b/src/magpie/auth/token_sink.py
@@ -111,15 +111,19 @@ def _deliver_file(token: str, settings: MagpieSettings) -> None:
         path.parent.mkdir(parents=True, exist_ok=True)
         # O_NOFOLLOW rejects the open outright if `path` is a symlink, so a
         # pre-placed symlink at the configured path can't redirect the
-        # plaintext token to an attacker-controlled location. O_CREAT with
-        # mode=0o600 covers the common case; chmod afterward guarantees 0600
-        # regardless of umask or a pre-existing file's mode. os.fdopen takes
-        # ownership of fd and closes it (even on error) via the context
-        # manager.
+        # plaintext token to an attacker-controlled location. mode=0o600 on
+        # O_CREAT only applies when the file is newly created -- if `path`
+        # already exists (e.g. an attacker pre-placed a 0666 file to widen
+        # the window), O_TRUNC truncates it but leaves its existing mode
+        # alone. So fchmod the fd to 0600 BEFORE writing any token bytes,
+        # rather than chmod-ing the path afterward: the token is never
+        # written into a file with a wider-than-0600 mode, even briefly.
+        # os.fdopen takes ownership of fd and closes it (even on error) via
+        # the context manager.
         fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW, 0o600)
+        os.fchmod(fd, 0o600)
         with os.fdopen(fd, "w") as f:
             f.write(token + "\n")
-        os.chmod(path, 0o600)
     except OSError as e:
         raise TokenSinkError(f"admin token file sink failed to write {path}: {e}") from e
 

--- a/src/magpie/auth/token_sink.py
+++ b/src/magpie/auth/token_sink.py
@@ -100,7 +100,8 @@ def _deliver_file(token: str, settings: MagpieSettings) -> None:
     """Write the token to a root-only (0600) file.
 
     Raises:
-        TokenSinkError: If the path is unset or the file can't be written.
+        TokenSinkError: If the path is unset, the file can't be written, or
+            the path is a symlink (rejected -- see O_NOFOLLOW below).
     """
     path = settings.admin_token_sink_file_path
     if path is None:  # pragma: no cover - guarded by config's derive_paths()
@@ -108,11 +109,14 @@ def _deliver_file(token: str, settings: MagpieSettings) -> None:
 
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
-        # O_CREAT with mode=0o600 covers the common case; chmod afterward
-        # guarantees 0600 regardless of umask or a pre-existing file's mode.
-        # os.fdopen takes ownership of fd and closes it (even on error) via
-        # the context manager.
-        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        # O_NOFOLLOW rejects the open outright if `path` is a symlink, so a
+        # pre-placed symlink at the configured path can't redirect the
+        # plaintext token to an attacker-controlled location. O_CREAT with
+        # mode=0o600 covers the common case; chmod afterward guarantees 0600
+        # regardless of umask or a pre-existing file's mode. os.fdopen takes
+        # ownership of fd and closes it (even on error) via the context
+        # manager.
+        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW, 0o600)
         with os.fdopen(fd, "w") as f:
             f.write(token + "\n")
         os.chmod(path, 0o600)
@@ -151,10 +155,16 @@ def _deliver_exec(token: str, settings: MagpieSettings) -> None:
         raise TokenSinkError(f"admin token exec sink failed to run {argv[0]!r}: {e}") from e
 
     if result.returncode != 0:
-        stderr = result.stderr.decode("utf-8", errors="replace").strip()
+        # Deliberately excludes the child's stderr text: the token is on its
+        # stdin, and a command that echoes stdin (or otherwise reflects its
+        # input) on failure could leak the token into this exception's
+        # message -- which callers may then print or log. Report only the
+        # byte count, never the content.
+        stderr_len = len(result.stderr)
         raise TokenSinkError(
             f"admin token exec sink command {argv[0]!r} exited with status "
-            f"{result.returncode}: {stderr or '(no stderr output)'}"
+            f"{result.returncode} ({stderr_len} byte(s) on stderr, omitted from this "
+            "error to avoid the risk of an echoed token leaking into logs)"
         )
 
 

--- a/src/magpie/auth/token_sink.py
+++ b/src/magpie/auth/token_sink.py
@@ -1,0 +1,184 @@
+"""Delivery sinks for the admin bootstrap token.
+
+magpie is both the *generator* and the *deliverer* of the first-boot admin
+token, so no secret needs to pre-exist for an operator to provision.
+``deliver_admin_token`` dispatches to one of four sinks selected by
+``MAGPIE_ADMIN_TOKEN_SINK``:
+
+- ``file``: write the token to a root-only (0600) file.
+- ``exec``: pipe the token to an operator-configured command via stdin only
+  (never argv or env), so it can't leak via ``ps`` or ``/proc/<pid>/environ``.
+- ``discard``: deliver nothing. The operator mints a token later via an
+  interactive ``magpie-ctl token create --scope admin``, which prints to
+  their exec session (not the container log stream) and is therefore safe.
+- ``stdout``: print the token to stdout. Opt-in only; never the default.
+
+Fail-closed: ``file`` and ``exec`` raise ``TokenSinkError`` on any delivery
+failure. Callers MUST treat this as fatal and abort rather than start serving
+with a generated-but-undelivered token. ``discard`` never raises -- silence is
+the intended behavior, not a failure.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import subprocess  # nosec B404 - operator-configured command, no shell=True, token via stdin only
+from typing import TYPE_CHECKING
+
+import click
+
+from magpie.cli.formatting import is_json_output
+
+if TYPE_CHECKING:
+    from magpie.config import MagpieSettings
+
+
+class TokenSinkError(RuntimeError):
+    """Raised when the admin token sink is unconfigured or fails to deliver.
+
+    Never includes the token value in its message.
+    """
+
+
+def deliver_admin_token(token: str, settings: MagpieSettings, *, action: str) -> None:
+    """Deliver a freshly generated or rotated admin token via the configured sink.
+
+    Emits a valueless structured log event (``admin_token_generated``) naming
+    the sink used -- never the token value -- once delivery succeeds (or is
+    intentionally skipped, for ``discard``).
+
+    Args:
+        token: Plaintext admin token to deliver.
+        settings: MagpieSettings with admin_token_sink and sink-specific options.
+        action: Short label for what triggered delivery (e.g. "init" or
+            "rotate"), included in the log event for auditability.
+
+    Raises:
+        TokenSinkError: If no sink is configured, or a delivering sink
+            (file/exec) fails to deliver the token. Callers must abort
+            startup/the command on this error and must not start serving.
+    """
+    sink = settings.admin_token_sink
+    if sink is None:
+        raise TokenSinkError(
+            "MAGPIE_ADMIN_TOKEN_SINK is not set. An explicit sink is required "
+            "(file, exec, discard, or stdout) -- there is no default, by design. "
+            "See docs/installation.md for details."
+        )
+
+    if sink == "file":
+        _deliver_file(token, settings)
+    elif sink == "exec":
+        _deliver_exec(token, settings)
+    elif sink == "discard":
+        pass  # Intentional non-delivery; not a failure.
+    elif sink == "stdout":
+        _deliver_stdout(token)
+    else:  # pragma: no cover - guarded by Literal type at the config layer
+        raise TokenSinkError(f"Unknown admin token sink: {sink}")
+
+    _log_admin_token_generated(sink, action)
+
+
+def _log_admin_token_generated(sink: str, action: str) -> None:
+    """Emit a valueless structured log line naming the sink used -- never the token.
+
+    Written directly to stderr (never stdout, which is reserved for command
+    output -- e.g. `--format json` payloads). This is intentionally
+    independent of structlog's global configuration: magpie-ctl commands
+    don't consistently configure it, and structlog's per-module logger
+    caching makes ad hoc reconfiguration within a single process unreliable
+    (see the caution around `cache_logger_on_first_use` in gc.py).
+    """
+    event = {"event": "admin_token_generated", "sink": sink, "action": action}
+    click.echo(json.dumps(event, sort_keys=True), err=True)
+
+
+def _deliver_file(token: str, settings: MagpieSettings) -> None:
+    """Write the token to a root-only (0600) file.
+
+    Raises:
+        TokenSinkError: If the path is unset or the file can't be written.
+    """
+    path = settings.admin_token_sink_file_path
+    if path is None:  # pragma: no cover - guarded by config's derive_paths()
+        raise TokenSinkError("MAGPIE_ADMIN_TOKEN_SINK_FILE_PATH is not set for sink=file")
+
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        # O_CREAT with mode=0o600 covers the common case; chmod afterward
+        # guarantees 0600 regardless of umask or a pre-existing file's mode.
+        # os.fdopen takes ownership of fd and closes it (even on error) via
+        # the context manager.
+        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(fd, "w") as f:
+            f.write(token + "\n")
+        os.chmod(path, 0o600)
+    except OSError as e:
+        raise TokenSinkError(f"admin token file sink failed to write {path}: {e}") from e
+
+
+def _deliver_exec(token: str, settings: MagpieSettings) -> None:
+    """Pipe the token to a configured command's stdin; never argv or env.
+
+    Raises:
+        TokenSinkError: If the command is unset, unparsable, fails to start,
+            times out, or exits non-zero.
+    """
+    command = settings.admin_token_sink_exec_command
+    if not command:  # pragma: no cover - guarded by caller in practice
+        raise TokenSinkError("MAGPIE_ADMIN_TOKEN_SINK_EXEC_COMMAND is not set for sink=exec")
+
+    try:
+        argv = shlex.split(command)
+    except ValueError as e:
+        raise TokenSinkError(f"admin token exec sink command could not be parsed: {e}") from e
+
+    if not argv:
+        raise TokenSinkError("admin token exec sink command is empty after parsing")
+
+    try:
+        result = subprocess.run(  # nosec B603 - operator-configured command, token via stdin only
+            argv,
+            input=token.encode("utf-8"),
+            capture_output=True,
+            timeout=settings.admin_token_sink_exec_timeout,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as e:
+        raise TokenSinkError(f"admin token exec sink failed to run {argv[0]!r}: {e}") from e
+
+    if result.returncode != 0:
+        stderr = result.stderr.decode("utf-8", errors="replace").strip()
+        raise TokenSinkError(
+            f"admin token exec sink command {argv[0]!r} exited with status "
+            f"{result.returncode}: {stderr or '(no stderr output)'}"
+        )
+
+
+def _deliver_stdout(token: str) -> None:
+    """Print the token to stdout with an explicit insecurity warning.
+
+    In `--format json` mode, the caller is responsible for embedding the
+    token in its own JSON payload instead -- printing this human-oriented
+    banner there would corrupt that machine-readable stdout output. The
+    warning itself is still surfaced, on stderr, in that mode.
+    """
+    if is_json_output():
+        click.echo(
+            "WARNING: MAGPIE_ADMIN_TOKEN_SINK=stdout is insecure -- the admin token "
+            "is included in this JSON output and will be captured by container logs "
+            "and any log shippers.",
+            err=True,
+        )
+        return
+
+    click.echo("")
+    click.echo("=" * 60)
+    click.echo("WARNING: MAGPIE_ADMIN_TOKEN_SINK=stdout is insecure -- this token")
+    click.echo("WILL be captured by container logs and any log shippers.")
+    click.echo("ADMIN TOKEN (store securely, only shown once!):")
+    click.echo(token)
+    click.echo("=" * 60)

--- a/src/magpie/config.py
+++ b/src/magpie/config.py
@@ -64,6 +64,22 @@ class MagpieSettings(BaseSettings):
     # Test endpoints (NEVER enable in production)
     enable_test_endpoints: bool = False  # MAGPIE_ENABLE_TEST_ENDPOINTS
 
+    # Admin bootstrap token delivery (see docs/installation.md "Admin Token Delivery")
+    # No default: an explicit sink choice is required (fail-closed). See
+    # magpie.auth.token_sink for the sinks themselves and their failure semantics.
+    admin_token_sink: Literal["file", "exec", "discard", "stdout"] | None = (
+        None  # MAGPIE_ADMIN_TOKEN_SINK
+    )
+    # Path for sink=file. Defaults to a sibling of database_path (typically /data)
+    # if unset; see derive_paths().
+    admin_token_sink_file_path: Path | None = None  # MAGPIE_ADMIN_TOKEN_SINK_FILE_PATH
+    # Shell-style command line for sink=exec (parsed with shlex, never run through a
+    # shell). The token is piped to the command's stdin only -- never argv or env.
+    admin_token_sink_exec_command: str | None = None  # MAGPIE_ADMIN_TOKEN_SINK_EXEC_COMMAND
+    admin_token_sink_exec_timeout: float = Field(
+        default=30.0, gt=0.0
+    )  # MAGPIE_ADMIN_TOKEN_SINK_EXEC_TIMEOUT_SECONDS
+
     @field_validator("allowed_cidrs")
     @classmethod
     def validate_cidrs(cls, v: str) -> str:
@@ -94,9 +110,11 @@ class MagpieSettings(BaseSettings):
 
     @model_validator(mode="after")
     def derive_paths(self) -> Self:
-        """Derive temp_path from storage_path if not set."""
+        """Derive temp_path and admin_token_sink_file_path if not set."""
         if self.temp_path is None:
             self.temp_path = self.storage_path / ".tmp"
+        if self.admin_token_sink_file_path is None:
+            self.admin_token_sink_file_path = self.database_path.parent / "admin-token"
         return self
 
 

--- a/src/magpie/config.py
+++ b/src/magpie/config.py
@@ -76,8 +76,12 @@ class MagpieSettings(BaseSettings):
     # Shell-style command line for sink=exec (parsed with shlex, never run through a
     # shell). The token is piped to the command's stdin only -- never argv or env.
     admin_token_sink_exec_command: str | None = None  # MAGPIE_ADMIN_TOKEN_SINK_EXEC_COMMAND
+    # NOTE: explicit validation_alias because "timeout" alone (the field name,
+    # which env_prefix + field-name derivation would produce as
+    # MAGPIE_ADMIN_TOKEN_SINK_EXEC_TIMEOUT) is ambiguous about units; the
+    # documented/compose-file variable name carries the unit instead.
     admin_token_sink_exec_timeout: float = Field(
-        default=30.0, gt=0.0
+        default=30.0, gt=0.0, validation_alias="MAGPIE_ADMIN_TOKEN_SINK_EXEC_TIMEOUT_SECONDS"
     )  # MAGPIE_ADMIN_TOKEN_SINK_EXEC_TIMEOUT_SECONDS
 
     @field_validator("allowed_cidrs")

--- a/src/magpie/ctl/commands/init.py
+++ b/src/magpie/ctl/commands/init.py
@@ -6,13 +6,15 @@ from typing import TYPE_CHECKING
 
 import click
 
-from magpie.auth.database import init_database
+from magpie.auth.database import get_connection, get_token_by_name, init_database
 from magpie.auth.models import TokenScope
-from magpie.auth.service import TokenExistsError, TokenFormatError, TokenService
+from magpie.auth.service import TokenError, TokenExistsError, TokenFormatError, TokenService
 from magpie.auth.token_sink import TokenSinkError, deliver_admin_token
 from magpie.cli.formatting import (
     CommandResult,
+    ErrorCode,
     is_json_output,
+    output_error,
     output_result,
 )
 from magpie.ctl import CTLContext
@@ -23,21 +25,49 @@ if TYPE_CHECKING:
 ADMIN_TOKEN_NAME = "admin"  # nosec B105 - not a password, just a token name
 
 
+def _admin_token_exists(settings: MagpieSettings) -> bool:
+    """Check (read-only) whether an admin token is already persisted.
+
+    Used to decide whether a new admin token candidate needs to be
+    generated and delivered at all, and (for --reset-admin-token) purely
+    for the "revoked existing" vs. "no existing token" status message --
+    it never gates a DB write on its own.
+    """
+    conn = get_connection(settings.database_path)
+    try:
+        return get_token_by_name(conn, ADMIN_TOKEN_NAME) is not None
+    finally:
+        conn.close()
+
+
 def _abort_on_sink_error(e: TokenSinkError) -> None:
     """Report a fatal token delivery failure and abort (fail-closed).
 
-    A generated-but-undelivered admin token is a liability, not a degraded
-    feature: the server must not start.
+    Called BEFORE any database mutation for the generated/candidate token,
+    for every admin-token-delivering path (first-boot init,
+    --reset-admin-token, and token rotate admin in token.py) -- so a
+    delivery failure here never destroys an existing, working admin token
+    and never leaves an orphaned, undelivered one in the database. See
+    docs/installation.md "Admin Token Delivery" for the full guarantee.
     """
     if is_json_output():
-        output_result(
-            CommandResult(
-                data={"error": str(e)},
-                human_output="",
-            )
-        )
-    else:
-        click.echo(f"Error: {e}", err=True)
+        output_error(ErrorCode.IO_ERROR, str(e))  # writes to stderr and exits; never returns
+    click.echo(f"Error: {e}", err=True)
+    raise SystemExit(1)
+
+
+def _abort_on_persist_error(e: TokenError) -> None:
+    """Report a fatal (and extremely unlikely) persistence failure and abort.
+
+    Reached only if a hash collision occurs while persisting a token whose
+    value has *already* been successfully delivered via the sink -- the
+    delivered value exists at the sink but couldn't be written to the
+    database. This is exceptionally rare (see TokenService.replace_token);
+    surfaced as a hard error rather than silently continuing.
+    """
+    if is_json_output():
+        output_error(ErrorCode.CONFLICT, str(e))  # writes to stderr and exits; never returns
+    click.echo(f"Error: {e}", err=True)
     raise SystemExit(1)
 
 
@@ -82,9 +112,14 @@ def init(ctx: CTLContext, reset_admin_token: bool, admin_token: str | None) -> N
 
     The admin token is delivered via the sink configured by
     MAGPIE_ADMIN_TOKEN_SINK (file/exec/discard/stdout) -- it is never printed
-    to stdout unless sink=stdout is explicitly chosen. A delivering sink
-    (file/exec) that fails to deliver aborts init with a non-zero exit; the
-    server does not start.
+    to stdout unless sink=stdout is explicitly chosen. Delivery is always
+    attempted BEFORE any database change: a delivering sink (file/exec) that
+    fails leaves the database untouched. On first boot that means no admin
+    token exists yet and the server does not start (matching entrypoint.sh's
+    retry-on-failure behavior); for --reset-admin-token (typically run via
+    `docker exec` against an already-running server), it means the existing
+    admin token is left valid and unchanged -- nothing is lost, and the
+    command can simply be retried once the sink is fixed.
 
     Use --reset-admin-token to revoke the existing admin token and
     generate a new one (useful if the token was compromised). The new
@@ -127,116 +162,139 @@ def init(ctx: CTLContext, reset_admin_token: bool, admin_token: str | None) -> N
     if not is_json_output():
         click.echo(f"Database initialized at: {settings.database_path}")
 
-    # Create or reset admin token
     token_service = TokenService(settings)
     plaintext_token: str | None = None
     token_already_exists = False
     delivered_sink: str | None = None
 
-    # Validate custom token format early (before revoking existing token)
+    # Validate custom token format early (cheap, no side effects; before any
+    # generation, delivery, or database change).
     if admin_token is not None:
         if not admin_token.startswith("mgp_ADMIN_"):
             error_msg = "Provided token must start with 'mgp_ADMIN_' for admin scope"
             if is_json_output():
-                output_result(
-                    CommandResult(
-                        data={"error": error_msg},
-                        human_output="",
-                    )
-                )
+                output_result(CommandResult(data={"error": error_msg}, human_output=""))
             else:
                 click.echo(f"Error: {error_msg}", err=True)
             raise SystemExit(1)
         if len(admin_token) <= len("mgp_ADMIN_"):
             error_msg = "Provided token is too short (must have content after 'mgp_ADMIN_' prefix)"
             if is_json_output():
-                output_result(
-                    CommandResult(
-                        data={"error": error_msg},
-                        human_output="",
-                    )
-                )
+                output_result(CommandResult(data={"error": error_msg}, human_output=""))
             else:
                 click.echo(f"Error: {error_msg}", err=True)
             raise SystemExit(1)
 
     if reset_admin_token:
-        # Revoke existing admin token first
-        if ctx.debug:
-            click.echo(f"Revoking existing admin token: {ADMIN_TOKEN_NAME}", err=True)
-        revoked = token_service.revoke_token(ADMIN_TOKEN_NAME)
-        if revoked and not is_json_output():
-            click.echo(f"Revoked existing admin token: {ADMIN_TOKEN_NAME}")
-        elif not revoked and not is_json_output():
-            click.echo("No existing admin token found to revoke")
+        # Determine the plaintext to deliver -- nothing is persisted yet.
+        plaintext_candidate = (
+            admin_token
+            if admin_token is not None
+            else token_service.generate_plaintext_token(TokenScope.ADMIN)
+        )
 
-        # Create new admin token (with provided token if specified)
+        # Deliver BEFORE touching the database. Fail-closed: on failure, no
+        # DB change has happened at all -- any existing admin token is left
+        # exactly as it was.
         try:
-            plaintext_token = token_service.create_token(
-                ADMIN_TOKEN_NAME, TokenScope.ADMIN, admin_token
-            )
-        except TokenFormatError as e:
-            # Token format validation failed
-            if is_json_output():
-                output_result(
-                    CommandResult(
-                        data={
-                            "error": str(e),
-                        },
-                        human_output="",
-                    )
-                )
-            else:
-                click.echo(f"Error: {e}", err=True)
-            raise SystemExit(1)
-
-        # Deliver the new token via the configured sink. Fail-closed: a
-        # delivery failure aborts init and the server does not start.
-        try:
-            deliver_admin_token(plaintext_token, settings, action="reset")
+            deliver_admin_token(plaintext_candidate, settings, action="reset")
         except TokenSinkError as e:
             _abort_on_sink_error(e)
+
         delivered_sink = settings.admin_token_sink
-        _echo_delivery_status(delivered_sink, settings)
-    else:
-        # Try to create admin token (may fail if already exists)
-        try:
-            plaintext_token = token_service.create_token(
-                ADMIN_TOKEN_NAME, TokenScope.ADMIN, admin_token
-            )
-        except TokenExistsError:
-            # Token already exists -- this is not first boot, so no new
-            # token was generated and nothing needs to be delivered. The
-            # sink does not need to be configured for this to succeed.
-            token_already_exists = True
+        had_existing = _admin_token_exists(settings)
+
+        if delivered_sink == "discard":
+            # Explicit non-retention: the operator's --reset-admin-token
+            # request still means "revoke whatever is there," but the newly
+            # generated value is never persisted -- matching discard's
+            # "retain no usable token" contract.
+            if ctx.debug:
+                click.echo(f"Revoking existing admin token: {ADMIN_TOKEN_NAME}", err=True)
+            token_service.revoke_token(ADMIN_TOKEN_NAME)
             plaintext_token = None
+            if not is_json_output():
+                click.echo(
+                    f"Revoked existing admin token: {ADMIN_TOKEN_NAME}"
+                    if had_existing
+                    else "No existing admin token found to revoke"
+                )
+                _echo_delivery_status(delivered_sink, settings)
+        else:
+            # Delivery succeeded: atomically revoke-if-present + persist the
+            # delivered value as a single DB transaction.
+            try:
+                token_service.replace_token(ADMIN_TOKEN_NAME, TokenScope.ADMIN, plaintext_candidate)
+            except TokenError as e:
+                _abort_on_persist_error(e)
+            plaintext_token = plaintext_candidate
+            if not is_json_output():
+                click.echo(
+                    f"Revoked existing admin token: {ADMIN_TOKEN_NAME}"
+                    if had_existing
+                    else "No existing admin token found to revoke"
+                )
+                _echo_delivery_status(delivered_sink, settings)
+    else:
+        # First boot only: check existence first (read-only) so a token is
+        # never generated and delivered needlessly when one already exists.
+        if _admin_token_exists(settings):
+            token_already_exists = True
             if not is_json_output():
                 click.echo("")
                 click.echo("Admin token already exists. Use --reset-admin-token to regenerate.")
-        except TokenFormatError as e:
-            # Token format validation failed
-            if is_json_output():
-                output_result(
-                    CommandResult(
-                        data={
-                            "error": str(e),
-                        },
-                        human_output="",
-                    )
-                )
-            else:
-                click.echo(f"Error: {e}", err=True)
-            raise SystemExit(1)
         else:
-            # First boot: deliver the freshly generated token via the
-            # configured sink. Fail-closed: a delivery failure aborts init
-            # and the server does not start.
+            plaintext_candidate = (
+                admin_token
+                if admin_token is not None
+                else token_service.generate_plaintext_token(TokenScope.ADMIN)
+            )
+
+            # Deliver BEFORE touching the database. Fail-closed: on failure,
+            # no admin token exists in the database, and the server does
+            # not start (entrypoint.sh removes the incomplete database and
+            # retries on next boot).
             try:
-                deliver_admin_token(plaintext_token, settings, action="init")
+                deliver_admin_token(plaintext_candidate, settings, action="init")
             except TokenSinkError as e:
                 _abort_on_sink_error(e)
+
             delivered_sink = settings.admin_token_sink
-            _echo_delivery_status(delivered_sink, settings)
+
+            if delivered_sink == "discard":
+                # Generate-and-immediately-drop: never persisted.
+                plaintext_token = None
+                if not is_json_output():
+                    _echo_delivery_status(delivered_sink, settings)
+            else:
+                try:
+                    plaintext_token = token_service.create_token(
+                        ADMIN_TOKEN_NAME, TokenScope.ADMIN, plaintext_candidate
+                    )
+                except TokenExistsError:
+                    # Lost a narrow race against a concurrent init (only
+                    # possible outside entrypoint.sh's flock-protected first
+                    # boot, e.g. two manual invocations at once). The token
+                    # we just delivered is not the one that ended up active;
+                    # report the existing-token case instead.
+                    token_already_exists = True
+                    plaintext_token = None
+                    delivered_sink = None
+                    if not is_json_output():
+                        click.echo("")
+                        click.echo(
+                            "Admin token already exists (lost a race with a concurrent "
+                            "init). Use --reset-admin-token to regenerate."
+                        )
+                except TokenFormatError as e:  # pragma: no cover - guarded by validation above
+                    if is_json_output():
+                        output_result(CommandResult(data={"error": str(e)}, human_output=""))
+                    else:
+                        click.echo(f"Error: {e}", err=True)
+                    raise SystemExit(1)
+                else:
+                    if not is_json_output():
+                        _echo_delivery_status(delivered_sink, settings)
 
     # JSON output. The token value is only ever included when sink=stdout was
     # explicitly chosen -- for all other sinks, JSON output (which also goes

--- a/src/magpie/ctl/commands/init.py
+++ b/src/magpie/ctl/commands/init.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import click
 
 from magpie.auth.database import init_database
 from magpie.auth.models import TokenScope
 from magpie.auth.service import TokenExistsError, TokenFormatError, TokenService
+from magpie.auth.token_sink import TokenSinkError, deliver_admin_token
 from magpie.cli.formatting import (
     CommandResult,
     is_json_output,
@@ -14,7 +17,49 @@ from magpie.cli.formatting import (
 )
 from magpie.ctl import CTLContext
 
+if TYPE_CHECKING:
+    from magpie.config import MagpieSettings
+
 ADMIN_TOKEN_NAME = "admin"  # nosec B105 - not a password, just a token name
+
+
+def _abort_on_sink_error(e: TokenSinkError) -> None:
+    """Report a fatal token delivery failure and abort (fail-closed).
+
+    A generated-but-undelivered admin token is a liability, not a degraded
+    feature: the server must not start.
+    """
+    if is_json_output():
+        output_result(
+            CommandResult(
+                data={"error": str(e)},
+                human_output="",
+            )
+        )
+    else:
+        click.echo(f"Error: {e}", err=True)
+    raise SystemExit(1)
+
+
+def _echo_delivery_status(sink: str | None, settings: MagpieSettings) -> None:
+    """Print a human-readable summary of how the admin token was delivered.
+
+    The token value itself is never echoed here -- the ``stdout`` sink prints
+    the value itself (with a warning) as part of delivery, so nothing further
+    is added for that case.
+    """
+    if is_json_output() or sink == "stdout":
+        return
+
+    click.echo("")
+    if sink == "file":
+        click.echo(f"Admin token delivered via 'file' sink: {settings.admin_token_sink_file_path}")
+    elif sink == "exec":
+        click.echo("Admin token delivered via 'exec' sink.")
+    elif sink == "discard":
+        click.echo("No bootstrap admin token was retained (sink=discard).")
+        click.echo("Mint one when ready via an interactive session:")
+        click.echo("  magpie-ctl token create --name ops-admin --scope admin")
 
 
 @click.command()
@@ -35,11 +80,15 @@ def init(ctx: CTLContext, reset_admin_token: bool, admin_token: str | None) -> N
     Creates storage directories and SQLite database if they don't exist.
     Generates a break-glass admin token on first run.
 
-    The admin token is printed to stdout and is ONLY VISIBLE ONCE.
-    Store it securely!
+    The admin token is delivered via the sink configured by
+    MAGPIE_ADMIN_TOKEN_SINK (file/exec/discard/stdout) -- it is never printed
+    to stdout unless sink=stdout is explicitly chosen. A delivering sink
+    (file/exec) that fails to deliver aborts init with a non-zero exit; the
+    server does not start.
 
     Use --reset-admin-token to revoke the existing admin token and
-    generate a new one (useful if the token was compromised).
+    generate a new one (useful if the token was compromised). The new
+    token is delivered through the same configured sink.
 
     Use --admin-token to specify a custom token instead of generating
     a random one. The token must start with 'mgp_ADMIN_'.
@@ -82,6 +131,7 @@ def init(ctx: CTLContext, reset_admin_token: bool, admin_token: str | None) -> N
     token_service = TokenService(settings)
     plaintext_token: str | None = None
     token_already_exists = False
+    delivered_sink: str | None = None
 
     # Validate custom token format early (before revoking existing token)
     if admin_token is not None:
@@ -140,27 +190,26 @@ def init(ctx: CTLContext, reset_admin_token: bool, admin_token: str | None) -> N
                 click.echo(f"Error: {e}", err=True)
             raise SystemExit(1)
 
-        if not is_json_output():
-            click.echo("")
-            click.echo("=" * 60)
-            click.echo("NEW ADMIN TOKEN (store securely, only shown once!):")
-            click.echo(plaintext_token)
-            click.echo("=" * 60)
+        # Deliver the new token via the configured sink. Fail-closed: a
+        # delivery failure aborts init and the server does not start.
+        try:
+            deliver_admin_token(plaintext_token, settings, action="reset")
+        except TokenSinkError as e:
+            _abort_on_sink_error(e)
+        delivered_sink = settings.admin_token_sink
+        _echo_delivery_status(delivered_sink, settings)
     else:
         # Try to create admin token (may fail if already exists)
         try:
             plaintext_token = token_service.create_token(
                 ADMIN_TOKEN_NAME, TokenScope.ADMIN, admin_token
             )
-            if not is_json_output():
-                click.echo("")
-                click.echo("=" * 60)
-                click.echo("ADMIN TOKEN (store securely, only shown once!):")
-                click.echo(plaintext_token)
-                click.echo("=" * 60)
         except TokenExistsError:
-            # Token already exists
+            # Token already exists -- this is not first boot, so no new
+            # token was generated and nothing needs to be delivered. The
+            # sink does not need to be configured for this to succeed.
             token_already_exists = True
+            plaintext_token = None
             if not is_json_output():
                 click.echo("")
                 click.echo("Admin token already exists. Use --reset-admin-token to regenerate.")
@@ -178,13 +227,27 @@ def init(ctx: CTLContext, reset_admin_token: bool, admin_token: str | None) -> N
             else:
                 click.echo(f"Error: {e}", err=True)
             raise SystemExit(1)
+        else:
+            # First boot: deliver the freshly generated token via the
+            # configured sink. Fail-closed: a delivery failure aborts init
+            # and the server does not start.
+            try:
+                deliver_admin_token(plaintext_token, settings, action="init")
+            except TokenSinkError as e:
+                _abort_on_sink_error(e)
+            delivered_sink = settings.admin_token_sink
+            _echo_delivery_status(delivered_sink, settings)
 
-    # JSON output
+    # JSON output. The token value is only ever included when sink=stdout was
+    # explicitly chosen -- for all other sinks, JSON output (which also goes
+    # to stdout) must not leak it either.
     if is_json_output():
+        json_token = plaintext_token if delivered_sink == "stdout" else None
         output_result(
             CommandResult(
                 data={
-                    "admin_token": plaintext_token,
+                    "admin_token": json_token,
+                    "admin_token_sink": delivered_sink,
                     "storage_path": str(settings.storage_path),
                     "database_path": str(settings.database_path),
                     "token_already_existed": token_already_exists,

--- a/src/magpie/ctl/commands/init.py
+++ b/src/magpie/ctl/commands/init.py
@@ -173,16 +173,14 @@ def init(ctx: CTLContext, reset_admin_token: bool, admin_token: str | None) -> N
         if not admin_token.startswith("mgp_ADMIN_"):
             error_msg = "Provided token must start with 'mgp_ADMIN_' for admin scope"
             if is_json_output():
-                output_result(CommandResult(data={"error": error_msg}, human_output=""))
-            else:
-                click.echo(f"Error: {error_msg}", err=True)
+                output_error(ErrorCode.VALIDATION_ERROR, error_msg)  # exits; never returns
+            click.echo(f"Error: {error_msg}", err=True)
             raise SystemExit(1)
         if len(admin_token) <= len("mgp_ADMIN_"):
             error_msg = "Provided token is too short (must have content after 'mgp_ADMIN_' prefix)"
             if is_json_output():
-                output_result(CommandResult(data={"error": error_msg}, human_output=""))
-            else:
-                click.echo(f"Error: {error_msg}", err=True)
+                output_error(ErrorCode.VALIDATION_ERROR, error_msg)  # exits; never returns
+            click.echo(f"Error: {error_msg}", err=True)
             raise SystemExit(1)
 
     if reset_admin_token:
@@ -288,9 +286,8 @@ def init(ctx: CTLContext, reset_admin_token: bool, admin_token: str | None) -> N
                         )
                 except TokenFormatError as e:  # pragma: no cover - guarded by validation above
                     if is_json_output():
-                        output_result(CommandResult(data={"error": str(e)}, human_output=""))
-                    else:
-                        click.echo(f"Error: {e}", err=True)
+                        output_error(ErrorCode.VALIDATION_ERROR, str(e))  # exits; never returns
+                    click.echo(f"Error: {e}", err=True)
                     raise SystemExit(1)
                 else:
                     if not is_json_output():

--- a/src/magpie/ctl/commands/token.py
+++ b/src/magpie/ctl/commands/token.py
@@ -321,12 +321,14 @@ def token_rotate(ctx: CTLContext, name: str) -> None:
 
         click.echo("")
         click.echo(f"TOKEN ROTATED: {name} (scope: {scope.value})")
-        if sink == "discard":
+        if sink == "file":
+            click.echo(f"Delivered via 'file' sink: {settings.admin_token_sink_file_path}")
+        elif sink == "exec":
+            click.echo("Delivered via 'exec' sink.")
+        elif sink == "discard":
             click.echo("No bootstrap admin token was retained (sink=discard).")
             click.echo("Mint one when ready via an interactive session:")
             click.echo("  magpie-ctl token create --name ops-admin --scope admin")
-        elif sink != "stdout":
-            click.echo(f"Delivered via sink: {sink}")
         return
 
     try:

--- a/src/magpie/ctl/commands/token.py
+++ b/src/magpie/ctl/commands/token.py
@@ -7,6 +7,7 @@ import click
 from magpie.auth.database import get_connection, list_tokens
 from magpie.auth.models import TokenScope
 from magpie.auth.service import TokenError, TokenService
+from magpie.auth.token_sink import TokenSinkError, deliver_admin_token
 from magpie.cli.formatting import (
     CommandResult,
     ErrorCode,
@@ -15,6 +16,7 @@ from magpie.cli.formatting import (
     output_result,
 )
 from magpie.ctl import CTLContext
+from magpie.ctl.commands.init import ADMIN_TOKEN_NAME
 from magpie.validation import ValidationError
 
 
@@ -216,8 +218,12 @@ def token_rotate(ctx: CTLContext, name: str) -> None:
     Revokes the existing token and creates a new one with the same name
     and scope. This is an atomic operation.
 
-    The new token is printed to stdout and is ONLY VISIBLE ONCE.
-    Store it securely!
+    The new token is printed to stdout and is ONLY VISIBLE ONCE. Store it
+    securely! EXCEPTION: rotating the break-glass admin token (name "admin")
+    delivers the new token via the same MAGPIE_ADMIN_TOKEN_SINK used by
+    `magpie-ctl init`, not directly to stdout, to keep its delivery model
+    consistent across its whole lifecycle. A delivering sink (file/exec)
+    that fails aborts the rotation with a non-zero exit.
 
     NAME is the token name to rotate.
 
@@ -257,6 +263,39 @@ def token_rotate(ctx: CTLContext, name: str) -> None:
 
     # Unpack the result (new_token, scope)
     new_token, scope = result
+
+    # The break-glass admin token is delivered through the same configured
+    # sink as init/reset-admin-token, never printed directly, so its
+    # delivery model stays consistent across its whole lifecycle.
+    if name == ADMIN_TOKEN_NAME:
+        try:
+            deliver_admin_token(new_token, settings, action="rotate")
+        except TokenSinkError as e:
+            if is_json_output():
+                output_error(ErrorCode.IO_ERROR, str(e))
+            else:
+                raise click.ClickException(str(e))
+
+        sink = settings.admin_token_sink
+        if is_json_output():
+            output_result(
+                CommandResult(
+                    data={
+                        "token": new_token if sink == "stdout" else None,
+                        "admin_token_sink": sink,
+                        "name": name,
+                        "scope": scope.value,
+                    },
+                    human_output="",
+                )
+            )
+            return
+
+        if sink != "stdout":
+            click.echo("")
+            click.echo(f"TOKEN ROTATED: {name} (scope: {scope.value})")
+            click.echo(f"Delivered via sink: {sink}")
+        return
 
     # JSON output
     if is_json_output():

--- a/src/magpie/ctl/commands/token.py
+++ b/src/magpie/ctl/commands/token.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import click
 
-from magpie.auth.database import get_connection, list_tokens
+from magpie.auth.database import get_connection, get_token_by_name, list_tokens
 from magpie.auth.models import TokenScope
 from magpie.auth.service import TokenError, TokenService
 from magpie.auth.token_sink import TokenSinkError, deliver_admin_token
@@ -239,6 +239,96 @@ def token_rotate(ctx: CTLContext, name: str) -> None:
     if ctx.debug:
         click.echo(f"Rotating token '{name}'...", err=True)
 
+    # The break-glass admin token is delivered through the same configured
+    # sink as init/reset-admin-token, never printed directly, so its
+    # delivery model stays consistent across its whole lifecycle. Handled
+    # entirely separately from the generic path below: delivery is always
+    # attempted BEFORE any database change, so a delivery failure leaves the
+    # existing admin token completely untouched (see
+    # magpie.ctl.commands.init._abort_on_sink_error for the shared
+    # rationale).
+    if name == ADMIN_TOKEN_NAME:
+        conn = get_connection(settings.database_path)
+        try:
+            existing = get_token_by_name(conn, name)
+        finally:
+            conn.close()
+
+        if existing is None:
+            msg = f"Token not found: {name}"
+            if is_json_output():
+                output_error(ErrorCode.NOT_FOUND, msg)
+            else:
+                raise click.ClickException(msg)
+
+        new_plaintext = token_service.generate_plaintext_token(existing.scope)
+
+        try:
+            deliver_admin_token(new_plaintext, settings, action="rotate")
+        except TokenSinkError as e:
+            # No DB mutation has happened -- the prior admin token, if any,
+            # remains valid and unchanged.
+            if is_json_output():
+                output_error(ErrorCode.IO_ERROR, str(e))
+            else:
+                raise click.ClickException(str(e))
+
+        sink = settings.admin_token_sink
+
+        if sink == "discard":
+            # Explicit non-retention: rotating still means "revoke the old
+            # token" (that's the operator's explicit ask), but the freshly
+            # delivered replacement is never persisted -- matching
+            # discard's "retain no usable token" contract.
+            token_service.revoke_token(name)
+            new_token: str | None = None
+            scope = existing.scope
+        else:
+            # Delivery succeeded: atomically revoke-old + persist the
+            # delivered value as a single DB transaction.
+            try:
+                rotate_result = token_service.rotate_token(name, plaintext_token=new_plaintext)
+            except TokenError as e:
+                # Hash collision during persistence (extremely unlikely):
+                # the value was already delivered but couldn't be written.
+                if is_json_output():
+                    output_error(ErrorCode.CONFLICT, str(e))
+                else:
+                    raise click.ClickException(str(e))
+            if rotate_result is None:
+                # Extremely unlikely TOCTOU: the token was deleted between
+                # our lookup above and this atomic rotate.
+                msg = f"Token not found: {name}"
+                if is_json_output():
+                    output_error(ErrorCode.NOT_FOUND, msg)
+                else:
+                    raise click.ClickException(msg)
+            new_token, scope = rotate_result
+
+        if is_json_output():
+            output_result(
+                CommandResult(
+                    data={
+                        "token": new_token if sink == "stdout" else None,
+                        "admin_token_sink": sink,
+                        "name": name,
+                        "scope": scope.value,
+                    },
+                    human_output="",
+                )
+            )
+            return
+
+        click.echo("")
+        click.echo(f"TOKEN ROTATED: {name} (scope: {scope.value})")
+        if sink == "discard":
+            click.echo("No bootstrap admin token was retained (sink=discard).")
+            click.echo("Mint one when ready via an interactive session:")
+            click.echo("  magpie-ctl token create --name ops-admin --scope admin")
+        elif sink != "stdout":
+            click.echo(f"Delivered via sink: {sink}")
+        return
+
     try:
         result = token_service.rotate_token(name)
     except ValidationError as e:
@@ -263,39 +353,6 @@ def token_rotate(ctx: CTLContext, name: str) -> None:
 
     # Unpack the result (new_token, scope)
     new_token, scope = result
-
-    # The break-glass admin token is delivered through the same configured
-    # sink as init/reset-admin-token, never printed directly, so its
-    # delivery model stays consistent across its whole lifecycle.
-    if name == ADMIN_TOKEN_NAME:
-        try:
-            deliver_admin_token(new_token, settings, action="rotate")
-        except TokenSinkError as e:
-            if is_json_output():
-                output_error(ErrorCode.IO_ERROR, str(e))
-            else:
-                raise click.ClickException(str(e))
-
-        sink = settings.admin_token_sink
-        if is_json_output():
-            output_result(
-                CommandResult(
-                    data={
-                        "token": new_token if sink == "stdout" else None,
-                        "admin_token_sink": sink,
-                        "name": name,
-                        "scope": scope.value,
-                    },
-                    human_output="",
-                )
-            )
-            return
-
-        if sink != "stdout":
-            click.echo("")
-            click.echo(f"TOKEN ROTATED: {name} (scope: {scope.value})")
-            click.echo(f"Delivered via sink: {sink}")
-        return
 
     # JSON output
     if is_json_output():

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -154,6 +154,11 @@ def admin_token(docker_services: dict[str, str]) -> str:
     Runs magpie-ctl init inside the container to get the admin token.
     Uses --reset-admin-token to ensure we always get a fresh token, even if
     one already exists (e.g., from cached Docker volumes or incomplete cleanup).
+
+    Overrides MAGPIE_ADMIN_TOKEN_SINK=stdout for just this `docker compose
+    exec` invocation so the token is scraped from stdout below, regardless of
+    docker-compose.yml's own (file-sink) default -- this is the harness
+    reading the token for its own use, not a production delivery path.
     """
     compose_cmd = [
         "docker",
@@ -167,7 +172,17 @@ def admin_token(docker_services: dict[str, str]) -> str:
     # Run magpie-ctl init with --reset-admin-token to ensure we always get a token
     # This handles cases where isolation fails (cached volumes, incomplete cleanup)
     result = subprocess.run(
-        [*compose_cmd, "exec", "-T", "magpie", "magpie-ctl", "init", "--reset-admin-token"],
+        [
+            *compose_cmd,
+            "exec",
+            "-T",
+            "-e",
+            "MAGPIE_ADMIN_TOKEN_SINK=stdout",
+            "magpie",
+            "magpie-ctl",
+            "init",
+            "--reset-admin-token",
+        ],
         cwd=PROJECT_ROOT,
         env=env,
         capture_output=True,
@@ -371,7 +386,8 @@ def cidr_admin_token(cidr_base_url: str) -> str:
     if not token:
         pytest.fail(
             "MAGPIE_CIDR_ADMIN_TOKEN environment variable not set. "
-            "Run 'docker compose exec magpie magpie-ctl init --reset-admin-token' "
+            "Run 'docker compose exec -e MAGPIE_ADMIN_TOKEN_SINK=stdout magpie "
+            "magpie-ctl init --reset-admin-token' "
             "and set the token in the test environment."
         )
 

--- a/tests/integration/test_ctl.py
+++ b/tests/integration/test_ctl.py
@@ -77,6 +77,10 @@ def ctl_runner(tmp_path: Path) -> Generator[tuple[CliRunner, Path], None, None]:
         env_overrides={
             "MAGPIE_STORAGE_PATH": str(tmp_path),
             "MAGPIE_DATABASE_PATH": str(tmp_path / "magpie.db"),
+            # sink=stdout keeps the admin token visible in `result.output` for
+            # these tests, matching pre-#387 behavior. Fail-closed / other sink
+            # behavior is covered separately in TestInitAdminTokenSink below.
+            "MAGPIE_ADMIN_TOKEN_SINK": "stdout",
         }
     )
 
@@ -162,7 +166,7 @@ class TestInit:
         result2 = runner.invoke(ctl_cli, ["init", "--reset-admin-token"])
         assert result2.exit_code == 0
         assert "Revoked existing admin token" in result2.output
-        assert "NEW ADMIN TOKEN" in result2.output
+        assert "ADMIN TOKEN" in result2.output
 
         # Extract new token using regex
         match2 = re.search(r"mgp_ADMIN_[A-Za-z0-9_-]+", result2.output)
@@ -218,7 +222,9 @@ class TestInit:
         result = runner.invoke(ctl_cli, ["--format", "json", "init"])
 
         assert result.exit_code == 0
-        response = json.loads(result.output)
+        # Use .stdout (not the mixed .output) since sink=stdout also emits a
+        # warning on stderr in JSON mode; see token_sink._deliver_stdout.
+        response = json.loads(result.stdout)
 
         # Validate top-level structure
         assert isinstance(response, dict), "Response must be a dict"
@@ -234,7 +240,7 @@ class TestInit:
         assert isinstance(data, dict), "data must be a dict"
 
         # Required fields
-        required_keys = {"admin_token", "storage_path", "database_path"}
+        required_keys = {"admin_token", "admin_token_sink", "storage_path", "database_path"}
         assert required_keys.issubset(data.keys()), (
             f"data must contain required keys: {required_keys}"
         )
@@ -245,9 +251,13 @@ class TestInit:
             f"data contains unexpected keys: {set(data.keys()) - allowed_keys}"
         )
 
-        # Validate required field types
+        # Validate required field types. admin_token is only included in the
+        # JSON payload when sink=stdout was explicitly chosen (as it is by
+        # the ctl_runner fixture here) -- for other sinks it's always None,
+        # even in JSON output, since that's still stdout.
         assert isinstance(data["admin_token"], str), "admin_token must be string"
         assert data["admin_token"].startswith("mgp_"), "admin_token must have mgp_ prefix"
+        assert data["admin_token_sink"] == "stdout"
         assert isinstance(data["storage_path"], str), "storage_path must be string"
         assert isinstance(data["database_path"], str), "database_path must be string"
 
@@ -329,6 +339,100 @@ class TestInit:
             assert len(admin_tokens) == 1, (
                 "Concurrent token creation should result in exactly one admin token (race condition safety)"
             )
+        finally:
+            conn.close()
+
+
+class TestInitAdminTokenSink:
+    """Integration tests for MAGPIE_ADMIN_TOKEN_SINK delivery against real filesystem I/O.
+
+    Uses its own EnvCliRunner (rather than the ctl_runner fixture, which sets
+    sink=stdout for the rest of TestInit) so each test controls the sink
+    explicitly.
+    """
+
+    def test_no_sink_configured_fails_closed(self, tmp_path: Path) -> None:
+        """Init aborts with a non-zero exit and no token in output when no sink is set."""
+        get_settings.cache_clear()
+        runner = EnvCliRunner(
+            env_overrides={
+                "MAGPIE_STORAGE_PATH": str(tmp_path),
+                "MAGPIE_DATABASE_PATH": str(tmp_path / "magpie.db"),
+            }
+        )
+        try:
+            result = runner.invoke(ctl_cli, ["init"])
+        finally:
+            get_settings.cache_clear()
+
+        assert result.exit_code != 0, f"Output: {result.output}"
+        assert "MAGPIE_ADMIN_TOKEN_SINK is not set" in result.output
+        assert "mgp_ADMIN_" not in result.output
+        # Storage and database are still created even though delivery failed --
+        # only the admin token itself was not generated/delivered.
+        assert (tmp_path / "magpie.db").exists()
+
+    def test_file_sink_writes_token_to_real_file(self, tmp_path: Path) -> None:
+        """Init with sink=file writes a 0600 file at the configured path."""
+        import os
+        import stat
+
+        token_file = tmp_path / "admin-token"
+        get_settings.cache_clear()
+        runner = EnvCliRunner(
+            env_overrides={
+                "MAGPIE_STORAGE_PATH": str(tmp_path),
+                "MAGPIE_DATABASE_PATH": str(tmp_path / "magpie.db"),
+                "MAGPIE_ADMIN_TOKEN_SINK": "file",
+                "MAGPIE_ADMIN_TOKEN_SINK_FILE_PATH": str(token_file),
+            }
+        )
+        try:
+            result = runner.invoke(ctl_cli, ["init"])
+        finally:
+            get_settings.cache_clear()
+
+        assert result.exit_code == 0, f"Output: {result.output}"
+        assert "mgp_ADMIN_" not in result.output
+        assert token_file.exists()
+        token_value = token_file.read_text().strip()
+        assert token_value.startswith("mgp_ADMIN_")
+        mode = stat.S_IMODE(os.stat(token_file).st_mode)
+        assert mode == 0o600
+
+    def test_discard_sink_then_mint_via_token_create(self, tmp_path: Path) -> None:
+        """Init with sink=discard prints no token; a usable one can be minted later."""
+        get_settings.cache_clear()
+        runner = EnvCliRunner(
+            env_overrides={
+                "MAGPIE_STORAGE_PATH": str(tmp_path),
+                "MAGPIE_DATABASE_PATH": str(tmp_path / "magpie.db"),
+                "MAGPIE_ADMIN_TOKEN_SINK": "discard",
+            }
+        )
+        try:
+            init_result = runner.invoke(ctl_cli, ["init"])
+            assert init_result.exit_code == 0, f"Output: {init_result.output}"
+            assert "mgp_ADMIN_" not in init_result.output
+
+            create_result = runner.invoke(
+                ctl_cli, ["token", "create", "--name", "ops-admin", "--scope", "admin"]
+            )
+        finally:
+            get_settings.cache_clear()
+
+        assert create_result.exit_code == 0, f"Output: {create_result.output}"
+        match = re.search(r"mgp_ADMIN_[A-Za-z0-9_-]+", create_result.output)
+        assert match is not None
+
+        conn = get_connection(tmp_path / "magpie.db")
+        try:
+            tokens = list_tokens(conn)
+            admin_scope_tokens = [t for t in tokens if t.scope == TokenScope.ADMIN]
+            # The first-boot "admin" token (generated, then discarded) plus
+            # the newly minted "ops-admin" token.
+            assert len(admin_scope_tokens) == 2
+            assert {t.name for t in admin_scope_tokens} == {"admin", "ops-admin"}
         finally:
             conn.close()
 

--- a/tests/integration/test_ctl.py
+++ b/tests/integration/test_ctl.py
@@ -429,10 +429,12 @@ class TestInitAdminTokenSink:
         try:
             tokens = list_tokens(conn)
             admin_scope_tokens = [t for t in tokens if t.scope == TokenScope.ADMIN]
-            # The first-boot "admin" token (generated, then discarded) plus
-            # the newly minted "ops-admin" token.
-            assert len(admin_scope_tokens) == 2
-            assert {t.name for t in admin_scope_tokens} == {"admin", "ops-admin"}
+            # sink=discard retains NO usable admin token: the first-boot
+            # "admin" token is generated, delivery (discard) succeeds
+            # trivially, and it is never persisted at all -- so only the
+            # newly minted "ops-admin" token should exist.
+            assert len(admin_scope_tokens) == 1
+            assert {t.name for t in admin_scope_tokens} == {"ops-admin"}
         finally:
             conn.close()
 

--- a/tests/unit/test_ctl_init_gc.py
+++ b/tests/unit/test_ctl_init_gc.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import re
+import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import patch
@@ -93,66 +94,93 @@ def create_artifact_with_blobs(
 
 
 class TestInitCommand:
-    """Tests for init command."""
+    """Tests for init command.
+
+    Most of these tests use sink=stdout explicitly to exercise the
+    delivery path while keeping the token visible in `result.output` for
+    assertions. Sink-specific behavior (file/exec/discard/fail-closed) is
+    covered in TestInitAdminTokenSink below and in test_token_sink.py.
+    """
 
     def test_init_creates_directories(
         self, cli_runner: CliRunner, test_settings: MagpieSettings
     ) -> None:
         """Init creates storage and temp directories."""
+        settings = test_settings.model_copy(update={"admin_token_sink": "discard"})
         with patch("magpie.ctl.commands.init.CTLContext") as mock_ctx_class:
             # Setup mock
             mock_ctx = mock_ctx_class.return_value
-            mock_ctx.settings = test_settings
+            mock_ctx.settings = settings
             mock_ctx.debug = False
 
-            with patch("magpie.ctl.get_settings", return_value=test_settings):
+            with patch("magpie.ctl.get_settings", return_value=settings):
                 result = cli_runner.invoke(cli, ["init"])
 
         assert result.exit_code == 0, f"Output: {result.output}"
-        assert test_settings.storage_path.exists()
-        assert test_settings.temp_path.exists()
+        assert settings.storage_path.exists()
+        assert settings.temp_path.exists()
 
     def test_init_creates_database(
         self, cli_runner: CliRunner, test_settings: MagpieSettings
     ) -> None:
         """Init creates SQLite database."""
-        with patch("magpie.ctl.get_settings", return_value=test_settings):
+        settings = test_settings.model_copy(update={"admin_token_sink": "discard"})
+        with patch("magpie.ctl.get_settings", return_value=settings):
             result = cli_runner.invoke(cli, ["init"])
 
         assert result.exit_code == 0, f"Output: {result.output}"
-        assert test_settings.database_path.exists()
+        assert settings.database_path.exists()
         assert "Database initialized" in result.output
 
     def test_init_creates_admin_token(
         self, cli_runner: CliRunner, test_settings: MagpieSettings
     ) -> None:
-        """Init creates admin token on first run."""
-        with patch("magpie.ctl.get_settings", return_value=test_settings):
+        """Init creates admin token on first run and delivers it via sink=stdout."""
+        settings = test_settings.model_copy(update={"admin_token_sink": "stdout"})
+        with patch("magpie.ctl.get_settings", return_value=settings):
             result = cli_runner.invoke(cli, ["init"])
 
         assert result.exit_code == 0, f"Output: {result.output}"
         assert "ADMIN TOKEN" in result.output
         assert "mgp_ADMIN_" in result.output
 
+    def test_init_without_sink_configured_fails_closed(
+        self, cli_runner: CliRunner, test_settings: MagpieSettings
+    ) -> None:
+        """Init aborts (non-zero exit) when no sink is configured; nothing is printed."""
+        with patch("magpie.ctl.get_settings", return_value=test_settings):
+            result = cli_runner.invoke(cli, ["init"])
+
+        assert result.exit_code != 0, f"Output: {result.output}"
+        assert "MAGPIE_ADMIN_TOKEN_SINK is not set" in result.output
+        assert "mgp_ADMIN_" not in result.output
+
     def test_init_token_already_exists(
         self, cli_runner: CliRunner, test_settings: MagpieSettings
     ) -> None:
-        """Init reports existing token when run twice."""
-        with patch("magpie.ctl.get_settings", return_value=test_settings):
+        """Init reports existing token when run twice; sink isn't needed on the second run."""
+        settings = test_settings.model_copy(update={"admin_token_sink": "discard"})
+        with patch("magpie.ctl.get_settings", return_value=settings):
             # First init creates token
             result1 = cli_runner.invoke(cli, ["init"])
             assert result1.exit_code == 0
 
-            # Second init should report token exists
+            # Second init should report token exists, even with no sink configured,
+            # since no new token is generated (first-boot-only).
+            no_sink_settings = test_settings.model_copy(
+                update={"database_path": settings.database_path}
+            )
+        with patch("magpie.ctl.get_settings", return_value=no_sink_settings):
             result2 = cli_runner.invoke(cli, ["init"])
-            assert result2.exit_code == 0
+            assert result2.exit_code == 0, f"Output: {result2.output}"
             assert "already exists" in result2.output
 
     def test_init_reset_admin_token_regenerates(
         self, cli_runner: CliRunner, test_settings: MagpieSettings
     ) -> None:
-        """Init --reset-admin-token regenerates token."""
-        with patch("magpie.ctl.get_settings", return_value=test_settings):
+        """Init --reset-admin-token regenerates token and delivers it via the sink."""
+        settings = test_settings.model_copy(update={"admin_token_sink": "stdout"})
+        with patch("magpie.ctl.get_settings", return_value=settings):
             # First init creates token
             result1 = cli_runner.invoke(cli, ["init"])
             assert result1.exit_code == 0
@@ -164,7 +192,7 @@ class TestInitCommand:
             # Reset token
             result2 = cli_runner.invoke(cli, ["init", "--reset-admin-token"])
             assert result2.exit_code == 0
-            assert "NEW ADMIN TOKEN" in result2.output
+            assert "ADMIN TOKEN" in result2.output
             assert "Revoked existing" in result2.output
 
             # Extract second token using regex
@@ -175,13 +203,32 @@ class TestInitCommand:
             # Tokens should be different
             assert first_token != second_token
 
+    def test_init_reset_admin_token_fails_closed_without_sink(
+        self, cli_runner: CliRunner, test_settings: MagpieSettings
+    ) -> None:
+        """Init --reset-admin-token aborts if no sink is configured for delivery."""
+        settings = test_settings.model_copy(update={"admin_token_sink": "discard"})
+        with patch("magpie.ctl.get_settings", return_value=settings):
+            result1 = cli_runner.invoke(cli, ["init"])
+            assert result1.exit_code == 0
+
+        no_sink_settings = test_settings.model_copy(
+            update={"database_path": settings.database_path}
+        )
+        with patch("magpie.ctl.get_settings", return_value=no_sink_settings):
+            result2 = cli_runner.invoke(cli, ["init", "--reset-admin-token"])
+
+        assert result2.exit_code != 0, f"Output: {result2.output}"
+        assert "MAGPIE_ADMIN_TOKEN_SINK is not set" in result2.output
+
     def test_init_with_custom_admin_token(
         self, cli_runner: CliRunner, test_settings: MagpieSettings
     ) -> None:
-        """Init accepts custom admin token."""
+        """Init accepts custom admin token and delivers it via sink=stdout."""
         custom_token = "mgp_ADMIN_my_custom_token_123"
+        settings = test_settings.model_copy(update={"admin_token_sink": "stdout"})
 
-        with patch("magpie.ctl.get_settings", return_value=test_settings):
+        with patch("magpie.ctl.get_settings", return_value=settings):
             result = cli_runner.invoke(cli, ["init", "--admin-token", custom_token])
 
         assert result.exit_code == 0, f"Output: {result.output}"
@@ -191,7 +238,7 @@ class TestInitCommand:
         # Verify the token was stored correctly by trying to validate it
         from magpie.auth.service import TokenService
 
-        token_service = TokenService(test_settings)
+        token_service = TokenService(settings)
         token_info = token_service.validate_token(custom_token)
         assert token_info is not None
         assert token_info.name == "admin"
@@ -200,9 +247,11 @@ class TestInitCommand:
     def test_init_with_invalid_token_prefix(
         self, cli_runner: CliRunner, test_settings: MagpieSettings
     ) -> None:
-        """Init rejects token without correct prefix."""
+        """Init rejects token without correct prefix (checked before sink delivery)."""
         invalid_token = "mgp_wrong_prefix_123"
 
+        # Deliberately no sink configured: format validation must fail before
+        # delivery is ever attempted.
         with patch("magpie.ctl.get_settings", return_value=test_settings):
             result = cli_runner.invoke(cli, ["init", "--admin-token", invalid_token])
 
@@ -224,10 +273,11 @@ class TestInitCommand:
     def test_init_reset_with_custom_token(
         self, cli_runner: CliRunner, test_settings: MagpieSettings
     ) -> None:
-        """Init --reset-admin-token works with custom token."""
+        """Init --reset-admin-token works with custom token, delivered via sink."""
         custom_token = "mgp_ADMIN_my_new_token_456"
+        settings = test_settings.model_copy(update={"admin_token_sink": "stdout"})
 
-        with patch("magpie.ctl.get_settings", return_value=test_settings):
+        with patch("magpie.ctl.get_settings", return_value=settings):
             # First init with random token
             result1 = cli_runner.invoke(cli, ["init"])
             assert result1.exit_code == 0
@@ -237,14 +287,14 @@ class TestInitCommand:
                 cli, ["init", "--reset-admin-token", "--admin-token", custom_token]
             )
             assert result2.exit_code == 0
-            assert "NEW ADMIN TOKEN" in result2.output
+            assert "ADMIN TOKEN" in result2.output
             assert custom_token in result2.output
             assert "Revoked existing" in result2.output
 
         # Verify the custom token is now active
         from magpie.auth.service import TokenService
 
-        token_service = TokenService(test_settings)
+        token_service = TokenService(settings)
         token_info = token_service.validate_token(custom_token)
         assert token_info is not None
         assert token_info.name == "admin"
@@ -254,18 +304,160 @@ class TestInitCommand:
     ) -> None:
         """Init --admin-token succeeds but reports when admin token already exists."""
         custom_token = "mgp_ADMIN_custom_token_789"
+        settings = test_settings.model_copy(update={"admin_token_sink": "discard"})
 
-        with patch("magpie.ctl.get_settings", return_value=test_settings):
+        with patch("magpie.ctl.get_settings", return_value=settings):
             # First init creates an admin token
             result1 = cli_runner.invoke(cli, ["init"])
             assert result1.exit_code == 0
 
-            # Second init with custom token should succeed but report existing admin token
+            # Second init with custom token should succeed but report existing admin token,
+            # even with no sink configured, since nothing new is generated or delivered.
+            no_sink_settings = test_settings.model_copy(
+                update={"database_path": settings.database_path}
+            )
+        with patch("magpie.ctl.get_settings", return_value=no_sink_settings):
             result2 = cli_runner.invoke(cli, ["init", "--admin-token", custom_token])
             assert result2.exit_code == 0, "init should succeed but report token exists"
             assert "already exists" in result2.output, "Should report token already exists"
             # Custom token should NOT be created or displayed
             assert custom_token not in result2.output, "Custom token should not be shown"
+
+
+class TestInitAdminTokenSink:
+    """Tests for MAGPIE_ADMIN_TOKEN_SINK delivery, fail-closed behavior, and discard."""
+
+    def test_file_sink_writes_0600_file(
+        self, cli_runner: CliRunner, test_settings: MagpieSettings, tmp_path: Path
+    ) -> None:
+        """sink=file writes the token to a root-only file and doesn't print it."""
+        import os
+        import stat
+
+        token_file = tmp_path / "admin-token"
+        settings = test_settings.model_copy(
+            update={"admin_token_sink": "file", "admin_token_sink_file_path": token_file}
+        )
+
+        with patch("magpie.ctl.get_settings", return_value=settings):
+            result = cli_runner.invoke(cli, ["init"])
+
+        assert result.exit_code == 0, f"Output: {result.output}"
+        assert "mgp_ADMIN_" not in result.output
+        assert token_file.exists()
+        token_value = token_file.read_text().strip()
+        assert token_value.startswith("mgp_ADMIN_")
+        mode = stat.S_IMODE(os.stat(token_file).st_mode)
+        assert mode == 0o600
+
+    def test_file_sink_delivery_failure_aborts_init(
+        self, cli_runner: CliRunner, test_settings: MagpieSettings, tmp_path: Path
+    ) -> None:
+        """A delivery failure for sink=file aborts init with a non-zero exit."""
+        blocker = tmp_path / "blocker"
+        blocker.write_text("not a directory")
+        unwritable_target = blocker / "admin-token"
+        settings = test_settings.model_copy(
+            update={"admin_token_sink": "file", "admin_token_sink_file_path": unwritable_target}
+        )
+
+        with patch("magpie.ctl.get_settings", return_value=settings):
+            result = cli_runner.invoke(cli, ["init"])
+
+        assert result.exit_code != 0, f"Output: {result.output}"
+        assert "mgp_ADMIN_" not in result.output
+
+    def test_exec_sink_receives_token_on_stdin(
+        self, cli_runner: CliRunner, test_settings: MagpieSettings, tmp_path: Path
+    ) -> None:
+        """sink=exec pipes the token to the configured command's stdin, not to stdout."""
+        out_file = tmp_path / "captured"
+        command = (
+            f"{sys.executable} -c \"import sys; open('{out_file}', 'w').write(sys.stdin.read())\""
+        )
+        settings = test_settings.model_copy(
+            update={"admin_token_sink": "exec", "admin_token_sink_exec_command": command}
+        )
+
+        with patch("magpie.ctl.get_settings", return_value=settings):
+            result = cli_runner.invoke(cli, ["init"])
+
+        assert result.exit_code == 0, f"Output: {result.output}"
+        assert "mgp_ADMIN_" not in result.output
+        assert out_file.read_text().strip().startswith("mgp_ADMIN_")
+
+    def test_exec_sink_nonzero_exit_aborts_init(
+        self, cli_runner: CliRunner, test_settings: MagpieSettings
+    ) -> None:
+        """A non-zero exit from the exec sink command aborts init with a non-zero exit."""
+        command = f'{sys.executable} -c "import sys; sys.exit(1)"'
+        settings = test_settings.model_copy(
+            update={"admin_token_sink": "exec", "admin_token_sink_exec_command": command}
+        )
+
+        with patch("magpie.ctl.get_settings", return_value=settings):
+            result = cli_runner.invoke(cli, ["init"])
+
+        assert result.exit_code != 0, f"Output: {result.output}"
+        assert "mgp_ADMIN_" not in result.output
+
+    def test_discard_sink_retains_no_usable_token_in_output(
+        self, cli_runner: CliRunner, test_settings: MagpieSettings
+    ) -> None:
+        """sink=discard succeeds without printing the token anywhere."""
+        settings = test_settings.model_copy(update={"admin_token_sink": "discard"})
+
+        with patch("magpie.ctl.get_settings", return_value=settings):
+            result = cli_runner.invoke(cli, ["init"])
+
+        assert result.exit_code == 0, f"Output: {result.output}"
+        assert "mgp_ADMIN_" not in result.output
+        assert "discard" in result.output.lower()
+        assert "magpie-ctl token create" in result.output
+
+    def test_discard_sink_token_recoverable_via_token_create(
+        self, cli_runner: CliRunner, test_settings: MagpieSettings
+    ) -> None:
+        """After discard, a new usable admin-scope token can be minted via token create."""
+        settings = test_settings.model_copy(update={"admin_token_sink": "discard"})
+
+        with patch("magpie.ctl.get_settings", return_value=settings):
+            result = cli_runner.invoke(cli, ["init"])
+            assert result.exit_code == 0
+
+            create_result = cli_runner.invoke(
+                cli, ["token", "create", "--name", "ops-admin", "--scope", "admin"]
+            )
+
+        assert create_result.exit_code == 0, f"Output: {create_result.output}"
+        match = re.search(r"mgp_ADMIN_[A-Za-z0-9_-]+", create_result.output)
+        assert match is not None
+
+        from magpie.auth.service import TokenService
+
+        token_service = TokenService(settings)
+        token_info = token_service.validate_token(match.group(0))
+        assert token_info is not None
+        assert token_info.scope.value == "admin"
+
+    def test_first_boot_only_second_init_does_not_regenerate(
+        self, cli_runner: CliRunner, test_settings: MagpieSettings
+    ) -> None:
+        """A second `init` call (DB already present) never generates/delivers a new token."""
+        settings = test_settings.model_copy(update={"admin_token_sink": "stdout"})
+
+        with patch("magpie.ctl.get_settings", return_value=settings):
+            result1 = cli_runner.invoke(cli, ["init"])
+            match1 = re.search(r"mgp_ADMIN_[A-Za-z0-9_-]+", result1.output)
+            assert match1 is not None
+            first_token = match1.group(0)
+
+            result2 = cli_runner.invoke(cli, ["init"])
+
+        assert result2.exit_code == 0
+        assert "already exists" in result2.output
+        assert first_token not in result2.output
+        assert "mgp_ADMIN_" not in result2.output
 
 
 class TestInitJsonOutput:
@@ -274,25 +466,40 @@ class TestInitJsonOutput:
     def test_init_with_admin_token_json_output(
         self, cli_runner: CliRunner, test_settings: MagpieSettings
     ) -> None:
-        """Init --admin-token with --format json returns valid JSON with token."""
+        """Init --admin-token with --format json and sink=stdout includes the token."""
         custom_token = "mgp_ADMIN_json_test_token_xyz_abcdefgh"
+        settings = test_settings.model_copy(update={"admin_token_sink": "stdout"})
 
-        with patch("magpie.ctl.get_settings", return_value=test_settings):
+        with patch("magpie.ctl.get_settings", return_value=settings):
             result = cli_runner.invoke(
                 cli, ["--format", "json", "init", "--admin-token", custom_token]
             )
 
         assert result.exit_code == 0, f"Output: {result.output}"
-        output = json.loads(result.output.strip())
+        output = json.loads(result.stdout.strip())
         # JSON output wraps in {"status": "ok", "data": {...}}
         assert output["status"] == "ok"
         data = output["data"]
-        # admin_token should be a string when first created
-        assert isinstance(data["admin_token"], str), "admin_token should be string on first init"
         assert data["admin_token"] == custom_token
+        assert data["admin_token_sink"] == "stdout"
         assert "storage_path" in data
         assert "database_path" in data
         assert data["token_already_existed"] is False
+
+    def test_init_json_output_non_stdout_sink_omits_token_value(
+        self, cli_runner: CliRunner, test_settings: MagpieSettings
+    ) -> None:
+        """JSON output never includes the token value for non-stdout sinks (it's still stdout)."""
+        settings = test_settings.model_copy(update={"admin_token_sink": "discard"})
+
+        with patch("magpie.ctl.get_settings", return_value=settings):
+            result = cli_runner.invoke(cli, ["--format", "json", "init"])
+
+        assert result.exit_code == 0, f"Output: {result.output}"
+        output = json.loads(result.stdout.strip())
+        data = output["data"]
+        assert data["admin_token"] is None
+        assert data["admin_token_sink"] == "discard"
 
     def test_init_with_invalid_token_json_output(
         self, cli_runner: CliRunner, test_settings: MagpieSettings
@@ -306,7 +513,7 @@ class TestInitJsonOutput:
             )
 
         assert result.exit_code == 1, f"Output: {result.output}"
-        output = json.loads(result.output.strip())
+        output = json.loads(result.stdout.strip())
         # Error output uses {"status": "ok", "data": {"error": ...}} structure
         data = output.get("data", output)
         assert "error" in data
@@ -317,8 +524,9 @@ class TestInitJsonOutput:
     ) -> None:
         """Init --reset-admin-token --admin-token with --format json returns valid JSON."""
         custom_token = "mgp_ADMIN_reset_json_test_456_abcdefgh"
+        settings = test_settings.model_copy(update={"admin_token_sink": "stdout"})
 
-        with patch("magpie.ctl.get_settings", return_value=test_settings):
+        with patch("magpie.ctl.get_settings", return_value=settings):
             # First init creates a token
             result1 = cli_runner.invoke(cli, ["init"])
             assert result1.exit_code == 0
@@ -330,7 +538,7 @@ class TestInitJsonOutput:
             )
 
         assert result2.exit_code == 0, f"Output: {result2.output}"
-        output = json.loads(result2.output.strip())
+        output = json.loads(result2.stdout.strip())
         # JSON output wraps in {"status": "ok", "data": {...}}
         assert output["status"] == "ok"
         data = output["data"]
@@ -349,7 +557,7 @@ class TestInitJsonOutput:
             )
 
         assert result.exit_code == 1, f"Output: {result.output}"
-        output = json.loads(result.output.strip())
+        output = json.loads(result.stdout.strip())
         # Error output uses {"status": "ok", "data": {"error": ...}} structure
         data = output.get("data", output)
         assert "error" in data
@@ -1011,7 +1219,7 @@ class TestGCJsonOutput:
             result = cli_runner.invoke(cli, ["gc", "--json-output"])
 
         assert result.exit_code == 0, f"Output: {result.output}"
-        output = json.loads(result.output.strip())
+        output = json.loads(result.stdout.strip())
         assert "dry_run" in output
         assert "blobs_deleted" in output
         assert "space_reclaimed_bytes" in output
@@ -1035,7 +1243,7 @@ class TestGCJsonOutput:
             result = cli_runner.invoke(cli, ["gc", "--json-output", "--dry-run"])
 
         assert result.exit_code == 0, f"Output: {result.output}"
-        output = json.loads(result.output.strip())
+        output = json.loads(result.stdout.strip())
         assert output["dry_run"] is True
         assert output["blobs_deleted"] == 1
 
@@ -1056,7 +1264,7 @@ class TestGCJsonOutput:
             result = cli_runner.invoke(cli, ["gc", "--json-output"])
 
         assert result.exit_code == 0, f"Output: {result.output}"
-        output = json.loads(result.output.strip())
+        output = json.loads(result.stdout.strip())
         assert output["dry_run"] is False
         assert output["blobs_deleted"] == 1
         assert output["space_reclaimed_bytes"] > 0
@@ -1070,7 +1278,7 @@ class TestGCJsonOutput:
             result = cli_runner.invoke(cli, ["gc", "--json-output"])
 
         assert result.exit_code == 1
-        output = json.loads(result.output.strip())
+        output = json.loads(result.stdout.strip())
         assert "error" in output
 
     def test_gc_json_output_no_human_readable_text(
@@ -1135,7 +1343,7 @@ class TestGCJsonOutput:
         assert result.exit_code == 1, f"Output: {result.output}"
 
         # Output should be valid JSON with error message
-        output = json.loads(result.output.strip())
+        output = json.loads(result.stdout.strip())
         assert "error" in output
         assert error_message in output["error"]
 
@@ -1199,7 +1407,7 @@ class TestFlushTagCommand:
             result = cli_runner.invoke(cli, ["flush-tag", "release", "--json-output"])
 
         assert result.exit_code == 0, f"Output: {result.output}"
-        output = json.loads(result.output.strip())
+        output = json.loads(result.stdout.strip())
         assert output["tag_name"] == "release"
         assert output["dry_run"] is False
         assert output["count"] == 1
@@ -1222,7 +1430,7 @@ class TestFlushTagCommand:
             result = cli_runner.invoke(cli, ["flush-tag", "release", "--json-output", "--dry-run"])
 
         assert result.exit_code == 0, f"Output: {result.output}"
-        output = json.loads(result.output.strip())
+        output = json.loads(result.stdout.strip())
         assert output["tag_name"] == "release"
         assert output["dry_run"] is True
         assert output["count"] == 1
@@ -1266,5 +1474,5 @@ class TestFlushTagCommand:
             result = cli_runner.invoke(cli, ["flush-tag", "release", "--json-output"])
 
         assert result.exit_code == 1
-        output = json.loads(result.output.strip())
+        output = json.loads(result.stdout.strip())
         assert "error" in output

--- a/tests/unit/test_ctl_init_gc.py
+++ b/tests/unit/test_ctl_init_gc.py
@@ -482,6 +482,25 @@ class TestInitAdminTokenSink:
             conn.close()
         assert not any(t.name == "admin" for t in tokens)
 
+    def test_sink_failure_json_output_emits_status_error_not_ok(
+        self, cli_runner: CliRunner, test_settings: MagpieSettings
+    ) -> None:
+        """A sink-abort in --format json mode emits {"status": "error"}, never "ok".
+
+        A validation error or delivery failure reported as status "ok" could
+        make an automated caller (e.g. the server, parsing this output)
+        believe init succeeded.
+        """
+        with patch("magpie.ctl.get_settings", return_value=test_settings):
+            result = cli_runner.invoke(cli, ["--format", "json", "init"])
+
+        assert result.exit_code != 0
+        output = json.loads(result.stderr.strip())
+        assert output["status"] == "error"
+        assert "MAGPIE_ADMIN_TOKEN_SINK is not set" in output["error"]["message"]
+        # And nothing resembling a success payload landed on stdout.
+        assert result.stdout.strip() == ""
+
     def test_discard_first_boot_persists_no_admin_token_row(
         self, cli_runner: CliRunner, test_settings: MagpieSettings
     ) -> None:
@@ -621,11 +640,10 @@ class TestInitJsonOutput:
             )
 
         assert result.exit_code == 1, f"Output: {result.output}"
-        output = json.loads(result.stdout.strip())
-        # Error output uses {"status": "ok", "data": {"error": ...}} structure
-        data = output.get("data", output)
-        assert "error" in data
-        assert "mgp_ADMIN_" in data["error"]
+        # output_error() writes {"status": "error", "error": {...}} to stderr.
+        output = json.loads(result.stderr.strip())
+        assert output["status"] == "error"
+        assert "mgp_ADMIN_" in output["error"]["message"]
 
     def test_init_reset_with_custom_token_json_output(
         self, cli_runner: CliRunner, test_settings: MagpieSettings
@@ -665,11 +683,10 @@ class TestInitJsonOutput:
             )
 
         assert result.exit_code == 1, f"Output: {result.output}"
-        output = json.loads(result.stdout.strip())
-        # Error output uses {"status": "ok", "data": {"error": ...}} structure
-        data = output.get("data", output)
-        assert "error" in data
-        assert "too short" in data["error"]
+        # output_error() writes {"status": "error", "error": {...}} to stderr.
+        output = json.loads(result.stderr.strip())
+        assert output["status"] == "error"
+        assert "too short" in output["error"]["message"]
 
 
 class TestGCCommand:

--- a/tests/unit/test_ctl_init_gc.py
+++ b/tests/unit/test_ctl_init_gc.py
@@ -159,7 +159,7 @@ class TestInitCommand:
         self, cli_runner: CliRunner, test_settings: MagpieSettings
     ) -> None:
         """Init reports existing token when run twice; sink isn't needed on the second run."""
-        settings = test_settings.model_copy(update={"admin_token_sink": "discard"})
+        settings = test_settings.model_copy(update={"admin_token_sink": "stdout"})
         with patch("magpie.ctl.get_settings", return_value=settings):
             # First init creates token
             result1 = cli_runner.invoke(cli, ["init"])
@@ -304,7 +304,7 @@ class TestInitCommand:
     ) -> None:
         """Init --admin-token succeeds but reports when admin token already exists."""
         custom_token = "mgp_ADMIN_custom_token_789"
-        settings = test_settings.model_copy(update={"admin_token_sink": "discard"})
+        settings = test_settings.model_copy(update={"admin_token_sink": "stdout"})
 
         with patch("magpie.ctl.get_settings", return_value=settings):
             # First init creates an admin token
@@ -458,6 +458,114 @@ class TestInitAdminTokenSink:
         assert "already exists" in result2.output
         assert first_token not in result2.output
         assert "mgp_ADMIN_" not in result2.output
+
+    def test_first_boot_delivery_failure_persists_no_admin_token(
+        self, cli_runner: CliRunner, test_settings: MagpieSettings
+    ) -> None:
+        """A failed first-boot delivery leaves no admin token row in the database."""
+        from magpie.auth.database import get_connection, list_tokens
+
+        command = f'{sys.executable} -c "import sys; sys.exit(1)"'
+        settings = test_settings.model_copy(
+            update={"admin_token_sink": "exec", "admin_token_sink_exec_command": command}
+        )
+
+        with patch("magpie.ctl.get_settings", return_value=settings):
+            result = cli_runner.invoke(cli, ["init"])
+
+        assert result.exit_code != 0
+
+        conn = get_connection(settings.database_path)
+        try:
+            tokens = list_tokens(conn)
+        finally:
+            conn.close()
+        assert not any(t.name == "admin" for t in tokens)
+
+    def test_discard_first_boot_persists_no_admin_token_row(
+        self, cli_runner: CliRunner, test_settings: MagpieSettings
+    ) -> None:
+        """sink=discard on first boot leaves no row for "admin" at all -- not just unusable."""
+        from magpie.auth.database import get_connection, list_tokens
+
+        settings = test_settings.model_copy(update={"admin_token_sink": "discard"})
+
+        with patch("magpie.ctl.get_settings", return_value=settings):
+            result = cli_runner.invoke(cli, ["init"])
+
+        assert result.exit_code == 0, f"Output: {result.output}"
+
+        conn = get_connection(settings.database_path)
+        try:
+            tokens = list_tokens(conn)
+        finally:
+            conn.close()
+        assert tokens == []
+
+    def test_reset_delivery_failure_leaves_prior_token_valid(
+        self, cli_runner: CliRunner, test_settings: MagpieSettings
+    ) -> None:
+        """A failed --reset-admin-token delivery must not destroy the working admin token.
+
+        This is the critical lockout scenario: --reset-admin-token is the
+        documented recovery runbook step, typically run via `docker exec`
+        against an already-running server. If a sink failure revoked the
+        old token before confirming delivery of the new one, the operator
+        would be locked out entirely.
+        """
+        from magpie.auth.service import TokenService
+
+        stdout_settings = test_settings.model_copy(update={"admin_token_sink": "stdout"})
+        with patch("magpie.ctl.get_settings", return_value=stdout_settings):
+            result1 = cli_runner.invoke(cli, ["init"])
+        match1 = re.search(r"mgp_ADMIN_[A-Za-z0-9_-]+", result1.output)
+        assert match1 is not None
+        original_token = match1.group(0)
+
+        failing_command = f'{sys.executable} -c "import sys; sys.exit(1)"'
+        failing_settings = test_settings.model_copy(
+            update={
+                "admin_token_sink": "exec",
+                "admin_token_sink_exec_command": failing_command,
+            }
+        )
+        with patch("magpie.ctl.get_settings", return_value=failing_settings):
+            result2 = cli_runner.invoke(cli, ["init", "--reset-admin-token"])
+
+        assert result2.exit_code != 0, f"Output: {result2.output}"
+
+        token_service = TokenService(test_settings)
+        assert token_service.validate_token(original_token) is not None
+
+    def test_reset_discard_revokes_old_but_persists_no_new_token(
+        self, cli_runner: CliRunner, test_settings: MagpieSettings
+    ) -> None:
+        """--reset-admin-token with sink=discard revokes the old token but persists nothing new."""
+        from magpie.auth.database import get_connection, list_tokens
+        from magpie.auth.service import TokenService
+
+        stdout_settings = test_settings.model_copy(update={"admin_token_sink": "stdout"})
+        with patch("magpie.ctl.get_settings", return_value=stdout_settings):
+            result1 = cli_runner.invoke(cli, ["init"])
+        match1 = re.search(r"mgp_ADMIN_[A-Za-z0-9_-]+", result1.output)
+        assert match1 is not None
+        original_token = match1.group(0)
+
+        discard_settings = test_settings.model_copy(update={"admin_token_sink": "discard"})
+        with patch("magpie.ctl.get_settings", return_value=discard_settings):
+            result2 = cli_runner.invoke(cli, ["init", "--reset-admin-token"])
+
+        assert result2.exit_code == 0, f"Output: {result2.output}"
+
+        token_service = TokenService(test_settings)
+        assert token_service.validate_token(original_token) is None
+
+        conn = get_connection(test_settings.database_path)
+        try:
+            tokens = list_tokens(conn)
+        finally:
+            conn.close()
+        assert not any(t.name == "admin" for t in tokens)
 
 
 class TestInitJsonOutput:

--- a/tests/unit/test_ctl_token.py
+++ b/tests/unit/test_ctl_token.py
@@ -384,8 +384,8 @@ class TestTokenRotateAdminSink:
         self, cli_runner: CliRunner, test_settings: MagpieSettings
     ) -> None:
         """Rotating name="admin" aborts with a non-zero exit if no sink is configured."""
-        discard_settings = test_settings.model_copy(update={"admin_token_sink": "discard"})
-        with patch("magpie.ctl.get_settings", return_value=discard_settings):
+        stdout_settings = test_settings.model_copy(update={"admin_token_sink": "stdout"})
+        with patch("magpie.ctl.get_settings", return_value=stdout_settings):
             init_result = cli_runner.invoke(cli, ["init"])
             assert init_result.exit_code == 0
 
@@ -402,10 +402,15 @@ class TestTokenRotateAdminSink:
         """Rotating name="admin" with a failing exec sink aborts with a non-zero exit."""
         import sys
 
-        discard_settings = test_settings.model_copy(update={"admin_token_sink": "discard"})
-        with patch("magpie.ctl.get_settings", return_value=discard_settings):
+        from magpie.auth.service import TokenService
+
+        stdout_settings = test_settings.model_copy(update={"admin_token_sink": "stdout"})
+        with patch("magpie.ctl.get_settings", return_value=stdout_settings):
             init_result = cli_runner.invoke(cli, ["init"])
             assert init_result.exit_code == 0
+        match = re.search(r"mgp_ADMIN_[A-Za-z0-9_-]+", init_result.output)
+        assert match is not None
+        original_token = match.group(0)
 
         command = f'{sys.executable} -c "import sys; sys.exit(1)"'
         exec_settings = test_settings.model_copy(
@@ -416,6 +421,76 @@ class TestTokenRotateAdminSink:
 
         assert rotate_result.exit_code != 0, f"Output: {rotate_result.output}"
         assert "mgp_ADMIN_" not in rotate_result.output
+
+        # Critical: the failed rotation must not have destroyed the prior,
+        # working admin token (lockout prevention).
+        token_service = TokenService(test_settings)
+        assert token_service.validate_token(original_token) is not None
+
+    def test_rotate_admin_failure_leaves_no_orphan_row(
+        self, cli_runner: CliRunner, test_settings: MagpieSettings
+    ) -> None:
+        """A failed rotation leaves exactly the original admin token row -- no orphan."""
+        import sys
+
+        from magpie.auth.database import get_connection, list_tokens
+
+        stdout_settings = test_settings.model_copy(update={"admin_token_sink": "stdout"})
+        with patch("magpie.ctl.get_settings", return_value=stdout_settings):
+            init_result = cli_runner.invoke(cli, ["init"])
+            assert init_result.exit_code == 0
+
+        conn = get_connection(test_settings.database_path)
+        try:
+            tokens_before = list_tokens(conn)
+        finally:
+            conn.close()
+
+        command = f'{sys.executable} -c "import sys; sys.exit(1)"'
+        exec_settings = test_settings.model_copy(
+            update={"admin_token_sink": "exec", "admin_token_sink_exec_command": command}
+        )
+        with patch("magpie.ctl.get_settings", return_value=exec_settings):
+            rotate_result = cli_runner.invoke(cli, ["token", "rotate", "admin"])
+        assert rotate_result.exit_code != 0
+
+        conn = get_connection(test_settings.database_path)
+        try:
+            tokens_after = list_tokens(conn)
+        finally:
+            conn.close()
+
+        assert [t.token_hash for t in tokens_after] == [t.token_hash for t in tokens_before]
+
+    def test_rotate_admin_discard_revokes_old_persists_nothing_new(
+        self, cli_runner: CliRunner, test_settings: MagpieSettings
+    ) -> None:
+        """Rotating with sink=discard revokes the old token but persists nothing new."""
+        from magpie.auth.database import get_connection, list_tokens
+        from magpie.auth.service import TokenService
+
+        stdout_settings = test_settings.model_copy(update={"admin_token_sink": "stdout"})
+        with patch("magpie.ctl.get_settings", return_value=stdout_settings):
+            init_result = cli_runner.invoke(cli, ["init"])
+        match = re.search(r"mgp_ADMIN_[A-Za-z0-9_-]+", init_result.output)
+        assert match is not None
+        original_token = match.group(0)
+
+        discard_settings = test_settings.model_copy(update={"admin_token_sink": "discard"})
+        with patch("magpie.ctl.get_settings", return_value=discard_settings):
+            rotate_result = cli_runner.invoke(cli, ["token", "rotate", "admin"])
+
+        assert rotate_result.exit_code == 0, f"Output: {rotate_result.output}"
+
+        token_service = TokenService(test_settings)
+        assert token_service.validate_token(original_token) is None
+
+        conn = get_connection(test_settings.database_path)
+        try:
+            tokens = list_tokens(conn)
+        finally:
+            conn.close()
+        assert not any(t.name == "admin" for t in tokens)
 
     def test_rotate_admin_json_output_omits_token_for_non_stdout_sink(
         self, cli_runner: CliRunner, test_settings: MagpieSettings, tmp_path: Path

--- a/tests/unit/test_ctl_token.py
+++ b/tests/unit/test_ctl_token.py
@@ -396,6 +396,26 @@ class TestTokenRotateAdminSink:
         assert "mgp_ADMIN_" not in rotate_result.output
         assert "MAGPIE_ADMIN_TOKEN_SINK is not set" in rotate_result.output
 
+    def test_rotate_admin_fails_closed_json_output_emits_status_error(
+        self, cli_runner: CliRunner, test_settings: MagpieSettings
+    ) -> None:
+        """A sink-abort rotating admin in --format json mode emits status "error", not "ok"."""
+        import json
+
+        stdout_settings = test_settings.model_copy(update={"admin_token_sink": "stdout"})
+        with patch("magpie.ctl.get_settings", return_value=stdout_settings):
+            init_result = cli_runner.invoke(cli, ["init"])
+            assert init_result.exit_code == 0
+
+        with patch("magpie.ctl.get_settings", return_value=test_settings):
+            rotate_result = cli_runner.invoke(cli, ["--format", "json", "token", "rotate", "admin"])
+
+        assert rotate_result.exit_code != 0
+        output = json.loads(rotate_result.stderr.strip())
+        assert output["status"] == "error"
+        assert "MAGPIE_ADMIN_TOKEN_SINK is not set" in output["error"]["message"]
+        assert rotate_result.stdout.strip() == ""
+
     def test_rotate_admin_exec_sink_nonzero_exit_aborts(
         self, cli_runner: CliRunner, test_settings: MagpieSettings
     ) -> None:

--- a/tests/unit/test_ctl_token.py
+++ b/tests/unit/test_ctl_token.py
@@ -332,6 +332,116 @@ class TestTokenRotate:
                 assert scope in result.output
 
 
+class TestTokenRotateAdminSink:
+    """Tests for rotating the break-glass admin token (name "admin") via the sink."""
+
+    def test_rotate_admin_delivers_via_sink_not_stdout(
+        self, cli_runner: CliRunner, test_settings: MagpieSettings, tmp_path: Path
+    ) -> None:
+        """Rotating name="admin" delivers through the sink, not printed to stdout."""
+        token_file = tmp_path / "admin-token"
+        settings = test_settings.model_copy(
+            update={"admin_token_sink": "file", "admin_token_sink_file_path": token_file}
+        )
+
+        with patch("magpie.ctl.get_settings", return_value=settings):
+            init_result = cli_runner.invoke(cli, ["init"])
+            assert init_result.exit_code == 0, f"Output: {init_result.output}"
+
+            rotate_result = cli_runner.invoke(cli, ["token", "rotate", "admin"])
+
+        assert rotate_result.exit_code == 0, f"Output: {rotate_result.output}"
+        assert "mgp_ADMIN_" not in rotate_result.output
+        assert token_file.exists()
+        assert token_file.read_text().strip().startswith("mgp_ADMIN_")
+
+    def test_rotate_admin_invalidates_old_token(
+        self, cli_runner: CliRunner, test_settings: MagpieSettings, tmp_path: Path
+    ) -> None:
+        """Rotating the admin token invalidates the previous one."""
+        from magpie.auth.service import TokenService
+
+        token_file = tmp_path / "admin-token"
+        settings = test_settings.model_copy(
+            update={"admin_token_sink": "file", "admin_token_sink_file_path": token_file}
+        )
+
+        with patch("magpie.ctl.get_settings", return_value=settings):
+            cli_runner.invoke(cli, ["init"])
+            original_token = token_file.read_text().strip()
+
+            rotate_result = cli_runner.invoke(cli, ["token", "rotate", "admin"])
+            assert rotate_result.exit_code == 0
+
+        new_token = token_file.read_text().strip()
+        assert new_token != original_token
+
+        token_service = TokenService(settings)
+        assert token_service.validate_token(original_token) is None
+        assert token_service.validate_token(new_token) is not None
+
+    def test_rotate_admin_fails_closed_without_sink(
+        self, cli_runner: CliRunner, test_settings: MagpieSettings
+    ) -> None:
+        """Rotating name="admin" aborts with a non-zero exit if no sink is configured."""
+        discard_settings = test_settings.model_copy(update={"admin_token_sink": "discard"})
+        with patch("magpie.ctl.get_settings", return_value=discard_settings):
+            init_result = cli_runner.invoke(cli, ["init"])
+            assert init_result.exit_code == 0
+
+        with patch("magpie.ctl.get_settings", return_value=test_settings):
+            rotate_result = cli_runner.invoke(cli, ["token", "rotate", "admin"])
+
+        assert rotate_result.exit_code != 0, f"Output: {rotate_result.output}"
+        assert "mgp_ADMIN_" not in rotate_result.output
+        assert "MAGPIE_ADMIN_TOKEN_SINK is not set" in rotate_result.output
+
+    def test_rotate_admin_exec_sink_nonzero_exit_aborts(
+        self, cli_runner: CliRunner, test_settings: MagpieSettings
+    ) -> None:
+        """Rotating name="admin" with a failing exec sink aborts with a non-zero exit."""
+        import sys
+
+        discard_settings = test_settings.model_copy(update={"admin_token_sink": "discard"})
+        with patch("magpie.ctl.get_settings", return_value=discard_settings):
+            init_result = cli_runner.invoke(cli, ["init"])
+            assert init_result.exit_code == 0
+
+        command = f'{sys.executable} -c "import sys; sys.exit(1)"'
+        exec_settings = test_settings.model_copy(
+            update={"admin_token_sink": "exec", "admin_token_sink_exec_command": command}
+        )
+        with patch("magpie.ctl.get_settings", return_value=exec_settings):
+            rotate_result = cli_runner.invoke(cli, ["token", "rotate", "admin"])
+
+        assert rotate_result.exit_code != 0, f"Output: {rotate_result.output}"
+        assert "mgp_ADMIN_" not in rotate_result.output
+
+    def test_rotate_admin_json_output_omits_token_for_non_stdout_sink(
+        self, cli_runner: CliRunner, test_settings: MagpieSettings, tmp_path: Path
+    ) -> None:
+        """--format json rotate of the admin token omits the value for non-stdout sinks."""
+        import json
+
+        token_file = tmp_path / "admin-token"
+        settings = test_settings.model_copy(
+            update={"admin_token_sink": "file", "admin_token_sink_file_path": token_file}
+        )
+
+        with patch("magpie.ctl.get_settings", return_value=settings):
+            init_result = cli_runner.invoke(cli, ["init"])
+            assert init_result.exit_code == 0
+
+            rotate_result = cli_runner.invoke(cli, ["--format", "json", "token", "rotate", "admin"])
+
+        assert rotate_result.exit_code == 0, f"Output: {rotate_result.output}"
+        output = json.loads(rotate_result.stdout.strip())
+        data = output["data"]
+        assert data["token"] is None
+        assert data["admin_token_sink"] == "file"
+        assert data["name"] == "admin"
+
+
 class TestTokenRevoke:
     """Tests for token revoke command."""
 

--- a/tests/unit/test_token_service.py
+++ b/tests/unit/test_token_service.py
@@ -366,15 +366,20 @@ class TestRotateToken:
         assert new_info.scope != TokenScope.ADMIN
 
         # Verify the rotate_token method signature - it should NOT accept a scope parameter
-        # This is a compile-time check via type inspection
+        # (scope is always derived from the existing token, never settable by the caller).
+        # This is a compile-time check via type inspection. It intentionally does NOT
+        # check the full parameter list: rotate_token also accepts an optional
+        # plaintext_token (used by the admin token's deliver-before-persist flow in
+        # magpie.ctl.commands.token) -- that lets a caller supply an already-generated,
+        # already-delivered plaintext, but never lets it choose the scope.
         import inspect
 
         sig = inspect.signature(token_service.rotate_token)
         param_names = list(sig.parameters.keys())
-        # Should only have 'name' parameter (besides self which is implicit)
-        assert param_names == ["name"], (
-            f"rotate_token should only accept 'name' parameter, got: {param_names}"
+        assert "scope" not in param_names, (
+            f"rotate_token must not accept a scope parameter, got: {param_names}"
         )
+        assert "name" in param_names
 
 
 class TestHasScope:

--- a/tests/unit/test_token_sink.py
+++ b/tests/unit/test_token_sink.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import stat
 import sys
 from pathlib import Path
@@ -63,8 +64,6 @@ class TestFileSink:
             update={"admin_token_sink": "file", "admin_token_sink_file_path": target}
         )
 
-        import os
-
         old_umask = os.umask(0o000)
         try:
             deliver_admin_token(TOKEN, settings, action="init")
@@ -96,6 +95,62 @@ class TestFileSink:
         deliver_admin_token(TOKEN, settings, action="rotate")
 
         assert target.read_text().strip() == TOKEN
+
+    def test_preexisting_wide_permissions_are_tightened_to_0600(
+        self, tmp_path: Path, base_settings: MagpieSettings
+    ) -> None:
+        """A pre-existing, world-readable target file must end up 0600.
+
+        os.open's mode=0o600 only applies when a file is newly created --
+        O_TRUNC on a pre-existing file leaves its mode untouched. Simulates
+        an attacker pre-placing a 0666 file at the target path to widen the
+        exposure window before the token is written.
+        """
+        target = tmp_path / "admin-token"
+        target.write_text("stale-value\n")
+        os.chmod(target, 0o666)
+
+        settings = base_settings.model_copy(
+            update={"admin_token_sink": "file", "admin_token_sink_file_path": target}
+        )
+
+        deliver_admin_token(TOKEN, settings, action="init")
+
+        mode = stat.S_IMODE(target.stat().st_mode)
+        assert mode == 0o600
+        assert target.read_text().strip() == TOKEN
+
+    def test_permissions_tightened_before_token_is_written(
+        self, tmp_path: Path, base_settings: MagpieSettings, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The fd's mode must already be 0600 by the time content is written.
+
+        Directly verifies the ordering (not just the end state): intercepts
+        os.fdopen (called immediately after os.open + os.fchmod, right
+        before the token is written) and asserts the fd's mode is already
+        0600 at that point, even though the target pre-existed with a wider
+        mode.
+        """
+        target = tmp_path / "admin-token"
+        target.write_text("stale-value\n")
+        os.chmod(target, 0o666)
+
+        settings = base_settings.model_copy(
+            update={"admin_token_sink": "file", "admin_token_sink_file_path": target}
+        )
+
+        real_fdopen = os.fdopen
+        observed_modes: list[int] = []
+
+        def spying_fdopen(fd: int, *args: object, **kwargs: object) -> object:
+            observed_modes.append(stat.S_IMODE(os.fstat(fd).st_mode))
+            return real_fdopen(fd, *args, **kwargs)  # type: ignore[arg-type]
+
+        monkeypatch.setattr(os, "fdopen", spying_fdopen)
+
+        deliver_admin_token(TOKEN, settings, action="init")
+
+        assert observed_modes == [0o600]
 
     def test_unwritable_path_raises_token_sink_error(
         self, tmp_path: Path, base_settings: MagpieSettings

--- a/tests/unit/test_token_sink.py
+++ b/tests/unit/test_token_sink.py
@@ -1,0 +1,264 @@
+"""Unit tests for admin token delivery sinks."""
+
+from __future__ import annotations
+
+import stat
+import sys
+from pathlib import Path
+
+import pytest
+
+from magpie.auth.token_sink import TokenSinkError, deliver_admin_token
+from magpie.config import MagpieSettings
+
+TOKEN = "mgp_ADMIN_test_token_value_should_never_leak"  # nosec B105 - test fixture, not a real secret
+
+
+@pytest.fixture
+def base_settings(tmp_path: Path) -> MagpieSettings:
+    """Create test MagpieSettings with temporary paths and no sink configured."""
+    return MagpieSettings(
+        storage_path=tmp_path / "storage",
+        database_path=tmp_path / "magpie.db",
+    )
+
+
+class TestNoSinkConfigured:
+    """Fail-closed: an unset sink is a hard failure, never a silent default."""
+
+    def test_none_sink_raises(self, base_settings: MagpieSettings) -> None:
+        with pytest.raises(TokenSinkError, match="MAGPIE_ADMIN_TOKEN_SINK is not set"):
+            deliver_admin_token(TOKEN, base_settings, action="init")
+
+
+class TestFileSink:
+    """Tests for sink=file."""
+
+    def test_writes_token_to_file(self, tmp_path: Path, base_settings: MagpieSettings) -> None:
+        target = tmp_path / "admin-token"
+        settings = base_settings.model_copy(
+            update={"admin_token_sink": "file", "admin_token_sink_file_path": target}
+        )
+
+        deliver_admin_token(TOKEN, settings, action="init")
+
+        assert target.read_text().strip() == TOKEN
+
+    def test_file_is_0600(self, tmp_path: Path, base_settings: MagpieSettings) -> None:
+        target = tmp_path / "admin-token"
+        settings = base_settings.model_copy(
+            update={"admin_token_sink": "file", "admin_token_sink_file_path": target}
+        )
+
+        deliver_admin_token(TOKEN, settings, action="init")
+
+        mode = stat.S_IMODE(target.stat().st_mode)
+        assert mode == 0o600
+
+    def test_file_0600_even_with_permissive_umask(
+        self, tmp_path: Path, base_settings: MagpieSettings
+    ) -> None:
+        target = tmp_path / "admin-token"
+        settings = base_settings.model_copy(
+            update={"admin_token_sink": "file", "admin_token_sink_file_path": target}
+        )
+
+        import os
+
+        old_umask = os.umask(0o000)
+        try:
+            deliver_admin_token(TOKEN, settings, action="init")
+        finally:
+            os.umask(old_umask)
+
+        mode = stat.S_IMODE(target.stat().st_mode)
+        assert mode == 0o600
+
+    def test_creates_parent_directories(
+        self, tmp_path: Path, base_settings: MagpieSettings
+    ) -> None:
+        target = tmp_path / "nested" / "dir" / "admin-token"
+        settings = base_settings.model_copy(
+            update={"admin_token_sink": "file", "admin_token_sink_file_path": target}
+        )
+
+        deliver_admin_token(TOKEN, settings, action="init")
+
+        assert target.read_text().strip() == TOKEN
+
+    def test_overwrites_existing_file(self, tmp_path: Path, base_settings: MagpieSettings) -> None:
+        target = tmp_path / "admin-token"
+        target.write_text("stale-value\n")
+        settings = base_settings.model_copy(
+            update={"admin_token_sink": "file", "admin_token_sink_file_path": target}
+        )
+
+        deliver_admin_token(TOKEN, settings, action="rotate")
+
+        assert target.read_text().strip() == TOKEN
+
+    def test_unwritable_path_raises_token_sink_error(
+        self, tmp_path: Path, base_settings: MagpieSettings
+    ) -> None:
+        # A file component in the path makes it impossible to create the
+        # parent directory, guaranteeing a write failure.
+        blocker = tmp_path / "blocker"
+        blocker.write_text("not a directory")
+        target = blocker / "admin-token"
+        settings = base_settings.model_copy(
+            update={"admin_token_sink": "file", "admin_token_sink_file_path": target}
+        )
+
+        with pytest.raises(TokenSinkError, match="admin token file sink failed to write"):
+            deliver_admin_token(TOKEN, settings, action="init")
+
+    def test_default_file_path_derived_from_database_path(self, tmp_path: Path) -> None:
+        settings = MagpieSettings(
+            storage_path=tmp_path / "storage",
+            database_path=tmp_path / "sub" / "magpie.db",
+            admin_token_sink="file",
+        )
+
+        assert settings.admin_token_sink_file_path == tmp_path / "sub" / "admin-token"
+
+
+class TestExecSink:
+    """Tests for sink=exec."""
+
+    def test_token_delivered_via_stdin(self, tmp_path: Path, base_settings: MagpieSettings) -> None:
+        out_file = tmp_path / "captured-stdin"
+        # Use the current interpreter so this works regardless of PATH setup.
+        command = (
+            f"{sys.executable} -c \"import sys; open('{out_file}', 'w').write(sys.stdin.read())\""
+        )
+        settings = base_settings.model_copy(
+            update={"admin_token_sink": "exec", "admin_token_sink_exec_command": command}
+        )
+
+        deliver_admin_token(TOKEN, settings, action="init")
+
+        assert out_file.read_text() == TOKEN
+
+    def test_token_not_in_argv_or_env(self, tmp_path: Path, base_settings: MagpieSettings) -> None:
+        """The token must never appear in the child's argv or environment."""
+        out_file = tmp_path / "captured-argv-env"
+        script = (
+            "import sys, os, json;"
+            f"open({str(out_file)!r}, 'w').write(json.dumps({{'argv': sys.argv, 'env': dict(os.environ)}}))"
+        )
+        command = f"{sys.executable} -c {script!r}"
+        settings = base_settings.model_copy(
+            update={"admin_token_sink": "exec", "admin_token_sink_exec_command": command}
+        )
+
+        deliver_admin_token(TOKEN, settings, action="init")
+
+        captured = out_file.read_text()
+        assert TOKEN not in captured
+
+    def test_nonzero_exit_raises_token_sink_error(
+        self, tmp_path: Path, base_settings: MagpieSettings
+    ) -> None:
+        command = f'{sys.executable} -c "import sys; sys.exit(3)"'
+        settings = base_settings.model_copy(
+            update={"admin_token_sink": "exec", "admin_token_sink_exec_command": command}
+        )
+
+        with pytest.raises(TokenSinkError, match="exited with status 3"):
+            deliver_admin_token(TOKEN, settings, action="init")
+
+    def test_nonzero_exit_error_does_not_include_token(
+        self, tmp_path: Path, base_settings: MagpieSettings
+    ) -> None:
+        command = f"{sys.executable} -c \"import sys; sys.stderr.write('boom'); sys.exit(1)\""
+        settings = base_settings.model_copy(
+            update={"admin_token_sink": "exec", "admin_token_sink_exec_command": command}
+        )
+
+        with pytest.raises(TokenSinkError) as exc_info:
+            deliver_admin_token(TOKEN, settings, action="init")
+
+        assert TOKEN not in str(exc_info.value)
+
+    def test_command_not_found_raises_token_sink_error(self, base_settings: MagpieSettings) -> None:
+        settings = base_settings.model_copy(
+            update={
+                "admin_token_sink": "exec",
+                "admin_token_sink_exec_command": "definitely-not-a-real-command-xyz",
+            }
+        )
+
+        with pytest.raises(TokenSinkError, match="failed to run"):
+            deliver_admin_token(TOKEN, settings, action="init")
+
+    def test_timeout_raises_token_sink_error(self, base_settings: MagpieSettings) -> None:
+        command = f'{sys.executable} -c "import time; time.sleep(5)"'
+        settings = base_settings.model_copy(
+            update={
+                "admin_token_sink": "exec",
+                "admin_token_sink_exec_command": command,
+                "admin_token_sink_exec_timeout": 0.1,
+            }
+        )
+
+        with pytest.raises(TokenSinkError, match="failed to run"):
+            deliver_admin_token(TOKEN, settings, action="init")
+
+    def test_unset_command_raises(self, base_settings: MagpieSettings) -> None:
+        settings = base_settings.model_copy(update={"admin_token_sink": "exec"})
+
+        with pytest.raises(TokenSinkError, match="MAGPIE_ADMIN_TOKEN_SINK_EXEC_COMMAND"):
+            deliver_admin_token(TOKEN, settings, action="init")
+
+    def test_unparsable_command_raises(self, base_settings: MagpieSettings) -> None:
+        # An unterminated quote is invalid shlex syntax.
+        settings = base_settings.model_copy(
+            update={"admin_token_sink": "exec", "admin_token_sink_exec_command": 'unterminated "'}
+        )
+
+        with pytest.raises(TokenSinkError, match="could not be parsed"):
+            deliver_admin_token(TOKEN, settings, action="init")
+
+    def test_whitespace_only_command_raises(self, base_settings: MagpieSettings) -> None:
+        settings = base_settings.model_copy(
+            update={"admin_token_sink": "exec", "admin_token_sink_exec_command": "   "}
+        )
+
+        with pytest.raises(TokenSinkError, match="empty after parsing"):
+            deliver_admin_token(TOKEN, settings, action="init")
+
+
+class TestDiscardSink:
+    """Tests for sink=discard."""
+
+    def test_discard_does_not_raise(self, base_settings: MagpieSettings) -> None:
+        settings = base_settings.model_copy(update={"admin_token_sink": "discard"})
+
+        deliver_admin_token(TOKEN, settings, action="init")  # should not raise
+
+    def test_discard_does_not_write_any_file(
+        self, tmp_path: Path, base_settings: MagpieSettings
+    ) -> None:
+        settings = base_settings.model_copy(update={"admin_token_sink": "discard"})
+
+        deliver_admin_token(TOKEN, settings, action="init")
+
+        # Nothing under tmp_path should have been created by delivery beyond
+        # what the fixture itself set up (storage_path/database_path dirs
+        # aren't even created by delivery).
+        assert not (tmp_path / "admin-token").exists()
+
+
+class TestStdoutSink:
+    """Tests for sink=stdout (opt-in only)."""
+
+    def test_prints_token_and_warning(
+        self, tmp_path: Path, base_settings: MagpieSettings, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        settings = base_settings.model_copy(update={"admin_token_sink": "stdout"})
+
+        deliver_admin_token(TOKEN, settings, action="init")
+
+        captured = capsys.readouterr()
+        assert TOKEN in captured.out
+        assert "insecure" in captured.out.lower()

--- a/tests/unit/test_token_sink.py
+++ b/tests/unit/test_token_sink.py
@@ -112,6 +112,28 @@ class TestFileSink:
         with pytest.raises(TokenSinkError, match="admin token file sink failed to write"):
             deliver_admin_token(TOKEN, settings, action="init")
 
+    def test_symlink_at_target_path_is_rejected(
+        self, tmp_path: Path, base_settings: MagpieSettings
+    ) -> None:
+        """A pre-placed symlink at the configured path must not be followed.
+
+        Otherwise an attacker who can create a symlink at the target path
+        (but not write the target's actual destination directly) could
+        redirect the plaintext token to a location of their choosing.
+        """
+        real_target = tmp_path / "elsewhere" / "not-the-real-path"
+        real_target.parent.mkdir(parents=True)
+        symlink_path = tmp_path / "admin-token"
+        symlink_path.symlink_to(real_target)
+        settings = base_settings.model_copy(
+            update={"admin_token_sink": "file", "admin_token_sink_file_path": symlink_path}
+        )
+
+        with pytest.raises(TokenSinkError, match="admin token file sink failed to write"):
+            deliver_admin_token(TOKEN, settings, action="init")
+
+        assert not real_target.exists()
+
     def test_default_file_path_derived_from_database_path(self, tmp_path: Path) -> None:
         settings = MagpieSettings(
             storage_path=tmp_path / "storage",
@@ -171,6 +193,28 @@ class TestExecSink:
         self, tmp_path: Path, base_settings: MagpieSettings
     ) -> None:
         command = f"{sys.executable} -c \"import sys; sys.stderr.write('boom'); sys.exit(1)\""
+        settings = base_settings.model_copy(
+            update={"admin_token_sink": "exec", "admin_token_sink_exec_command": command}
+        )
+
+        with pytest.raises(TokenSinkError) as exc_info:
+            deliver_admin_token(TOKEN, settings, action="init")
+
+        assert TOKEN not in str(exc_info.value)
+
+    def test_nonzero_exit_does_not_leak_echoed_stdin(
+        self, tmp_path: Path, base_settings: MagpieSettings
+    ) -> None:
+        """A command that echoes its stdin (the token) to stderr must not leak it.
+
+        This is the realistic leak scenario: an operator-configured command
+        that reflects its input back on failure (common for debugging) must
+        never cause the token to end up in TokenSinkError's message, which
+        callers print/log.
+        """
+        command = (
+            f'{sys.executable} -c "import sys; sys.stderr.write(sys.stdin.read()); sys.exit(1)"'
+        )
         settings = base_settings.model_copy(
             update={"admin_token_sink": "exec", "admin_token_sink_exec_command": command}
         )


### PR DESCRIPTION
## Summary

Fixes the plaintext admin token leak into container logs (#387) by making
magpie both the generator and deliverer of the first-boot bootstrap token,
via a pluggable `MAGPIE_ADMIN_TOKEN_SINK`:

- **`file`** -- write a root-only (0600) file at `MAGPIE_ADMIN_TOKEN_SINK_FILE_PATH`
- **`exec`** -- pipe the token to an operator-configured command via **stdin
  only** (never argv/env), e.g. `vault kv put -mount=secret bootstrap/magpie/admin-token token=-`;
  a non-zero exit is a delivery failure
- **`discard`** -- generate and immediately drop the bootstrap token; mint a
  usable one later via an interactive `docker exec ... magpie-ctl token
  create --scope admin` (safe -- not captured by the container log stream)
- **`stdout`** -- opt-in only, warned; the old (insecure) behavior, never the
  default

**Fail-closed:** a delivery failure for `file`/`exec` aborts `magpie-ctl
init`; the server does not start. `docker-compose.prod.yml` now requires
`MAGPIE_ADMIN_TOKEN_SINK` to be set explicitly (compose itself refuses to
start without it, mirroring the existing `MAGPIE_DOMAIN` pattern); the dev
`docker-compose.yml` defaults to `sink=file` for frictionless local
bootstrap.

**Rotation uses the same sink:** `magpie-ctl init --reset-admin-token` and
`magpie-ctl token rotate admin` (specifically the break-glass token named
`admin`) deliver the new token through the configured sink rather than
printing it. Rotating any other token name is unaffected -- that path is
already safe (interactive `docker exec`, not log-captured).

A valueless structured log line records generation/rotation and which sink
handled it (never the token value).

## Design judgment calls

- **Structured log event bypasses structlog's global config.** magpie-ctl
  commands don't consistently call `configure_logging()`, and structlog's
  per-module logger caching makes ad hoc reconfiguration unreliable within a
  single process (this surfaced two *pre-existing*, unrelated,
  order-dependent test failures in `TestFlushTagCommand` when I initially
  tried wiring `configure_logging()` into the ctl command group -- reverted
  that approach). The valueless event is instead written directly via
  `click.echo(..., err=True)` as a small JSON line, independent of any
  global logging state.
- **JSON output (`--format json`) never includes the token** unless
  `sink=stdout` was explicitly chosen -- for other sinks, `admin_token` is
  `null` in the JSON payload (stdout is stdout, whether human or JSON
  formatted).
- **Default file path** for `sink=file`, when `MAGPIE_ADMIN_TOKEN_SINK_FILE_PATH`
  is unset, is derived as a sibling of `MAGPIE_DATABASE_PATH` (typically
  `/data/admin-token`), matching the existing database-path convention.
- **`exec` uses `shlex.split()`, not `shell=True`** -- avoids shell injection
  risk from the configured command string entirely; the token is never part
  of argv, only piped via stdin.
- Fixed two test-methodology bugs surfaced along the way: several
  `--json-output`/`--format json` tests were asserting against
  `result.output` (Click 8.2+'s intentionally *mixed* stdout+stderr stream)
  instead of `result.stdout`; switched them to `.stdout` to match how real
  JSON consumers (e.g. `subprocess_utils.run_ctl_command`) actually read
  these commands' output.

## Test plan

- [x] `just lint` / `just fmt-check` -- clean
- [x] `just test-ci` (1476 passed, 1 skipped) and full local suite including
      `tests/security/`, `tests/concurrency/`
- [x] `uv run bandit -r src/magpie` -- no issues
- [x] New unit tests: `tests/unit/test_token_sink.py` (all four sinks, 0600
      file perms + umask independence, exec stdin-only / not-in-argv-or-env,
      exec non-zero exit, exec timeout/unparsable/empty command, fail-closed
      with no sink configured)
- [x] Updated `tests/unit/test_ctl_init_gc.py` (`TestInitAdminTokenSink`) and
      `tests/unit/test_ctl_token.py` (`TestTokenRotateAdminSink`) for the new
      sink-aware `init`/`token rotate` flows, first-boot-only behavior, and
      the discard-then-mint-later flow
- [x] Updated `tests/integration/test_ctl.py` (`TestInitAdminTokenSink`) with
      real-filesystem coverage (0600 file on disk, fail-closed, discard +
      mint-later against a real SQLite DB)
- [x] Manually verified end-to-end against the real `docker-compose.yml` +
      Dockerfile: built the image, ran `docker compose up`, confirmed the
      container auto-ran `magpie-ctl init`, wrote a 0600
      `/data/admin-token` file readable on the host bind mount, emitted the
      valueless log event to stderr, and the server started and served
      `/health` successfully

(AI-generated via Claude Code w/ Fable 5)